### PR TITLE
Group search results by podcast and episode

### DIFF
--- a/apps/web/src/app/api/search/grouped/route.ts
+++ b/apps/web/src/app/api/search/grouped/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { searchGrouped } from "@/lib/search";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+
+  const q = searchParams.get("q")?.trim();
+  if (!q) {
+    return NextResponse.json({ error: "q is required" }, { status: 400 });
+  }
+
+  const feedId = searchParams.get("feedId") || null;
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+
+  try {
+    const result = await searchGrouped(q, feedId, page, pageSize);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("Grouped search error:", err);
+    return NextResponse.json({ error: "Search failed" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/search/mentions/route.ts
+++ b/apps/web/src/app/api/search/mentions/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { searchMentions } from "@/lib/search";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+
+  const q = searchParams.get("q")?.trim();
+  if (!q) {
+    return NextResponse.json({ error: "q is required" }, { status: 400 });
+  }
+
+  const episodeId = searchParams.get("episodeId")?.trim();
+  if (!episodeId) {
+    return NextResponse.json({ error: "episodeId is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await searchMentions(q, episodeId);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("Mentions search error:", err);
+    return NextResponse.json({ error: "Search failed" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,20 +1,25 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Search } from "lucide-react";
+import { useState } from "react";
+import { Search, List, Layers } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import SearchResult from "@/components/SearchResult";
-import type { SearchPage } from "@/lib/search";
+import FeedGroupCard from "@/components/FeedGroupCard";
+import type { SearchPage, GroupedSearchResult } from "@/lib/search";
 
 const PAGE_SIZE = 20;
+
+type ViewMode = "grouped" | "flat";
 
 export default function HomePage() {
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
   const [feedFilter, setFeedFilter] = useState<string>("");
   const [page, setPage] = useState(1);
+  const [viewMode, setViewMode] = useState<ViewMode>("grouped");
 
-  const { data, isLoading, isFetching } = useQuery<SearchPage>({
+  // Flat search query
+  const flatQuery = useQuery<SearchPage>({
     queryKey: ["search", submittedQuery, feedFilter, page],
     queryFn: async () => {
       if (!submittedQuery) return { results: [], total: 0, page: 1, pageSize: PAGE_SIZE };
@@ -28,7 +33,27 @@ export default function HomePage() {
       if (!resp.ok) throw new Error("Search failed");
       return resp.json();
     },
-    enabled: Boolean(submittedQuery),
+    enabled: Boolean(submittedQuery) && viewMode === "flat",
+    staleTime: 30_000,
+  });
+
+  // Grouped search query
+  const groupedQuery = useQuery<GroupedSearchResult>({
+    queryKey: ["search-grouped", submittedQuery, feedFilter, page],
+    queryFn: async () => {
+      if (!submittedQuery)
+        return { feeds: [], totalFeeds: 0, totalEpisodes: 0, totalMentions: 0 };
+      const params = new URLSearchParams({
+        q: submittedQuery,
+        page: String(page),
+        pageSize: String(PAGE_SIZE),
+      });
+      if (feedFilter) params.set("feedId", feedFilter);
+      const resp = await fetch(`/api/search/grouped?${params}`);
+      if (!resp.ok) throw new Error("Search failed");
+      return resp.json();
+    },
+    enabled: Boolean(submittedQuery) && viewMode === "grouped",
     staleTime: 30_000,
   });
 
@@ -38,7 +63,15 @@ export default function HomePage() {
     setSubmittedQuery(query.trim());
   }
 
-  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+  const isLoading =
+    viewMode === "flat"
+      ? flatQuery.isLoading || flatQuery.isFetching
+      : groupedQuery.isLoading || groupedQuery.isFetching;
+
+  const totalPages =
+    viewMode === "flat" && flatQuery.data
+      ? Math.ceil(flatQuery.data.total / PAGE_SIZE)
+      : 0;
 
   return (
     <div className="space-y-6">
@@ -61,8 +94,44 @@ export default function HomePage() {
 
       {submittedQuery && (
         <div className="space-y-4">
-          {isLoading || isFetching ? (
-            // Skeleton loading state
+          {/* View mode toggle */}
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-muted-foreground">
+              {viewMode === "grouped" && groupedQuery.data
+                ? `Found in ${groupedQuery.data.totalFeeds} podcast${groupedQuery.data.totalFeeds !== 1 ? "s" : ""}, ${groupedQuery.data.totalEpisodes} episode${groupedQuery.data.totalEpisodes !== 1 ? "s" : ""} (${groupedQuery.data.totalMentions} mention${groupedQuery.data.totalMentions !== 1 ? "s" : ""})`
+                : viewMode === "flat" && flatQuery.data
+                  ? `Page ${page} of ${totalPages} · ${flatQuery.data.total} results`
+                  : ""}
+            </div>
+            <div className="flex items-center border border-border rounded-lg overflow-hidden">
+              <button
+                onClick={() => { setViewMode("grouped"); setPage(1); }}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
+                  viewMode === "grouped"
+                    ? "bg-primary text-primary-foreground"
+                    : "hover:bg-accent/30"
+                }`}
+                title="Grouped view"
+              >
+                <Layers size={13} />
+                Grouped
+              </button>
+              <button
+                onClick={() => { setViewMode("flat"); setPage(1); }}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
+                  viewMode === "flat"
+                    ? "bg-primary text-primary-foreground"
+                    : "hover:bg-accent/30"
+                }`}
+                title="Flat view"
+              >
+                <List size={13} />
+                Flat
+              </button>
+            </div>
+          </div>
+
+          {isLoading ? (
             <div className="space-y-3">
               {Array.from({ length: 3 }).map((_, i) => (
                 <div key={i} className="border border-border rounded-lg p-4 space-y-2 animate-pulse">
@@ -73,47 +142,62 @@ export default function HomePage() {
                 </div>
               ))}
             </div>
-          ) : data && data.results.length > 0 ? (
-            <>
-              <div className="text-sm text-muted-foreground">
-                Page {page} of {totalPages} · {data.total} results
-              </div>
-
+          ) : viewMode === "grouped" ? (
+            // Grouped view
+            groupedQuery.data && groupedQuery.data.feeds.length > 0 ? (
               <div className="space-y-3">
-                {data.results.map((result) => (
-                  <SearchResult key={result.id} result={result} />
+                {groupedQuery.data.feeds.map((feed) => (
+                  <FeedGroupCard key={feed.feedId} feed={feed} query={submittedQuery} />
                 ))}
               </div>
-
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between pt-2">
-                  <button
-                    onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    disabled={page === 1}
-                    className="text-sm px-3 py-1.5 border border-border rounded disabled:opacity-40"
-                  >
-                    ← Previous
-                  </button>
-                  <span className="text-sm text-muted-foreground">
-                    Page {page} of {totalPages}
-                  </span>
-                  <button
-                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={page === totalPages}
-                    className="text-sm px-3 py-1.5 border border-border rounded disabled:opacity-40"
-                  >
-                    Next →
-                  </button>
-                </div>
-              )}
-            </>
+            ) : (
+              <div className="text-center py-16 space-y-2">
+                <p className="text-muted-foreground">No results for &ldquo;{submittedQuery}&rdquo;</p>
+                <p className="text-sm text-muted-foreground">
+                  Try checking your spelling, or use broader search terms.
+                </p>
+              </div>
+            )
           ) : (
-            <div className="text-center py-16 space-y-2">
-              <p className="text-muted-foreground">No results for "{submittedQuery}"</p>
-              <p className="text-sm text-muted-foreground">
-                Try checking your spelling, or use broader search terms.
-              </p>
-            </div>
+            // Flat view
+            flatQuery.data && flatQuery.data.results.length > 0 ? (
+              <>
+                <div className="space-y-3">
+                  {flatQuery.data.results.map((result) => (
+                    <SearchResult key={result.id} result={result} />
+                  ))}
+                </div>
+
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-between pt-2">
+                    <button
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                      disabled={page === 1}
+                      className="text-sm px-3 py-1.5 border border-border rounded disabled:opacity-40"
+                    >
+                      &larr; Previous
+                    </button>
+                    <span className="text-sm text-muted-foreground">
+                      Page {page} of {totalPages}
+                    </span>
+                    <button
+                      onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                      disabled={page === totalPages}
+                      className="text-sm px-3 py-1.5 border border-border rounded disabled:opacity-40"
+                    >
+                      Next &rarr;
+                    </button>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="text-center py-16 space-y-2">
+                <p className="text-muted-foreground">No results for &ldquo;{submittedQuery}&rdquo;</p>
+                <p className="text-sm text-muted-foreground">
+                  Try checking your spelling, or use broader search terms.
+                </p>
+              </div>
+            )
           )}
         </div>
       )}

--- a/apps/web/src/components/EpisodeMentionList.tsx
+++ b/apps/web/src/components/EpisodeMentionList.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Play } from "lucide-react";
+import path from "path";
+import { useAudioPlayer } from "@/components/AudioPlayerContext";
+import { formatTimestamp } from "@/lib/timestamp";
+import type { EpisodeMentions } from "@/lib/search";
+
+interface Props {
+  query: string;
+  episodeId: string;
+  episodeTitle: string;
+  audioLocalPath: string | null;
+  feedTitle: string;
+}
+
+export default function EpisodeMentionList({
+  query,
+  episodeId,
+  episodeTitle,
+  audioLocalPath,
+  feedTitle,
+}: Props) {
+  const { playEpisode } = useAudioPlayer();
+
+  const { data, isLoading } = useQuery<EpisodeMentions>({
+    queryKey: ["mentions", query, episodeId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ q: query, episodeId });
+      const resp = await fetch(`/api/search/mentions?${params}`);
+      if (!resp.ok) throw new Error("Failed to load mentions");
+      return resp.json();
+    },
+    staleTime: 60_000,
+  });
+
+  function handlePlay(startTime: number) {
+    if (!audioLocalPath) return;
+    const safeName = path.basename(audioLocalPath);
+    playEpisode(episodeId, safeName, startTime, episodeTitle, feedTitle);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 py-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-10 bg-muted rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.mentions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-2">No mentions found.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5 py-2">
+      {data.mentions.map((mention) => (
+        <div
+          key={mention.id}
+          className="flex items-start gap-3 rounded px-3 py-2 text-sm hover:bg-accent/30 transition-colors"
+        >
+          <span className="shrink-0 font-mono text-xs text-muted-foreground pt-0.5 w-14 text-right">
+            {formatTimestamp(mention.startTime)}
+          </span>
+
+          <div className="min-w-0 flex-1">
+            {mention.speakerDisplay && (
+              <span className="font-medium text-foreground mr-1.5">
+                {mention.speakerDisplay}:
+              </span>
+            )}
+            <span
+              className="text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground"
+              dangerouslySetInnerHTML={{ __html: mention.snippet }}
+            />
+          </div>
+
+          {audioLocalPath && (
+            <button
+              onClick={() => handlePlay(mention.startTime)}
+              className="shrink-0 inline-flex items-center gap-1 text-xs bg-primary text-primary-foreground px-2 py-1 rounded hover:opacity-90 transition-opacity"
+            >
+              <Play size={11} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/FeedGroupCard.tsx
+++ b/apps/web/src/components/FeedGroupCard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight, Radio, FileText } from "lucide-react";
+import EpisodeMentionList from "@/components/EpisodeMentionList";
+import type { FeedGroup } from "@/lib/search";
+
+interface Props {
+  feed: FeedGroup;
+  query: string;
+}
+
+export default function FeedGroupCard({ feed, query }: Props) {
+  const [expandedFeed, setExpandedFeed] = useState(true);
+  const [expandedEpisodes, setExpandedEpisodes] = useState<Set<string>>(
+    new Set()
+  );
+
+  function toggleEpisode(episodeId: string) {
+    setExpandedEpisodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(episodeId)) {
+        next.delete(episodeId);
+      } else {
+        next.add(episodeId);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      {/* Feed header */}
+      <button
+        onClick={() => setExpandedFeed((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent/30 transition-colors text-left"
+      >
+        <ChevronRight
+          size={16}
+          className={`shrink-0 text-muted-foreground transition-transform ${
+            expandedFeed ? "rotate-90" : ""
+          }`}
+        />
+        <Radio size={16} className="shrink-0 text-primary" />
+        <span className="font-medium truncate flex-1">{feed.feedTitle}</span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {feed.mentionCount} mention{feed.mentionCount !== 1 ? "s" : ""} in{" "}
+          {feed.episodes.length} episode{feed.episodes.length !== 1 ? "s" : ""}
+        </span>
+      </button>
+
+      {/* Episode list */}
+      {expandedFeed && (
+        <div className="border-t border-border">
+          {feed.episodes.map((episode) => {
+            const isExpanded = expandedEpisodes.has(episode.episodeId);
+
+            return (
+              <div key={episode.episodeId} className="border-b border-border last:border-b-0">
+                {/* Episode row */}
+                <button
+                  onClick={() => toggleEpisode(episode.episodeId)}
+                  className="w-full flex items-center gap-3 px-4 py-2.5 pl-11 hover:bg-accent/30 transition-colors text-left"
+                >
+                  <ChevronRight
+                    size={14}
+                    className={`shrink-0 text-muted-foreground transition-transform ${
+                      isExpanded ? "rotate-90" : ""
+                    }`}
+                  />
+                  <FileText size={14} className="shrink-0 text-muted-foreground" />
+                  <span className="text-sm truncate flex-1">
+                    {episode.episodeTitle}
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {episode.mentionCount} mention
+                    {episode.mentionCount !== 1 ? "s" : ""}
+                  </span>
+                </button>
+
+                {/* Expanded mentions */}
+                {isExpanded && (
+                  <div className="pl-16 pr-4 pb-2">
+                    <EpisodeMentionList
+                      query={query}
+                      episodeId={episode.episodeId}
+                      episodeTitle={episode.episodeTitle}
+                      audioLocalPath={episode.audioLocalPath}
+                      feedTitle={feed.feedTitle}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,5 +1,47 @@
 import pool from "@/lib/db";
 
+// ── Grouped search types ────────────────────────────────────
+
+export interface GroupedSearchResult {
+  feeds: FeedGroup[];
+  totalFeeds: number;
+  totalEpisodes: number;
+  totalMentions: number;
+}
+
+export interface FeedGroup {
+  feedId: string;
+  feedTitle: string;
+  mentionCount: number;
+  episodes: EpisodeGroup[];
+}
+
+export interface EpisodeGroup {
+  episodeId: string;
+  episodeTitle: string;
+  audioUrl: string;
+  audioLocalPath: string | null;
+  mentionCount: number;
+  bestRank: number;
+}
+
+export interface EpisodeMentions {
+  episodeId: string;
+  mentions: Mention[];
+}
+
+export interface Mention {
+  id: number;
+  startTime: number;
+  endTime: number;
+  speakerLabel: string | null;
+  speakerDisplay: string | null;
+  snippet: string;
+  rank: number;
+}
+
+// ── Flat search types ───────────────────────────────────────
+
 export interface SearchResult {
   id: number;
   startTime: number;
@@ -101,5 +143,129 @@ export async function searchSegments(
     total: parseInt(countResult.rows[0].count, 10),
     page,
     pageSize,
+  };
+}
+
+/**
+ * Grouped search — returns results grouped by feed → episode with mention counts.
+ * Paginated at the episode level.
+ */
+export async function searchGrouped(
+  query: string,
+  feedId: string | null,
+  page: number,
+  pageSize: number = 20
+): Promise<GroupedSearchResult> {
+  const offset = (page - 1) * pageSize;
+
+  const [rowsResult, countResult] = await Promise.all([
+    pool.query(
+      `SELECT
+        f.id AS feed_id,
+        f.title AS feed_title,
+        e.id AS episode_id,
+        e.title AS episode_title,
+        e.audio_url,
+        e.audio_local_path,
+        COUNT(s.id)::int AS mention_count,
+        MAX(ts_rank(to_tsvector('english', s.text), query)) AS best_rank
+      FROM segments s
+      JOIN episodes e ON s.episode_id = e.id
+      JOIN feeds f ON e.feed_id = f.id,
+        plainto_tsquery('english', $1) AS query
+      WHERE to_tsvector('english', s.text) @@ query
+        AND ($2::uuid IS NULL OR f.id = $2)
+      GROUP BY f.id, f.title, e.id, e.title, e.audio_url, e.audio_local_path
+      ORDER BY best_rank DESC, mention_count DESC
+      LIMIT $3 OFFSET $4`,
+      [query, feedId, pageSize, offset]
+    ),
+    pool.query(
+      `SELECT
+        COUNT(DISTINCT e.id)::int AS total_episodes,
+        COUNT(DISTINCT f.id)::int AS total_feeds,
+        COUNT(s.id)::int AS total_mentions
+      FROM segments s
+      JOIN episodes e ON s.episode_id = e.id
+      JOIN feeds f ON e.feed_id = f.id,
+        plainto_tsquery('english', $1) AS query
+      WHERE to_tsvector('english', s.text) @@ query
+        AND ($2::uuid IS NULL OR f.id = $2)`,
+      [query, feedId]
+    ),
+  ]);
+
+  // Group episode rows by feed
+  const feedMap = new Map<string, FeedGroup>();
+
+  for (const row of rowsResult.rows) {
+    const feedKey = row.feed_id;
+    if (!feedMap.has(feedKey)) {
+      feedMap.set(feedKey, {
+        feedId: row.feed_id,
+        feedTitle: row.feed_title,
+        mentionCount: 0,
+        episodes: [],
+      });
+    }
+    const feed = feedMap.get(feedKey)!;
+    const mentionCount = row.mention_count;
+    feed.mentionCount += mentionCount;
+    feed.episodes.push({
+      episodeId: row.episode_id,
+      episodeTitle: row.episode_title,
+      audioUrl: row.audio_url,
+      audioLocalPath: row.audio_local_path,
+      mentionCount,
+      bestRank: parseFloat(row.best_rank),
+    });
+  }
+
+  const counts = countResult.rows[0];
+
+  return {
+    feeds: Array.from(feedMap.values()),
+    totalFeeds: counts.total_feeds,
+    totalEpisodes: counts.total_episodes,
+    totalMentions: counts.total_mentions,
+  };
+}
+
+/**
+ * Fetch individual matching segments for one episode (loaded on expand).
+ */
+export async function searchMentions(
+  query: string,
+  episodeId: string
+): Promise<EpisodeMentions> {
+  const result = await pool.query(
+    `SELECT
+      s.id,
+      s.start_time,
+      s.end_time,
+      s.speaker_label,
+      COALESCE(sn.display_name, s.speaker_label) AS speaker_display,
+      ts_headline('english', s.text, query, 'MaxWords=20, MinWords=10') AS snippet,
+      ts_rank(to_tsvector('english', s.text), query) AS rank
+    FROM segments s
+    LEFT JOIN speaker_names sn ON sn.episode_id = s.episode_id AND sn.speaker_label = s.speaker_label,
+      plainto_tsquery('english', $1) AS query
+    WHERE s.episode_id = $2
+      AND to_tsvector('english', s.text) @@ query
+    ORDER BY s.start_time ASC`,
+    [query, episodeId]
+  );
+
+  return {
+    episodeId,
+    mentions: result.rows.map((row) => ({
+      id: row.id,
+      startTime: parseFloat(row.start_time),
+      endTime: parseFloat(row.end_time),
+      speakerLabel: row.speaker_label,
+      speakerDisplay: row.speaker_display,
+      snippet: row.snippet,
+      rank: parseFloat(row.rank),
+    })),
   };
 }

--- a/apps/web/tests/unit/grouped-search.test.ts
+++ b/apps/web/tests/unit/grouped-search.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for grouped search API route parameter validation.
+ *
+ * These test the route handler logic without a live database by mocking
+ * the search functions.
+ *
+ * @jest-environment node
+ */
+
+// Mock the search module before importing routes
+jest.mock("@/lib/search", () => ({
+  searchGrouped: jest.fn(),
+  searchMentions: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+
+describe("GET /api/search/grouped", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+  let searchGrouped: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import("@/app/api/search/grouped/route");
+    GET = mod.GET;
+    const searchMod = await import("@/lib/search");
+    searchGrouped = searchMod.searchGrouped as jest.Mock;
+  });
+
+  test("returns 400 when q is missing", async () => {
+    const req = new NextRequest("http://localhost/api/search/grouped");
+    const resp = await GET(req);
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toBe("q is required");
+  });
+
+  test("returns 400 when q is empty", async () => {
+    const req = new NextRequest("http://localhost/api/search/grouped?q=   ");
+    const resp = await GET(req);
+    expect(resp.status).toBe(400);
+  });
+
+  test("calls searchGrouped with correct params", async () => {
+    const mockResult = {
+      feeds: [],
+      totalFeeds: 0,
+      totalEpisodes: 0,
+      totalMentions: 0,
+    };
+    searchGrouped.mockResolvedValue(mockResult);
+
+    const req = new NextRequest(
+      "http://localhost/api/search/grouped?q=tariffs&page=2&pageSize=10"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(200);
+    expect(searchGrouped).toHaveBeenCalledWith("tariffs", null, 2, 10);
+  });
+
+  test("passes feedId filter when provided", async () => {
+    searchGrouped.mockResolvedValue({
+      feeds: [],
+      totalFeeds: 0,
+      totalEpisodes: 0,
+      totalMentions: 0,
+    });
+
+    const feedId = "abc-123";
+    const req = new NextRequest(
+      `http://localhost/api/search/grouped?q=test&feedId=${feedId}`
+    );
+    await GET(req);
+    expect(searchGrouped).toHaveBeenCalledWith("test", feedId, 1, 20);
+  });
+
+  test("clamps pageSize to max 50", async () => {
+    searchGrouped.mockResolvedValue({
+      feeds: [],
+      totalFeeds: 0,
+      totalEpisodes: 0,
+      totalMentions: 0,
+    });
+
+    const req = new NextRequest(
+      "http://localhost/api/search/grouped?q=test&pageSize=100"
+    );
+    await GET(req);
+    expect(searchGrouped).toHaveBeenCalledWith("test", null, 1, 50);
+  });
+
+  test("returns 500 on search error", async () => {
+    searchGrouped.mockRejectedValue(new Error("DB down"));
+
+    const req = new NextRequest(
+      "http://localhost/api/search/grouped?q=test"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(500);
+  });
+});
+
+describe("GET /api/search/mentions", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+  let searchMentions: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import("@/app/api/search/mentions/route");
+    GET = mod.GET;
+    const searchMod = await import("@/lib/search");
+    searchMentions = searchMod.searchMentions as jest.Mock;
+  });
+
+  test("returns 400 when q is missing", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/mentions?episodeId=ep-1"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toBe("q is required");
+  });
+
+  test("returns 400 when episodeId is missing", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/mentions?q=tariffs"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toBe("episodeId is required");
+  });
+
+  test("calls searchMentions with correct params", async () => {
+    const mockResult = {
+      episodeId: "ep-1",
+      mentions: [
+        {
+          id: 1,
+          startTime: 10.0,
+          endTime: 15.0,
+          speakerLabel: "SPEAKER_00",
+          speakerDisplay: "Alice",
+          snippet: "about <b>tariffs</b>",
+          rank: 0.5,
+        },
+      ],
+    };
+    searchMentions.mockResolvedValue(mockResult);
+
+    const req = new NextRequest(
+      "http://localhost/api/search/mentions?q=tariffs&episodeId=ep-1"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(200);
+    expect(searchMentions).toHaveBeenCalledWith("tariffs", "ep-1");
+
+    const body = await resp.json();
+    expect(body.episodeId).toBe("ep-1");
+    expect(body.mentions).toHaveLength(1);
+    expect(body.mentions[0].snippet).toContain("<b>tariffs</b>");
+  });
+
+  test("returns 500 on search error", async () => {
+    searchMentions.mockRejectedValue(new Error("DB down"));
+
+    const req = new NextRequest(
+      "http://localhost/api/search/mentions?q=test&episodeId=ep-1"
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds grouped search view that organizes results by podcast → episode with mention counts
- Lazy-loads individual mentions per episode on expand (separate API call)
- Adds flat/grouped view toggle on the home page (grouped is default)
- Shows summary bar: "Found in X podcasts, Y episodes (Z mentions)"

## New files

| File | Purpose |
|------|---------|
| `apps/web/src/app/api/search/grouped/route.ts` | Grouped search endpoint — returns feeds → episodes with counts |
| `apps/web/src/app/api/search/mentions/route.ts` | Mentions endpoint — returns matching segments for one episode |
| `apps/web/src/components/FeedGroupCard.tsx` | Collapsible feed group with episode list |
| `apps/web/src/components/EpisodeMentionList.tsx` | Lazy-loaded mention list with timestamps, speakers, and play buttons |
| `apps/web/tests/unit/grouped-search.test.ts` | 10 unit tests for both new API routes |

## Modified files

| File | Changes |
|------|---------|
| `apps/web/src/lib/search.ts` | Added `GroupedSearchResult`, `FeedGroup`, `EpisodeGroup`, `Mention` types + `searchGrouped()` and `searchMentions()` query functions |
| `apps/web/src/app/page.tsx` | Added grouped/flat view toggle, grouped view rendering with `FeedGroupCard` |

Closes #13

## Test plan

- [x] All 10 new API route tests pass (parameter validation, mock DB calls, error handling)
- [x] All 12 existing web unit tests pass (timestamp, audio-route minus pre-existing failure)
- [x] All 72 pipeline unit tests pass (no regressions)
- [ ] Manual: search with grouped view shows podcast → episode hierarchy
- [ ] Manual: expanding an episode lazy-loads mentions with play buttons
- [ ] Manual: flat view toggle works and shows original card layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)