### PR TITLE
Replace faster-whisper with WhisperX pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxx
 # ── Pipeline tuning ───────────────────────────────────────
 WHISPER_MODEL=large-v3-turbo  # tiny|base|small|medium|large-v3|large-v3-turbo
 WHISPER_COMPUTE_TYPE=int8     # int8 (fast, recommended for CPU) | float32 (accurate)
-WHISPER_BEAM_SIZE=5           # Beam search width (1=greedy, 5=default)
+WHISPER_BATCH_SIZE=16         # WhisperX batched inference batch size
 DATA_DIR=/data
 ARCHIVE_AUDIO=true
 AUDIO_ARCHIVE_BITRATE=64k

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -14,10 +14,10 @@ class Settings(BaseSettings):
     # HuggingFace
     hf_token: str
 
-    # Whisper
+    # Whisper (WhisperX / CTranslate2 backend)
     whisper_model: str = "large-v3-turbo"
     whisper_compute_type: str = "int8"
-    whisper_beam_size: int = 5
+    whisper_batch_size: int = 16
 
     # Storage
     data_dir: str = "/data"

--- a/apps/pipeline/app/services/whisper.py
+++ b/apps/pipeline/app/services/whisper.py
@@ -1,7 +1,8 @@
 """
 Whisper speech-to-text service — PRD-01 §5.4
 
-Uses faster-whisper (CTranslate2 backend) for optimized CPU inference.
+Uses WhisperX (CTranslate2 backend + wav2vec2 word-level alignment)
+for optimized CPU inference.
 
 CRITICAL: The caller (transcribe.py) is responsible for calling unload_model()
 after transcription. Whisper and pyannote must never be in memory simultaneously.
@@ -22,18 +23,22 @@ def load_model(model_name: str = "large-v3-turbo") -> None:
     if _model is not None:
         return
 
-    from faster_whisper import WhisperModel
+    import whisperx
     from app.config import settings
 
     device = "cuda" if _cuda_available() else "cpu"
     compute_type = settings.whisper_compute_type
 
     logger.info(
-        '"action": "whisper_load_start", "model": "%s", "compute_type": "%s"',
-        model_name, compute_type,
+        '"action": "whisper_load_start", "model": "%s", "backend": "whisperx"',
+        model_name,
     )
 
-    _model = WhisperModel(model_name, device=device, compute_type=compute_type)
+    _model = whisperx.load_model(
+        model_name,
+        device=device,
+        compute_type=compute_type,
+    )
 
     logger.info(
         '"action": "whisper_load_complete", "model": "%s", "device": "%s"',
@@ -61,32 +66,40 @@ def transcribe(audio_path: str, model_name: str = "large-v3-turbo") -> tuple[lis
     segments: list of {"start": float, "end": float, "text": str}
     language: detected language code (e.g. "en")
     """
+    import whisperx
     from app.config import settings
 
     load_model(model_name)
 
-    # IMPORTANT: model.transcribe() returns a generator — segments are produced
-    # lazily as transcription progresses. We must materialize with list().
-    result_segments, info = _model.transcribe(
-        audio_path,
-        beam_size=settings.whisper_beam_size,
-        vad_filter=True,       # Skip silence — important for podcasts
-    )
+    device = "cuda" if _cuda_available() else "cpu"
+    audio = whisperx.load_audio(audio_path)
 
-    language = info.language if info.language else "unknown"
+    # Stage 1: Transcribe (batched inference via faster-whisper)
+    result = _model.transcribe(audio, batch_size=settings.whisper_batch_size)
+    language = result.get("language", "unknown") or "unknown"
 
+    # Stage 2: Word-level alignment (optional but recommended)
+    try:
+        model_a, metadata = whisperx.load_align_model(language_code=language, device=device)
+        result = whisperx.align(result["segments"], model_a, metadata, audio, device)
+        del model_a
+        gc.collect()
+    except Exception as exc:
+        logger.warning('"action": "whisper_align_failed", "error": "%s"', exc)
+        # Fall back to segment-level timestamps (still usable)
+
+    # Convert to expected output format
     segments = []
-    for seg in result_segments:
+    for seg in result.get("segments", []):
         segments.append({
-            "start": seg.start,
-            "end": seg.end,
-            "text": seg.text.strip(),
+            "start": seg.get("start", 0.0),
+            "end": seg.get("end", 0.0),
+            "text": seg.get("text", "").strip(),
         })
 
     logger.info(
         '"action": "whisper_transcribe_complete", "segments": %d, "language": "%s"',
-        len(segments),
-        language,
+        len(segments), language,
     )
     return segments, language
 

--- a/apps/pipeline/app/tasks/prewarm.py
+++ b/apps/pipeline/app/tasks/prewarm.py
@@ -10,6 +10,7 @@ WARMING_UP → OK.
 Usage (from docker-compose.yml):
   python -m app.tasks.prewarm
 """
+import gc
 import logging
 import sys
 from pathlib import Path
@@ -35,7 +36,7 @@ def main() -> None:
 
     logger.info('"action": "prewarm_start", "whisper_model": "%s"', settings.whisper_model)
 
-    # Download Whisper
+    # Download Whisper (WhisperX + CTranslate2 model)
     try:
         from app.services.whisper import load_model, unload_model
         logger.info('"action": "prewarm_whisper_download"')
@@ -45,6 +46,18 @@ def main() -> None:
     except Exception as exc:
         logger.error('"action": "prewarm_whisper_failed", "error": "%s"', exc)
         sys.exit(1)
+
+    # Download wav2vec2 alignment model — failure is non-fatal
+    try:
+        import whisperx
+        device = "cpu"
+        logger.info('"action": "prewarm_align_model_download"')
+        model_a, metadata = whisperx.load_align_model(language_code="en", device=device)
+        del model_a, metadata
+        gc.collect()
+        logger.info('"action": "prewarm_align_model_done"')
+    except Exception as exc:
+        logger.warning('"action": "prewarm_align_model_failed", "error": "%s"', exc)
 
     # Download pyannote — failure is non-fatal (per PRD-01 §5.4)
     try:

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -33,8 +33,8 @@ feedparser = "^6.0.11"
 # Audio processing
 ffmpeg-python = "^0.2.0"
 
-# ML — Whisper (CTranslate2 backend)
-faster-whisper = "^1.2.0"
+# ML — WhisperX (CTranslate2 backend + wav2vec2 alignment)
+whisperx = "^3.8.0"
 torch = "^2.2.0"
 
 # ML — pyannote diarization

--- a/apps/pipeline/tests/unit/conftest.py
+++ b/apps/pipeline/tests/unit/conftest.py
@@ -1,0 +1,8 @@
+"""Unit test configuration — ensure mock modules are available for patching."""
+import sys
+from unittest.mock import MagicMock
+
+# WhisperX is a heavy ML dependency not installed in the test environment.
+# Provide a mock module so that patch("whisperx.load_model") etc. can resolve.
+if "whisperx" not in sys.modules:
+    sys.modules["whisperx"] = MagicMock()

--- a/apps/pipeline/tests/unit/test_whisper_service.py
+++ b/apps/pipeline/tests/unit/test_whisper_service.py
@@ -1,4 +1,5 @@
-"""Unit tests for the faster-whisper based whisper service."""
+"""Unit tests for the WhisperX-based whisper service."""
+import gc
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,22 +10,25 @@ class TestLoadModel:
         import app.services.whisper as ws
         ws._model = None
 
-    def test_load_model_creates_whisper_model(self):
-        """load_model() creates a WhisperModel with correct args."""
+    def test_load_model_creates_whisperx_model(self):
+        """load_model() creates a WhisperX model with correct args."""
+        mock_model = MagicMock()
         with patch("app.services.whisper._cuda_available", return_value=False), \
-             patch("faster_whisper.WhisperModel") as MockModel:
+             patch("whisperx.load_model", return_value=mock_model) as mock_load:
             import app.services.whisper as ws
             ws.load_model("large-v3-turbo")
-            MockModel.assert_called_once_with("large-v3-turbo", device="cpu", compute_type="int8")
-            assert ws._model is not None
+            mock_load.assert_called_once_with(
+                "large-v3-turbo", device="cpu", compute_type="int8",
+            )
+            assert ws._model is mock_model
 
     def test_load_model_noop_if_cached(self):
         """load_model() is a no-op when model is already loaded."""
-        with patch("faster_whisper.WhisperModel") as MockModel:
+        with patch("whisperx.load_model") as mock_load:
             import app.services.whisper as ws
             ws._model = MagicMock()  # already loaded
             ws.load_model("large-v3-turbo")
-            MockModel.assert_not_called()
+            mock_load.assert_not_called()
 
 
 class TestUnloadModel:
@@ -38,21 +42,34 @@ class TestUnloadModel:
 
 class TestTranscribe:
     MOCK_SEGMENTS = [
-        MagicMock(start=0.0, end=2.5, text=" Hello world. "),
-        MagicMock(start=2.5, end=5.0, text=" Second segment. "),
+        {"start": 0.0, "end": 2.5, "text": " Hello world. "},
+        {"start": 2.5, "end": 5.0, "text": " Second segment. "},
     ]
 
     def test_transcribe_returns_expected_format(self):
         """transcribe() returns (segments, language) with correct structure."""
-        mock_info = MagicMock()
-        mock_info.language = "en"
-
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = (iter(self.MOCK_SEGMENTS), mock_info)
+        mock_model.transcribe.return_value = {
+            "segments": self.MOCK_SEGMENTS,
+            "language": "en",
+        }
+
+        mock_align_model = MagicMock()
+        mock_metadata = MagicMock()
+        aligned_result = {
+            "segments": [
+                {"start": 0.0, "end": 2.5, "text": " Hello world. "},
+                {"start": 2.5, "end": 5.0, "text": " Second segment. "},
+            ],
+        }
 
         import app.services.whisper as ws
         ws._model = mock_model
-        with patch("app.services.whisper.load_model"):
+        with patch("app.services.whisper.load_model"), \
+             patch("app.services.whisper._cuda_available", return_value=False), \
+             patch("whisperx.load_audio", return_value=MagicMock()), \
+             patch("whisperx.load_align_model", return_value=(mock_align_model, mock_metadata)), \
+             patch("whisperx.align", return_value=aligned_result):
             segments, language = ws.transcribe("/tmp/test.wav")
 
         assert language == "en"
@@ -62,16 +79,61 @@ class TestTranscribe:
 
     def test_transcribe_handles_unknown_language(self):
         """transcribe() returns 'unknown' when language detection fails."""
-        mock_info = MagicMock()
-        mock_info.language = None
-
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = (iter([]), mock_info)
+        mock_model.transcribe.return_value = {
+            "segments": [],
+            "language": None,
+        }
 
         import app.services.whisper as ws
         ws._model = mock_model
-        with patch("app.services.whisper.load_model"):
+        with patch("app.services.whisper.load_model"), \
+             patch("app.services.whisper._cuda_available", return_value=False), \
+             patch("whisperx.load_audio", return_value=MagicMock()), \
+             patch("whisperx.load_align_model", side_effect=Exception("no model for unknown")):
             segments, language = ws.transcribe("/tmp/test.wav")
 
         assert language == "unknown"
         assert segments == []
+
+    def test_transcribe_graceful_alignment_failure(self):
+        """transcribe() falls back to segment-level timestamps when alignment fails."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            "segments": self.MOCK_SEGMENTS,
+            "language": "en",
+        }
+
+        import app.services.whisper as ws
+        ws._model = mock_model
+        with patch("app.services.whisper.load_model"), \
+             patch("app.services.whisper._cuda_available", return_value=False), \
+             patch("whisperx.load_audio", return_value=MagicMock()), \
+             patch("whisperx.load_align_model", side_effect=Exception("alignment failed")):
+            segments, language = ws.transcribe("/tmp/test.wav")
+
+        assert language == "en"
+        assert len(segments) == 2
+        assert segments[0] == {"start": 0.0, "end": 2.5, "text": "Hello world."}
+
+    def test_transcribe_passes_batch_size_from_settings(self):
+        """transcribe() passes whisper_batch_size from settings to model.transcribe()."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            "segments": [],
+            "language": "en",
+        }
+
+        import app.services.whisper as ws
+        ws._model = mock_model
+        with patch("app.services.whisper.load_model"), \
+             patch("app.services.whisper._cuda_available", return_value=False), \
+             patch("whisperx.load_audio", return_value=MagicMock()) as mock_load_audio, \
+             patch("whisperx.load_align_model", side_effect=Exception("skip")), \
+             patch("app.config.settings") as mock_settings:
+            mock_settings.whisper_batch_size = 8
+            ws.transcribe("/tmp/test.wav")
+
+        mock_model.transcribe.assert_called_once()
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["batch_size"] == 8


### PR DESCRIPTION
## Summary

- Replaces `faster-whisper` with `whisperx` for transcription, adding wav2vec2 word-level alignment with graceful fallback to segment-level timestamps on failure
- Adds `whisper_batch_size` config (replaces `whisper_beam_size`) for WhisperX batched inference
- Prewarm task now also downloads the wav2vec2 English alignment model
- Existing pyannote diarization pipeline unchanged (Option A per issue)

## Changes

- `pyproject.toml`: `faster-whisper` → `whisperx`
- `config.py`: `whisper_beam_size` → `whisper_batch_size` (default 16)
- `whisper.py`: Rewritten to use `whisperx.load_model()`, `whisperx.load_audio()`, `whisperx.align()`
- `prewarm.py`: Downloads wav2vec2 alignment model (non-fatal on failure)
- `.env.example`: Updated config vars
- Tests: Updated mocks + 2 new test cases (alignment fallback, batch_size passthrough)

Closes #7

## Test plan

- [x] All 72 unit tests pass
- [ ] Docker image builds with new `whisperx` dependency
- [ ] Full pipeline processes an episode end-to-end (transcribe → diarize → done)
- [ ] Verify `large-v3-turbo` model loads via WhisperX (fall back to `large-v3` if not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)