### PR TITLE
Add processing duration tracking for transcribe and diarize tasks

### DIFF
--- a/apps/pipeline/alembic/versions/003_add_processing_duration_columns.py
+++ b/apps/pipeline/alembic/versions/003_add_processing_duration_columns.py
@@ -1,0 +1,27 @@
+"""Add processing duration columns to episodes
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-03-14
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '003'
+down_revision: Union[str, None] = '002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('episodes', sa.Column('transcribe_duration_secs', sa.Float(), nullable=True))
+    op.add_column('episodes', sa.Column('diarize_duration_secs', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('episodes', 'diarize_duration_secs')
+    op.drop_column('episodes', 'transcribe_duration_secs')

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -84,6 +84,10 @@ class Episode(Base):
     inference_skipped: Mapped[bool] = mapped_column(Boolean, default=False)
     inference_error: Mapped[str | None] = mapped_column(Text)
 
+    # Processing duration (seconds)
+    transcribe_duration_secs: Mapped[float | None] = mapped_column(Float)
+    diarize_duration_secs: Mapped[float | None] = mapped_column(Float)
+
     # Celery task reference
     celery_task_id: Mapped[str | None] = mapped_column(Text)
 

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -10,6 +10,7 @@ Diarization task — PRD-01 §5.5
 """
 import json
 import logging
+import time
 from pathlib import Path
 
 from app.config import settings
@@ -36,6 +37,7 @@ def diarize_episode(self, episode_id: str) -> str:
         try:
             from app.services.pyannote import diarize
 
+            t0 = time.monotonic()
             diarization_segments = diarize(audio_path)
 
             # Try word-level alignment first (preferred)
@@ -44,8 +46,9 @@ def diarize_episode(self, episode_id: str) -> str:
             else:
                 _diarize_segment_level(db, episode_id, diarization_segments)
 
+            diarize_secs = round(time.monotonic() - t0, 1)
             db.query(Episode).filter(Episode.id == episode_id).update(
-                {"has_diarization": True, "diarization_error": None}
+                {"has_diarization": True, "diarization_error": None, "diarize_duration_secs": diarize_secs}
             )
             db.commit()
 

--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -11,6 +11,7 @@ import gc
 import json
 import logging
 import os
+import time
 from pathlib import Path
 
 from app.config import settings
@@ -48,9 +49,15 @@ def transcribe_episode(self, episode_id: str) -> str:
         try:
             from app.services.whisper import transcribe
 
+            t0 = time.monotonic()
             segments_data, language, aligned_result = transcribe(
                 str(wav_path), model_name=settings.whisper_model
             )
+            transcribe_secs = round(time.monotonic() - t0, 1)
+            db.query(Episode).filter(Episode.id == episode_id).update(
+                {"transcribe_duration_secs": transcribe_secs}
+            )
+            db.commit()
         except MemoryError as exc:
             _mark_failed(db, episode_id, "OOM", str(exc))
             return episode_id
@@ -95,10 +102,11 @@ def transcribe_episode(self, episode_id: str) -> str:
         db.commit()
 
         logger.info(
-            '"action": "transcribe_complete", "episode_id": "%s", "segments": %d, "language": "%s"',
+            '"action": "transcribe_complete", "episode_id": "%s", "segments": %d, "language": "%s", "duration_secs": %.1f',
             episode_id,
             len(segments_data),
             language,
+            transcribe_secs,
         )
 
         from app.tasks.diarize import diarize_episode

--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -26,6 +26,8 @@ interface Episode {
   has_diarization: boolean;
   diarization_error: string | null;
   inference_error: string | null;
+  transcribe_duration_secs: number | null;
+  diarize_duration_secs: number | null;
   feed_id: string | null;
   feed_title: string | null;
 }
@@ -88,6 +90,16 @@ export default async function EpisodePage({ params }: { params: { id: string } }
           )}
           {episode.duration_secs && <span>{formatTime(episode.duration_secs)}</span>}
         </div>
+        {(episode.transcribe_duration_secs || episode.diarize_duration_secs) && (
+          <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
+            {episode.transcribe_duration_secs != null && (
+              <span>Transcription: {formatTime(episode.transcribe_duration_secs)}</span>
+            )}
+            {episode.diarize_duration_secs != null && (
+              <span>Diarization: {formatTime(episode.diarize_duration_secs)}</span>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Diarization failure banner — PRD-02 §5.3 */}


### PR DESCRIPTION
## Summary
- Add `transcribe_duration_secs` and `diarize_duration_secs` columns to the episodes table via Alembic migration
- Track wall-clock duration in the transcribe and diarize Celery tasks
- Display processing durations on the episode detail page in the web UI

## Test plan
- [ ] Verify Alembic migration applies cleanly (`make shell-db` to inspect columns)
- [ ] Run a transcribe + diarize pipeline and confirm durations are stored
- [ ] Check episode detail page shows duration values

🤖 Generated with [Claude Code](https://claude.com/claude-code)