### PR TITLE
Add TEST podcast mode: sample 5 episodes before full ingestion

### DIFF
--- a/apps/pipeline/alembic/versions/005_add_feed_mode_column.py
+++ b/apps/pipeline/alembic/versions/005_add_feed_mode_column.py
@@ -1,0 +1,28 @@
+"""Add mode column to feeds (test | full)
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-03-16
+
+Per issue #23: TEST podcast mode — sample 5 episodes before committing to full ingestion.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '005'
+down_revision: Union[str, None] = '004'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('feeds', sa.Column('mode', sa.Text(), nullable=False, server_default='full'))
+    op.create_index('ix_feeds_mode', 'feeds', ['mode'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_feeds_mode', table_name='feeds')
+    op.drop_column('feeds', 'mode')

--- a/apps/pipeline/app/api/feeds.py
+++ b/apps/pipeline/app/api/feeds.py
@@ -1,5 +1,5 @@
 """
-Feed management API — PRD-01 §10
+Feed management API — PRD-01 §10, Issue #23
 
 POST   /api/feeds         Add a new RSS feed (with validation — GAP-02)
 GET    /api/feeds         List all feeds
@@ -8,7 +8,7 @@ POST   /api/feeds/{id}/poll  Trigger immediate re-poll
 """
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -25,6 +25,7 @@ router = APIRouter()
 
 class AddFeedRequest(BaseModel):
     url: str
+    mode: Literal["test", "full"] = "full"
 
 
 class FeedResponse(BaseModel):
@@ -34,6 +35,7 @@ class FeedResponse(BaseModel):
     description: Optional[str]
     image_url: Optional[str]
     website_url: Optional[str]
+    mode: str
     last_polled_at: Optional[datetime]
     created_at: datetime
 
@@ -45,16 +47,37 @@ def add_feed(body: AddFeedRequest, db: Session = Depends(get_db)) -> FeedRespons
     """
     Add a new RSS feed. Validates the URL is a parseable RSS/Atom feed (GAP-02)
     before persisting. Enqueues ingestion of all existing episodes.
+
+    Issue #23: If a feed already exists in test mode and is re-added, it gets
+    promoted to full mode and remaining episodes are ingested.
     """
+    # Check for existing feed first — handle test→full promotion
+    existing = db.query(Feed).filter(Feed.url == body.url).first()
+    if existing:
+        if existing.mode == "test" and body.mode == "full":
+            # Promote test → full: flip mode and re-ingest to pick up remaining episodes
+            existing.mode = "full"
+            db.commit()
+            db.refresh(existing)
+            try:
+                ingest_feed.delay(existing.id)
+            except Exception as exc:
+                logger.error(
+                    '"action": "promote_feed_dispatch_failed", "feed_id": "%s", "error": "%s"',
+                    existing.id, exc,
+                )
+            logger.info(
+                '"action": "feed_promoted", "feed_id": "%s", "url": "%s"',
+                existing.id, body.url,
+            )
+            return FeedResponse.model_validate(existing)
+        raise HTTPException(status_code=409, detail="Feed already registered")
+
     # GAP-02: validate the feed is parseable before storing
     try:
         feed_meta = rss_service.validate_and_parse_feed(body.url)
     except rss_service.InvalidFeedError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
-
-    existing = db.query(Feed).filter(Feed.url == body.url).first()
-    if existing:
-        raise HTTPException(status_code=409, detail="Feed already registered")
 
     feed = Feed(
         url=body.url,
@@ -62,6 +85,7 @@ def add_feed(body: AddFeedRequest, db: Session = Depends(get_db)) -> FeedRespons
         description=feed_meta.description,
         image_url=feed_meta.image_url,
         website_url=feed_meta.website_url,
+        mode=body.mode,
     )
     db.add(feed)
     db.flush()  # Assign ID without committing, so we can roll back on dispatch failure
@@ -80,7 +104,10 @@ def add_feed(body: AddFeedRequest, db: Session = Depends(get_db)) -> FeedRespons
     db.commit()
     db.refresh(feed)
 
-    logger.info('"action": "feed_added", "feed_id": "%s", "url": "%s"', feed.id, feed.url)
+    logger.info(
+        '"action": "feed_added", "feed_id": "%s", "url": "%s", "mode": "%s"',
+        feed.id, feed.url, feed.mode,
+    )
     return FeedResponse.model_validate(feed)
 
 

--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -51,6 +51,7 @@ def get_queue(db: Session = Depends(get_db)) -> QueueStateResponse:
             "error_class": ep.error_class,
             "retry_count": ep.retry_count,
             "retry_max": ep.retry_max,
+            "feed_mode": ep.feed.mode if ep.feed else None,
         }
 
     return QueueStateResponse(

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -39,6 +39,9 @@ class Feed(Base):
     image_url: Mapped[str | None] = mapped_column(Text)
     website_url: Mapped[str | None] = mapped_column(Text)
     last_polled_at: Mapped[datetime | None] = mapped_column()
+    # Issue #23: test | full — test mode limits to 5 random episodes
+    mode: Mapped[str] = mapped_column(Text, nullable=False, default="full")
+
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 
     episodes: Mapped[list["Episode"]] = relationship(

--- a/apps/pipeline/app/scheduler.py
+++ b/apps/pipeline/app/scheduler.py
@@ -29,14 +29,14 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @celery_app.task(name="poll_all_feeds")
 def poll_all_feeds() -> dict:
-    """Poll all registered feeds for new episodes."""
+    """Poll all registered feeds for new episodes. Issue #23: skip test feeds."""
     from app.database import SessionLocal
     from app.models import Feed
     from app.tasks.ingest import ingest_feed
 
     db = SessionLocal()
     try:
-        feeds = db.query(Feed).all()
+        feeds = db.query(Feed).filter(Feed.mode == "full").all()
         for feed in feeds:
             ingest_feed.delay(feed.id)
         return {"polled": len(feeds)}

--- a/apps/pipeline/app/tasks/ingest.py
+++ b/apps/pipeline/app/tasks/ingest.py
@@ -5,6 +5,7 @@ ingest_feed   — poll an RSS feed, enqueue any new episodes
 ingest_episode — run the full pipeline for a single episode
 """
 import logging
+import random
 from datetime import datetime, timezone
 
 from app.database import SessionLocal
@@ -13,6 +14,9 @@ from app.services import rss as rss_service
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
+
+# Issue #23: max episodes to process in test mode
+TEST_MODE_MAX_EPISODES = 5
 
 
 @celery_app.task(bind=True, name="ingest_feed")
@@ -28,17 +32,30 @@ def ingest_feed(self, feed_id: str) -> dict:
             return {"error": "Feed not found"}
 
         episodes_meta = rss_service.fetch_episodes(feed.url)
+
+        # Filter out episodes that already exist in the DB
+        existing_guids = set(
+            row[0]
+            for row in db.query(Episode.guid).filter(Episode.feed_id == feed_id).all()
+        )
+        new_episodes_meta = [m for m in episodes_meta if m.guid not in existing_guids]
+
+        # Issue #23: in test mode, limit to TEST_MODE_MAX_EPISODES total episodes
+        if feed.mode == "test":
+            existing_count = db.query(Episode).filter(Episode.feed_id == feed_id).count()
+            remaining_slots = max(0, TEST_MODE_MAX_EPISODES - existing_count)
+            if remaining_slots == 0:
+                logger.info(
+                    '"action": "test_mode_limit_reached", "feed_id": "%s"', feed_id
+                )
+                feed.last_polled_at = datetime.now(timezone.utc)
+                db.commit()
+                return {"new_episodes": 0, "reason": "test_mode_limit_reached"}
+            if len(new_episodes_meta) > remaining_slots:
+                new_episodes_meta = random.sample(new_episodes_meta, remaining_slots)
+
         new_count = 0
-
-        for meta in episodes_meta:
-            existing = (
-                db.query(Episode)
-                .filter(Episode.feed_id == feed_id, Episode.guid == meta.guid)
-                .first()
-            )
-            if existing:
-                continue
-
+        for meta in new_episodes_meta:
             episode = Episode(
                 feed_id=feed_id,
                 guid=meta.guid,
@@ -62,9 +79,10 @@ def ingest_feed(self, feed_id: str) -> dict:
         db.commit()
 
         logger.info(
-            '"action": "feed_polled", "feed_id": "%s", "new_episodes": %d',
+            '"action": "feed_polled", "feed_id": "%s", "new_episodes": %d, "mode": "%s"',
             feed_id,
             new_count,
+            feed.mode,
         )
         return {"new_episodes": new_count}
     finally:

--- a/apps/web/src/app/api/feeds/route.ts
+++ b/apps/web/src/app/api/feeds/route.ts
@@ -6,7 +6,7 @@ const PIPELINE_API = process.env.PIPELINE_API_URL ?? "http://pipeline:8000";
 export async function GET() {
   try {
     const result = await pool.query(`
-      SELECT f.id, f.url, f.title, f.last_polled_at,
+      SELECT f.id, f.url, f.title, f.mode, f.last_polled_at,
              COUNT(e.id)::int AS episode_count
       FROM feeds f
       LEFT JOIN episodes e ON e.feed_id = f.id

--- a/apps/web/src/app/feeds/page.tsx
+++ b/apps/web/src/app/feeds/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Plus, RefreshCw, Trash2, FlaskConical } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -14,11 +14,13 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 interface Feed {
   id: string;
   url: string;
   title: string | null;
+  mode: string;
   last_polled_at: string | null;
   episode_count: number;
 }
@@ -33,16 +35,17 @@ export default function FeedsPage() {
   const queryClient = useQueryClient();
   const [showAddModal, setShowAddModal] = useState(false);
   const [newUrl, setNewUrl] = useState("");
+  const [addMode, setAddMode] = useState<"test" | "full">("test");
   const [addError, setAddError] = useState<string | null>(null);
 
   const { data: feeds = [], isLoading } = useQuery({ queryKey: ["feeds"], queryFn: fetchFeeds });
 
   const addFeed = useMutation({
-    mutationFn: async (url: string) => {
+    mutationFn: async ({ url, mode }: { url: string; mode: string }) => {
       const resp = await fetch("/api/feeds", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ url, mode }),
       });
       if (!resp.ok) {
         const err = await resp.json();
@@ -54,9 +57,26 @@ export default function FeedsPage() {
       queryClient.invalidateQueries({ queryKey: ["feeds"] });
       setShowAddModal(false);
       setNewUrl("");
+      setAddMode("test");
       setAddError(null);
     },
     onError: (err: Error) => setAddError(err.message),
+  });
+
+  const promoteFeed = useMutation({
+    mutationFn: async ({ url }: { url: string }) => {
+      const resp = await fetch("/api/feeds", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, mode: "full" }),
+      });
+      if (!resp.ok) {
+        const err = await resp.json();
+        throw new Error(err.detail ?? "Failed to promote feed");
+      }
+      return resp.json();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["feeds"] }),
   });
 
   const pollFeed = useMutation({
@@ -90,7 +110,7 @@ export default function FeedsPage() {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
-                addFeed.mutate(newUrl.trim());
+                addFeed.mutate({ url: newUrl.trim(), mode: addMode });
               }}
               className="space-y-4"
             >
@@ -102,6 +122,31 @@ export default function FeedsPage() {
                 required
                 autoFocus
               />
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setAddMode("test")}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    addMode === "test"
+                      ? "bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200 ring-1 ring-violet-300 dark:ring-violet-700"
+                      : "bg-muted text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  <FlaskConical size={14} />
+                  Test (5 episodes)
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAddMode("full")}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    addMode === "full"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  Full
+                </button>
+              </div>
               {addError && <p className="text-sm text-destructive">{addError}</p>}
               <div className="flex justify-end gap-2">
                 <Button
@@ -148,7 +193,15 @@ export default function FeedsPage() {
             <Card key={feed.id} className="hover:bg-accent/30 transition-colors">
               <CardContent className="p-4 flex items-center justify-between gap-4">
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium truncate">{feed.title ?? feed.url}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium truncate">{feed.title ?? feed.url}</p>
+                    {feed.mode === "test" && (
+                      <Badge variant="outline" className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-1">
+                        <FlaskConical size={10} />
+                        Test
+                      </Badge>
+                    )}
+                  </div>
                   <p className="text-xs text-muted-foreground truncate">{feed.url}</p>
                   <p className="text-xs text-muted-foreground">
                     {feed.episode_count} episodes ·{" "}
@@ -158,6 +211,20 @@ export default function FeedsPage() {
                   </p>
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
+                  {feed.mode === "test" && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        if (confirm("Promote this feed to full mode? All remaining episodes will be ingested.")) {
+                          promoteFeed.mutate({ url: feed.url });
+                        }
+                      }}
+                      className="h-8 text-xs"
+                    >
+                      Promote to Full
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="icon"

--- a/apps/web/src/app/podcasts/[id]/page.tsx
+++ b/apps/web/src/app/podcasts/[id]/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, FlaskConical } from "lucide-react";
 import pool from "@/lib/db";
+import { Badge } from "@/components/ui/badge";
 
 export const dynamic = "force-dynamic";
 
@@ -19,6 +20,7 @@ interface Feed {
   title: string | null;
   image_url: string | null;
   website_url: string | null;
+  mode: string;
 }
 
 async function getFeed(id: string): Promise<Feed | null> {
@@ -61,7 +63,15 @@ export default async function PodcastPage({ params }: { params: { id: string } }
         <Link href="/podcasts" className="text-sm text-muted-foreground hover:text-foreground">
           ← Podcasts
         </Link>
-        <h1 className="text-2xl font-semibold mt-2">{feed.title ?? "Untitled podcast"}</h1>
+        <div className="flex items-center gap-2 mt-2">
+          <h1 className="text-2xl font-semibold">{feed.title ?? "Untitled podcast"}</h1>
+          {feed.mode === "test" && (
+            <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-1">
+              <FlaskConical size={12} />
+              Test
+            </Badge>
+          )}
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import Image from "next/image";
+import { FlaskConical } from "lucide-react";
 import pool from "@/lib/db";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 export const dynamic = "force-dynamic";
@@ -10,6 +12,7 @@ interface Feed {
   id: string;
   title: string | null;
   image_url: string | null;
+  mode: string;
   episode_count: number;
   last_polled_at: string | null;
 }
@@ -20,6 +23,7 @@ async function getFeeds(): Promise<Feed[]> {
       f.id,
       f.title,
       f.image_url,
+      f.mode,
       f.last_polled_at,
       COUNT(e.id)::int AS episode_count
     FROM feeds f
@@ -71,7 +75,15 @@ export default async function PodcastsPage() {
                   </div>
                 )}
                 <CardContent className="p-3 space-y-1">
-                  <p className="text-sm font-medium line-clamp-2">{feed.title ?? "Untitled"}</p>
+                  <div className="flex items-center gap-1.5">
+                    <p className="text-sm font-medium line-clamp-2">{feed.title ?? "Untitled"}</p>
+                    {feed.mode === "test" && (
+                      <Badge variant="outline" className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
+                        <FlaskConical size={9} />
+                        Test
+                      </Badge>
+                    )}
+                  </div>
                   <p className="text-xs text-muted-foreground">{feed.episode_count} episodes</p>
                 </CardContent>
               </Card>

--- a/apps/web/src/components/FeedGroupCard.tsx
+++ b/apps/web/src/components/FeedGroupCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, Radio, FileText } from "lucide-react";
+import { ChevronRight, Radio, FileText, FlaskConical } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import EpisodeMentionList from "@/components/EpisodeMentionList";
 import type { FeedGroup } from "@/lib/search";
 
@@ -44,6 +45,12 @@ export default function FeedGroupCard({ feed, query }: Props) {
         />
         <Radio size={16} className="shrink-0 text-primary" />
         <span className="font-medium truncate flex-1">{feed.feedTitle}</span>
+        {feed.feedMode === "test" && (
+          <Badge variant="outline" className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
+            <FlaskConical size={9} />
+            Test
+          </Badge>
+        )}
         <span className="text-xs text-muted-foreground shrink-0">
           {feed.mentionCount} mention{feed.mentionCount !== 1 ? "s" : ""} in{" "}
           {feed.episodes.length} episode{feed.episodes.length !== 1 ? "s" : ""}

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AlertTriangle, RefreshCw, ChevronDown } from "lucide-react";
+import { AlertTriangle, RefreshCw, ChevronDown, FlaskConical } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -15,6 +15,7 @@ interface Job {
   error_class: string | null;
   retry_count: number;
   retry_max: number;
+  feed_mode: string | null;
 }
 
 interface QueueState {
@@ -44,7 +45,15 @@ function JobCard({ job, onRetry }: { job: Job; onRetry: (taskId: string) => void
     <Card>
       <CardContent className="p-3 space-y-1">
         <div className="flex items-start justify-between gap-2">
-          <span className="text-sm font-medium">{job.title ?? job.episode_id}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium">{job.title ?? job.episode_id}</span>
+            {job.feed_mode === "test" && (
+              <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
+                <FlaskConical size={9} />
+                Test
+              </Badge>
+            )}
+          </div>
           {job.status === "failed" && (
             <button
               onClick={() => canRetry && job.celery_task_id && onRetry(job.celery_task_id)}

--- a/apps/web/src/components/SearchResult.tsx
+++ b/apps/web/src/components/SearchResult.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, ExternalLink, Play } from "lucide-react";
+import { AlertTriangle, ExternalLink, FlaskConical, Play } from "lucide-react";
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
 import { buildTimestampUrl, formatTimestamp } from "@/lib/timestamp";
 import { Card, CardContent } from "@/components/ui/card";
@@ -63,6 +63,12 @@ export default function SearchResult({ result }: Props) {
                     {result.episodeTitle}
                   </span>
                 </>
+              )}
+              {result.feedMode === "test" && (
+                <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
+                  <FlaskConical size={9} />
+                  Test
+                </Badge>
               )}
               {!result.hasDiarization && (
                 <Badge variant="outline" className="text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700 gap-1">

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -12,6 +12,7 @@ export interface GroupedSearchResult {
 export interface FeedGroup {
   feedId: string;
   feedTitle: string;
+  feedMode: string;
   mentionCount: number;
   episodes: EpisodeGroup[];
 }
@@ -59,6 +60,7 @@ export interface SearchResult {
   hasDiarization: boolean;
   diarizationError: string | null;
   feedTitle: string | null;
+  feedMode: string;
   feedId: string;
 }
 
@@ -99,6 +101,7 @@ export async function searchSegments(
         e.has_diarization,
         e.diarization_error,
         f.title AS feed_title,
+        f.mode AS feed_mode,
         f.id AS feed_id
       FROM segments s
       JOIN episodes e ON s.episode_id = e.id
@@ -139,6 +142,7 @@ export async function searchSegments(
     hasDiarization: row.has_diarization,
     diarizationError: row.diarization_error,
     feedTitle: row.feed_title,
+    feedMode: row.feed_mode,
     feedId: row.feed_id,
   }));
 
@@ -167,6 +171,7 @@ export async function searchGrouped(
       `SELECT
         f.id AS feed_id,
         f.title AS feed_title,
+        f.mode AS feed_mode,
         e.id AS episode_id,
         e.title AS episode_title,
         e.audio_url,
@@ -180,7 +185,7 @@ export async function searchGrouped(
         plainto_tsquery('english', $1) AS query
       WHERE to_tsvector('english', s.text) @@ query
         AND ($2::uuid IS NULL OR f.id = $2)
-      GROUP BY f.id, f.title, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
+      GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
       ORDER BY best_rank DESC, mention_count DESC
       LIMIT $3 OFFSET $4`,
       [query, feedId, pageSize, offset]
@@ -209,6 +214,7 @@ export async function searchGrouped(
       feedMap.set(feedKey, {
         feedId: row.feed_id,
         feedTitle: row.feed_title,
+        feedMode: row.feed_mode,
         mentionCount: 0,
         episodes: [],
       });


### PR DESCRIPTION
## Summary

Implements #23. Adds a **test mode** for adding podcasts — only 5 randomly selected episodes are processed, letting you trial a feed before committing to the full back catalog.

- **Database**: Migration 005 adds `mode` column (`test`|`full`, default `full`) to `feeds` table with index
- **Ingestion**: Test mode limits to 5 random episodes via `random.sample()`; existing episodes count against the cap
- **Feed API**: Accepts `mode` parameter; re-adding a test feed with `mode=full` promotes it and ingests remaining episodes
- **Scheduler**: `poll_all_feeds` skips test feeds — only full feeds are auto-polled
- **Queue API**: Includes `feed_mode` in job responses for UI badging
- **UI**: Mode toggle in Add Feed dialog (defaults to Test), violet "Test" badges everywhere (feeds page, podcasts list, podcast detail, search results, queue), and "Promote to Full" button on test feeds

## Test plan

- [ ] Add a feed in test mode — verify exactly 5 episodes are queued
- [ ] Add a feed with ≤5 episodes in test mode — verify all episodes are queued
- [ ] Verify test badge appears on feeds page, podcasts list, podcast detail header
- [ ] Promote a test feed to full — verify remaining episodes are ingested without duplicating existing ones
- [ ] Verify Celery Beat periodic polling skips test feeds
- [ ] Verify test badge appears in search results (grouped and flat) and queue job cards

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)