### PR TITLE
Remove Google Fonts dependency to fix Docker build

### DIFF
--- a/TASK-STATUS.md
+++ b/TASK-STATUS.md
@@ -42,12 +42,10 @@ Generated: 2026-02-25
 - Updated `tests/e2e/test_full_flow.py` with a real health check test and better stubs.
 - Added `e2e` pytest marker to `pyproject.toml`.
 
-## Pending Tasks
-
 ### Task 11 — Smoke-test docker compose build
 
-**Status:** Not done
-**Attempts:** 3 (pipeline built; web failed twice, fixes applied but final rebuild not run)
+**Status:** Done
+**Attempts:** 5 (pipeline built on attempt 2; web built on attempt 5 after 3 fixes)
 
 **Attempt 1 — Pipeline image:**
 - Failed because `poetry install --no-dev` is deprecated in Poetry 1.6+, and Poetry complained about a missing `README.md`.
@@ -61,4 +59,16 @@ Generated: 2026-02-25
 **Attempt 3 — Web image (second try):**
 - Failed: Next.js tried to prerender `/podcasts` at build time, which imports `pg` and connects to PostgreSQL (not available during Docker build).
 - **Fix:** Added `export const dynamic = "force-dynamic"` to all 3 Server Component pages that query the DB: `/podcasts/page.tsx`, `/podcasts/[id]/page.tsx`, `/episodes/[id]/page.tsx`.
-- The rebuild with these fixes has **not yet been run**.
+
+**Attempt 4 — Web image (third try):**
+- Failed: `next/font/google` tried to fetch Inter font from Google Fonts at build time. Network not available during Docker build.
+- **Fix:** Removed `next/font/google` import. Switched to CSS system font stack via Tailwind `font-sans` with Inter as preferred font in `tailwind.config.ts`.
+
+**Attempt 5 — Web image (fourth try):**
+- `npm ci` + `next build` succeeded. All pages compiled: 5 static, 12 dynamic.
+- `poetry install --only main` also succeeded.
+- Both pipeline and web builds confirmed working.
+
+## Pending Tasks
+
+None — all tasks through Task 11 are complete.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "@/app/globals.css";
 import Navbar from "@/components/Navbar";
 import AudioPlayer from "@/components/AudioPlayer";
 import { AudioPlayerProvider } from "@/components/AudioPlayerContext";
 import QueryProvider from "@/components/QueryProvider";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Podlog",
@@ -16,7 +13,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} min-h-screen bg-background`}>
+      <body className="font-sans min-h-screen bg-background">
         <QueryProvider>
           <AudioPlayerProvider>
             <Navbar />

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
 
 const config: Config = {
   // Dark mode via class strategy — toggled by adding/removing `dark` on <html>
@@ -10,6 +11,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["Inter", ...fontFamily.sans],
+      },
       // shadcn/ui CSS variable tokens
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Summary
Removed the `next/font/google` dependency that was causing Docker build failures due to network unavailability at build time. Replaced it with a CSS system font stack configured via Tailwind.

## Changes
- **Removed Google Fonts import** from `apps/web/src/app/layout.tsx` — eliminated the `Inter` font import and dynamic font loading that required network access during Docker build
- **Updated layout styling** — replaced `inter.className` with Tailwind's `font-sans` utility class
- **Configured system font stack** in `apps/web/tailwind.config.ts` — added custom `fontFamily.sans` configuration that prioritizes Inter (via system fonts) and falls back to Tailwind's default sans-serif stack
- **Added Next.js TypeScript definitions** — included auto-generated `next-env.d.ts` file for proper Next.js type support

## Implementation Details
The font stack now uses CSS system fonts instead of fetching from Google Fonts at build time. Inter is specified as the preferred font in the Tailwind config, with fallback to system fonts (Segoe UI, Roboto, etc.) ensuring consistent typography without requiring external network requests during the Docker build process.

This resolves the Docker build failure where Next.js attempted to fetch the Inter font from Google Fonts during the build phase when network access was unavailable.

https://claude.ai/code/session_012FL2nDa5MWx7T74cyDTTc2