### PR TITLE
Add landing page branding, footer, and O'Saasy license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+O'Saasy License Agreement
 
 Copyright (c) 2026 Đorđe
 
@@ -9,8 +9,14 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+2. No licensee or downstream recipient may use the Software (including any
+   modified or derivative versions) to directly compete with the original
+   Licensor by offering it to third parties as a hosted, managed, or
+   Software-as-a-Service (SaaS) product or cloud service where the primary
+   value of the service is the functionality of the Software itself.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,6 @@ make help              # List all available commands
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+[O'Saasy License](https://osaasy.dev). See [LICENSE](LICENSE).
 
 **pyannote models** are subject to their own license — you must accept this independently at [huggingface.co/pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1). Users are responsible for copyright compliance with podcast audio content.

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -3,7 +3,7 @@ name = "podlog-pipeline"
 version = "0.1.0"
 description = "Podlog ingestion pipeline — RSS fetch, Whisper transcription, pyannote diarization"
 authors = []
-license = "MIT"
+license = "O'Saasy"
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "podlog-web",
   "version": "0.1.0",
   "private": true,
+  "license": "O'Saasy",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "@/app/globals.css";
 import Navbar from "@/components/Navbar";
 import AudioPlayer from "@/components/AudioPlayer";
+import Footer from "@/components/Footer";
 import { AudioPlayerProvider } from "@/components/AudioPlayerContext";
 import QueryProvider from "@/components/QueryProvider";
 
@@ -23,6 +24,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <main className="max-w-5xl mx-auto px-4 py-8 pb-24">
               {children}
             </main>
+            <Footer />
             {/* Global persistent player — fixed to bottom, persists across navigation */}
             <AudioPlayer />
           </AudioPlayerProvider>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -75,6 +75,15 @@ export default function HomePage() {
 
   return (
     <div className="space-y-6">
+      {!submittedQuery && (
+        <div className="text-center py-8 space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Podlog</h1>
+          <p className="text-muted-foreground">
+            Self-hosted podcast transcription and search
+          </p>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit} className="space-y-3">
         <div className="relative">
           <Search

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Activity } from "lucide-react";
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
+
+interface HealthData {
+  status: string;
+}
+
+export default function Footer() {
+  const health = useQuery<HealthData>({
+    queryKey: ["pipeline-health"],
+    queryFn: async () => {
+      const resp = await fetch("/api/pipeline/health", { cache: "no-store" });
+      if (!resp.ok) return { status: "DEGRADED" };
+      return resp.json();
+    },
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+
+  const status = health.data?.status ?? "UNKNOWN";
+  const statusColor =
+    status === "OK"
+      ? "text-green-500"
+      : status === "WARMING_UP"
+        ? "text-yellow-500"
+        : "text-red-500";
+
+  return (
+    <footer className="border-t border-border bg-background/80 text-sm text-muted-foreground">
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+        {/* Top row: branding + status */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div className="space-y-1">
+            <p className="font-semibold text-foreground text-base">Podlog</p>
+            <p>Self-hosted podcast transcription and search</p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Activity size={14} className={statusColor} />
+            <span className={statusColor}>{status === "OK" ? "All systems online" : status === "WARMING_UP" ? "Pipeline warming up" : "Pipeline offline"}</span>
+          </div>
+        </div>
+
+        {/* Info grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-xs">
+          {/* Credits */}
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">Credits</p>
+            <p>
+              Built by{" "}
+              <a href="https://github.com/brlauuu" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+                @brlauuu
+              </a>
+              {" "}and{" "}
+              <a href="https://www.anthropic.com" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+                Claude (Anthropic)
+              </a>
+            </p>
+            <p>
+              <a href="https://github.com/brlauuu/podlog" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+                GitHub
+              </a>
+              {" · "}
+              <a href="https://osaasy.dev" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+                O&apos;Saasy License
+              </a>
+            </p>
+          </div>
+
+          {/* Tech stack */}
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">Built with</p>
+            <p>Whisper &middot; pyannote &middot; Next.js &middot; PostgreSQL &middot; Celery</p>
+          </div>
+
+          {/* Privacy */}
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">Privacy</p>
+            <p>All data stays on your machine. No external telemetry.</p>
+          </div>
+        </div>
+
+        {/* Bottom row */}
+        <div className="flex items-center justify-between pt-2 border-t border-border text-xs">
+          <p>&copy; 2026 Đorđe. O&apos;Saasy License.</p>
+          <p>v{APP_VERSION}</p>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Add project branding (name + tagline) to the landing page when no search query is active
- Create a reusable `Footer` component displayed across all pages with: developer credits, GitHub link, tech stack summary, privacy note, version number, and live pipeline health status
- Switch license from MIT to [O'Saasy](https://osaasy.dev) — update `LICENSE`, `README.md`, `package.json`, and `pyproject.toml`

## Test plan
- [x] 79/79 pipeline unit tests pass
- [x] Web unit tests pass (pre-existing `audio-route` failure unrelated)
- [x] TypeScript compiles with no new errors
- [ ] Verify footer renders on all pages with correct info
- [ ] Verify health status indicator reflects pipeline state
- [ ] Verify landing page shows branding when search is empty, hides it during search

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)