### PR TITLE
Implement word-level speaker alignment for diarization

### DIFF
--- a/apps/pipeline/app/services/alignment.py
+++ b/apps/pipeline/app/services/alignment.py
@@ -1,13 +1,109 @@
 """
 Whisper ↔ pyannote segment alignment — PRD-01 §5.5
 
-Strategy: majority overlap.
-  For each Whisper segment, find the pyannote speaker whose time range
-  overlaps the most. In case of a tie, prefer the earlier-starting speaker.
+Two strategies:
+
+1. Word-level alignment (preferred): assigns speakers per word using overlap
+   with pyannote segments, then rebuilds display segments from consecutive
+   same-speaker words. Handles speaker transitions within a sentence.
+
+2. Majority overlap (fallback): assigns a single speaker per Whisper segment
+   based on which pyannote speaker overlaps the most.
 
 This is the testable core logic — no database or model dependencies.
 """
 from typing import Optional
+
+
+def assign_speakers_wordlevel(
+    aligned_segments: list[dict],
+    diarization_segments: list[dict],
+) -> list[dict]:
+    """
+    Word-level speaker assignment with segment rebuilding.
+
+    Args:
+        aligned_segments: WhisperX segments with "words" arrays, each word
+                          having {"word": str, "start": float, "end": float}
+        diarization_segments: list of {"speaker": str, "start": float, "end": float}
+
+    Returns:
+        list of rebuilt segments: {"start": float, "end": float, "text": str, "speaker": str}
+        Consecutive words with the same speaker are merged into one segment.
+    """
+    # Flatten all words from all segments
+    words = []
+    for seg in aligned_segments:
+        for w in seg.get("words", []):
+            start = w.get("start")
+            end = w.get("end")
+            word_text = w.get("word", "")
+            if start is not None and end is not None and word_text:
+                words.append({"word": word_text, "start": start, "end": end})
+
+    if not words:
+        return []
+
+    # Assign speaker to each word
+    for word in words:
+        word["speaker"] = _best_speaker_for_interval(
+            word["start"], word["end"], diarization_segments
+        )
+
+    # Rebuild segments from consecutive same-speaker words
+    rebuilt = []
+    current_speaker = words[0]["speaker"]
+    current_start = words[0]["start"]
+    current_end = words[0]["end"]
+    current_words = [words[0]["word"]]
+
+    for word in words[1:]:
+        if word["speaker"] == current_speaker:
+            current_end = word["end"]
+            current_words.append(word["word"])
+        else:
+            rebuilt.append({
+                "start": current_start,
+                "end": current_end,
+                "text": "".join(current_words).strip(),
+                "speaker": current_speaker,
+            })
+            current_speaker = word["speaker"]
+            current_start = word["start"]
+            current_end = word["end"]
+            current_words = [word["word"]]
+
+    # Final segment
+    rebuilt.append({
+        "start": current_start,
+        "end": current_end,
+        "text": "".join(current_words).strip(),
+        "speaker": current_speaker,
+    })
+
+    return rebuilt
+
+
+def _best_speaker_for_interval(
+    start: float, end: float, diarization_segments: list[dict]
+) -> str:
+    """Find the speaker with the most overlap for a time interval."""
+    best_speaker = "SPEAKER_00"
+    best_overlap = 0.0
+    best_start = float("inf")
+
+    for d_seg in diarization_segments:
+        overlap = _overlap(start, end, d_seg["start"], d_seg["end"])
+        if overlap <= 0:
+            continue
+        if overlap > best_overlap or (
+            overlap == best_overlap and d_seg["start"] < best_start
+        ):
+            best_overlap = overlap
+            best_speaker = d_seg["speaker"]
+            best_start = d_seg["start"]
+
+    return best_speaker
 
 
 def assign_speakers(
@@ -15,7 +111,7 @@ def assign_speakers(
     diarization_segments: list[dict],
 ) -> dict[int, str]:
     """
-    Assign a speaker label to each transcript segment.
+    Fallback: segment-level majority overlap speaker assignment.
 
     Args:
         transcript_segments: list of {"id": int, "start": float, "end": float}

--- a/apps/pipeline/app/services/whisper.py
+++ b/apps/pipeline/app/services/whisper.py
@@ -59,12 +59,14 @@ def unload_model() -> None:
     logger.info('"action": "whisper_unloaded"')
 
 
-def transcribe(audio_path: str, model_name: str = "large-v3-turbo") -> tuple[list[dict], str]:
+def transcribe(audio_path: str, model_name: str = "large-v3-turbo") -> tuple[list[dict], str, dict]:
     """
-    Transcribe audio file. Returns (segments, language).
+    Transcribe audio file. Returns (segments, language, aligned_result).
 
     segments: list of {"start": float, "end": float, "text": str}
     language: detected language code (e.g. "en")
+    aligned_result: full WhisperX result dict with word-level timestamps
+                    (contains "segments" with "words" arrays if alignment succeeded)
     """
     import whisperx
     from app.config import settings
@@ -101,7 +103,7 @@ def transcribe(audio_path: str, model_name: str = "large-v3-turbo") -> tuple[lis
         '"action": "whisper_transcribe_complete", "segments": %d, "language": "%s"',
         len(segments), language,
     )
-    return segments, language
+    return segments, language, result
 
 
 def _cuda_available() -> bool:

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -2,14 +2,17 @@
 Diarization task — PRD-01 §5.5
 
 - Runs pyannote speaker diarization on the audio file
-- Aligns speaker segments with Whisper transcript segments (majority overlap)
-- Updates segment speaker_label in database
+- If word-level alignment data exists (from WhisperX), assigns speakers per word
+  and rebuilds segments at speaker boundaries
+- Falls back to segment-level majority overlap if no word data available
 - Graceful failure: if diarization fails for any reason, episode is still marked
   done (has_diarization=False, diarization_error populated)
 """
+import json
 import logging
 from pathlib import Path
 
+from app.config import settings
 from app.database import SessionLocal
 from app.models import Episode, Segment
 
@@ -22,6 +25,7 @@ from app.tasks.celery_app import celery_app
 @celery_app.task(bind=True, name="diarize_episode")
 def diarize_episode(self, episode_id: str) -> str:
     db = SessionLocal()
+    alignment_path = Path(settings.transcript_dir) / f"{episode_id}.whisperx.json"
     try:
         episode = db.query(Episode).filter(Episode.id == episode_id).first()
         if not episode or not episode.audio_local_path:
@@ -31,39 +35,20 @@ def diarize_episode(self, episode_id: str) -> str:
 
         try:
             from app.services.pyannote import diarize
-            from app.services.alignment import assign_speakers
 
             diarization_segments = diarize(audio_path)
-            transcript_segments = (
-                db.query(Segment)
-                .filter(Segment.episode_id == episode_id)
-                .order_by(Segment.start_time)
-                .all()
-            )
 
-            assignments = assign_speakers(
-                transcript_segments=[
-                    {"id": s.id, "start": s.start_time, "end": s.end_time}
-                    for s in transcript_segments
-                ],
-                diarization_segments=diarization_segments,
-            )
-
-            for seg_id, speaker in assignments.items():
-                db.query(Segment).filter(Segment.id == seg_id).update(
-                    {"speaker_label": speaker}
-                )
+            # Try word-level alignment first (preferred)
+            if alignment_path.exists():
+                _diarize_wordlevel(db, episode_id, alignment_path, diarization_segments)
+            else:
+                _diarize_segment_level(db, episode_id, diarization_segments)
 
             db.query(Episode).filter(Episode.id == episode_id).update(
                 {"has_diarization": True, "diarization_error": None}
             )
             db.commit()
 
-            logger.info(
-                '"action": "diarize_complete", "episode_id": "%s", "speakers": %d',
-                episode_id,
-                len(set(assignments.values())),
-            )
         except Exception as exc:
             # Diarization failure is non-fatal — transcript is preserved (PRD-01 §5.5)
             db.query(Episode).filter(Episode.id == episode_id).update(
@@ -85,4 +70,93 @@ def diarize_episode(self, episode_id: str) -> str:
         infer_speakers.delay(episode_id)
         return episode_id
     finally:
+        # Clean up alignment file
+        if alignment_path.exists():
+            try:
+                alignment_path.unlink()
+            except Exception:
+                pass
         db.close()
+
+
+def _diarize_wordlevel(
+    db, episode_id: str, alignment_path: Path, diarization_segments: list[dict]
+) -> None:
+    """Word-level speaker assignment: rebuild segments at speaker boundaries."""
+    from app.services.alignment import assign_speakers_wordlevel
+
+    with open(alignment_path) as f:
+        aligned_result = json.load(f)
+
+    aligned_segments = aligned_result.get("segments", [])
+
+    # Check if word-level data actually exists
+    has_words = any(seg.get("words") for seg in aligned_segments)
+    if not has_words:
+        logger.info(
+            '"action": "diarize_wordlevel_no_words", "episode_id": "%s", '
+            '"reason": "alignment data has no word timestamps, falling back to segment-level"',
+            episode_id,
+        )
+        _diarize_segment_level(db, episode_id, diarization_segments)
+        return
+
+    rebuilt_segments = assign_speakers_wordlevel(aligned_segments, diarization_segments)
+
+    # Replace existing segments with rebuilt ones
+    db.query(Segment).filter(Segment.episode_id == episode_id).delete()
+    for seg in rebuilt_segments:
+        db.add(
+            Segment(
+                episode_id=episode_id,
+                start_time=seg["start"],
+                end_time=seg["end"],
+                text=seg["text"],
+                speaker_label=seg["speaker"],
+            )
+        )
+    db.flush()
+
+    logger.info(
+        '"action": "diarize_wordlevel_complete", "episode_id": "%s", '
+        '"segments": %d, "speakers": %d',
+        episode_id,
+        len(rebuilt_segments),
+        len({s["speaker"] for s in rebuilt_segments}),
+    )
+
+
+def _diarize_segment_level(
+    db, episode_id: str, diarization_segments: list[dict]
+) -> None:
+    """Fallback: segment-level majority overlap speaker assignment."""
+    from app.services.alignment import assign_speakers
+
+    transcript_segments = (
+        db.query(Segment)
+        .filter(Segment.episode_id == episode_id)
+        .order_by(Segment.start_time)
+        .all()
+    )
+
+    assignments = assign_speakers(
+        transcript_segments=[
+            {"id": s.id, "start": s.start_time, "end": s.end_time}
+            for s in transcript_segments
+        ],
+        diarization_segments=diarization_segments,
+    )
+
+    for seg_id, speaker in assignments.items():
+        db.query(Segment).filter(Segment.id == seg_id).update(
+            {"speaker_label": speaker}
+        )
+    db.flush()
+
+    logger.info(
+        '"action": "diarize_segment_level_complete", "episode_id": "%s", '
+        '"segments": %d, "speakers": %d',
+        episode_id,
+        len(assignments),
+        len(set(assignments.values())),
+    )

--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -8,6 +8,7 @@ Transcription task — PRD-01 §5.3, §5.4
   (mandatory — Whisper + pyannote must never be resident simultaneously)
 """
 import gc
+import json
 import logging
 import os
 from pathlib import Path
@@ -47,7 +48,9 @@ def transcribe_episode(self, episode_id: str) -> str:
         try:
             from app.services.whisper import transcribe
 
-            segments_data, language = transcribe(str(wav_path), model_name=settings.whisper_model)
+            segments_data, language, aligned_result = transcribe(
+                str(wav_path), model_name=settings.whisper_model
+            )
         except MemoryError as exc:
             _mark_failed(db, episode_id, "OOM", str(exc))
             return episode_id
@@ -60,6 +63,18 @@ def transcribe_episode(self, episode_id: str) -> str:
             _unload_whisper()
             if wav_path.exists():
                 wav_path.unlink()
+
+        # Step 2b: save word-level alignment data for diarization
+        alignment_path = Path(settings.transcript_dir) / f"{episode_id}.whisperx.json"
+        try:
+            alignment_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(alignment_path, "w") as f:
+                json.dump(aligned_result, f)
+        except Exception as exc:
+            logger.warning(
+                '"action": "alignment_save_failed", "episode_id": "%s", "error": "%s"',
+                episode_id, exc,
+            )
 
         # Step 3: persist segments
         db.query(Segment).filter(Segment.episode_id == episode_id).delete()

--- a/apps/pipeline/tests/unit/test_alignment.py
+++ b/apps/pipeline/tests/unit/test_alignment.py
@@ -1,9 +1,14 @@
 """
-Unit tests for majority-overlap speaker alignment — PRD-01 §5.5, PRD-01 §12
+Unit tests for speaker alignment — PRD-01 §5.5, PRD-01 §12
+Tests both word-level and segment-level (fallback) alignment.
 """
 import pytest
 
-from app.services.alignment import assign_speakers, _overlap
+from app.services.alignment import (
+    assign_speakers,
+    assign_speakers_wordlevel,
+    _overlap,
+)
 
 
 class TestOverlap:
@@ -24,6 +29,8 @@ class TestOverlap:
 
 
 class TestAssignSpeakers:
+    """Segment-level majority overlap (fallback)."""
+
     def test_simple_single_speaker(self):
         segs = [{"id": 1, "start": 0.0, "end": 10.0}]
         diar = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 10.0}]
@@ -73,3 +80,144 @@ class TestAssignSpeakers:
         diar = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 10.0}]
         result = assign_speakers(segs, diar)
         assert result[1] == "SPEAKER_00"  # Falls back to default
+
+
+class TestAssignSpeakersWordlevel:
+    """Word-level speaker alignment with segment rebuilding."""
+
+    def test_single_speaker_merges_all_words(self):
+        """All words from one speaker should produce a single segment."""
+        aligned = [
+            {
+                "start": 0.0, "end": 3.0, "text": "Hello world",
+                "words": [
+                    {"word": " Hello", "start": 0.0, "end": 1.0},
+                    {"word": " world", "start": 1.0, "end": 2.0},
+                ],
+            },
+        ]
+        diar = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0}]
+        result = assign_speakers_wordlevel(aligned, diar)
+
+        assert len(result) == 1
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "Hello world"
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 2.0
+
+    def test_speaker_transition_splits_segment(self):
+        """A speaker change mid-segment should produce two rebuilt segments."""
+        aligned = [
+            {
+                "start": 0.0, "end": 6.0,
+                "text": "How are you I am fine",
+                "words": [
+                    {"word": " How", "start": 0.0, "end": 1.0},
+                    {"word": " are", "start": 1.0, "end": 2.0},
+                    {"word": " you", "start": 2.0, "end": 3.0},
+                    {"word": " I", "start": 3.5, "end": 4.0},
+                    {"word": " am", "start": 4.0, "end": 4.5},
+                    {"word": " fine", "start": 4.5, "end": 5.5},
+                ],
+            },
+        ]
+        diar = [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 3.2},
+            {"speaker": "SPEAKER_01", "start": 3.2, "end": 6.0},
+        ]
+        result = assign_speakers_wordlevel(aligned, diar)
+
+        assert len(result) == 2
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "How are you"
+        assert result[1]["speaker"] == "SPEAKER_01"
+        assert result[1]["text"] == "I am fine"
+
+    def test_rapid_back_and_forth(self):
+        """Multiple speaker transitions within a short span."""
+        aligned = [
+            {
+                "start": 0.0, "end": 6.0,
+                "text": "Yes No Maybe",
+                "words": [
+                    {"word": " Yes", "start": 0.0, "end": 1.0},
+                    {"word": " No", "start": 2.0, "end": 3.0},
+                    {"word": " Maybe", "start": 4.0, "end": 5.0},
+                ],
+            },
+        ]
+        diar = [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 1.5},
+            {"speaker": "SPEAKER_01", "start": 1.5, "end": 3.5},
+            {"speaker": "SPEAKER_00", "start": 3.5, "end": 6.0},
+        ]
+        result = assign_speakers_wordlevel(aligned, diar)
+
+        assert len(result) == 3
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "Yes"
+        assert result[1]["speaker"] == "SPEAKER_01"
+        assert result[1]["text"] == "No"
+        assert result[2]["speaker"] == "SPEAKER_00"
+        assert result[2]["text"] == "Maybe"
+
+    def test_multiple_whisperx_segments(self):
+        """Words from multiple WhisperX segments are flattened and reassigned."""
+        aligned = [
+            {
+                "start": 0.0, "end": 2.0, "text": "First",
+                "words": [{"word": " First", "start": 0.0, "end": 1.0}],
+            },
+            {
+                "start": 2.0, "end": 4.0, "text": "Second",
+                "words": [{"word": " Second", "start": 2.0, "end": 3.0}],
+            },
+        ]
+        diar = [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 1.5},
+            {"speaker": "SPEAKER_01", "start": 1.5, "end": 4.0},
+        ]
+        result = assign_speakers_wordlevel(aligned, diar)
+
+        assert len(result) == 2
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "First"
+        assert result[1]["speaker"] == "SPEAKER_01"
+        assert result[1]["text"] == "Second"
+
+    def test_no_words_returns_empty(self):
+        """Segments without word data should return empty list."""
+        aligned = [{"start": 0.0, "end": 5.0, "text": "Hello"}]  # no "words" key
+        diar = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0}]
+        result = assign_speakers_wordlevel(aligned, diar)
+        assert result == []
+
+    def test_words_missing_timestamps_are_skipped(self):
+        """Words without start/end timestamps are excluded."""
+        aligned = [
+            {
+                "start": 0.0, "end": 3.0, "text": "A B",
+                "words": [
+                    {"word": " A", "start": 0.0, "end": 1.0},
+                    {"word": " B"},  # missing timestamps
+                    {"word": " C", "start": 2.0, "end": 3.0},
+                ],
+            },
+        ]
+        diar = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0}]
+        result = assign_speakers_wordlevel(aligned, diar)
+
+        assert len(result) == 1
+        assert result[0]["text"] == "A C"
+
+    def test_empty_diarization_defaults_to_speaker_00(self):
+        """Words with no matching diarization segments default to SPEAKER_00."""
+        aligned = [
+            {
+                "start": 0.0, "end": 2.0, "text": "Hello",
+                "words": [{"word": " Hello", "start": 0.0, "end": 1.0}],
+            },
+        ]
+        result = assign_speakers_wordlevel(aligned, [])
+        assert len(result) == 1
+        assert result[0]["speaker"] == "SPEAKER_00"

--- a/apps/pipeline/tests/unit/test_whisper_service.py
+++ b/apps/pipeline/tests/unit/test_whisper_service.py
@@ -70,12 +70,13 @@ class TestTranscribe:
              patch("whisperx.load_audio", return_value=MagicMock()), \
              patch("whisperx.load_align_model", return_value=(mock_align_model, mock_metadata)), \
              patch("whisperx.align", return_value=aligned_result):
-            segments, language = ws.transcribe("/tmp/test.wav")
+            segments, language, result = ws.transcribe("/tmp/test.wav")
 
         assert language == "en"
         assert len(segments) == 2
         assert segments[0] == {"start": 0.0, "end": 2.5, "text": "Hello world."}
         assert segments[1] == {"start": 2.5, "end": 5.0, "text": "Second segment."}
+        assert "segments" in result
 
     def test_transcribe_handles_unknown_language(self):
         """transcribe() returns 'unknown' when language detection fails."""
@@ -91,7 +92,7 @@ class TestTranscribe:
              patch("app.services.whisper._cuda_available", return_value=False), \
              patch("whisperx.load_audio", return_value=MagicMock()), \
              patch("whisperx.load_align_model", side_effect=Exception("no model for unknown")):
-            segments, language = ws.transcribe("/tmp/test.wav")
+            segments, language, result = ws.transcribe("/tmp/test.wav")
 
         assert language == "unknown"
         assert segments == []
@@ -110,7 +111,7 @@ class TestTranscribe:
              patch("app.services.whisper._cuda_available", return_value=False), \
              patch("whisperx.load_audio", return_value=MagicMock()), \
              patch("whisperx.load_align_model", side_effect=Exception("alignment failed")):
-            segments, language = ws.transcribe("/tmp/test.wav")
+            segments, language, result = ws.transcribe("/tmp/test.wav")
 
         assert language == "en"
         assert len(segments) == 2


### PR DESCRIPTION
## Summary

- Replaces segment-level majority-overlap speaker assignment with word-level alignment
- Speaker transitions within a sentence are now correctly split into separate segments
- Falls back to segment-level assignment when word data is unavailable

## How it works

1. **Transcribe task** saves the full WhisperX result (with word-level timestamps) as `{transcript_dir}/{episode_id}.whisperx.json`
2. **Diarize task** loads the JSON, runs pyannote, assigns speakers per word using overlap, then rebuilds segments from consecutive same-speaker words
3. The intermediate JSON is cleaned up after diarization
4. If no word data exists (alignment failed), falls back to the original segment-level majority overlap

## Changes

| File | What changed |
|------|-------------|
| `whisper.py` | `transcribe()` now returns `(segments, language, aligned_result)` — the raw WhisperX dict with word timestamps |
| `transcribe.py` | Saves aligned result as JSON for the diarize task |
| `alignment.py` | New `assign_speakers_wordlevel()` — assigns speakers per word, rebuilds segments at speaker boundaries |
| `diarize.py` | Uses word-level alignment when JSON exists, falls back to segment-level |
| `test_alignment.py` | 7 new tests: speaker transitions, rapid back-and-forth, missing words, empty diarization |
| `test_whisper_service.py` | Updated for 3-tuple return value |

Closes #4

## Test plan

- [x] All 79 unit tests pass (72 existing + 7 new)
- [ ] Manual: re-process an episode and verify speaker transitions are split correctly
- [ ] Manual: verify fallback works when alignment JSON is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)