### PR TITLE
Link brlauuu references to GitHub Pages blog

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -90,7 +90,7 @@ export default function Footer() {
             <p className="font-medium text-foreground">Credits</p>
             <p>
               Built by{" "}
-              <a href="https://github.com/brlauuu" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+              <a href="https://brlauuu.github.io" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
                 @brlauuu
               </a>
               {" "}and{" "}
@@ -134,7 +134,7 @@ export default function Footer() {
 
         {/* Bottom row */}
         <div className="flex items-center justify-between pt-2 border-t border-border text-xs">
-          <p>&copy; 2026 brlauuu. O&apos;Saasy License.</p>
+          <p>&copy; 2026 <a href="https://brlauuu.github.io" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">brlauuu</a>. O&apos;Saasy License.</p>
           <p>v{APP_VERSION}</p>
         </div>
       </div>

--- a/apps/web/tests/unit/footer-links.test.tsx
+++ b/apps/web/tests/unit/footer-links.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Unit test for Footer component — verifies brlauuu links point to
+ * the personal blog (GitHub Pages) per issue #25.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Mock TanStack React Query so Footer renders without a QueryClient
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: true }),
+}));
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  Github: () => <svg data-testid="github-icon" />,
+}));
+
+import Footer from "@/components/Footer";
+
+const BLOG_URL = "https://brlauuu.github.io";
+
+describe("Footer brlauuu links", () => {
+  beforeEach(() => {
+    render(<Footer />);
+  });
+
+  test("@brlauuu credits link points to GitHub Pages blog", () => {
+    const link = screen.getByRole("link", { name: "@brlauuu" });
+    expect(link).toHaveAttribute("href", BLOG_URL);
+  });
+
+  test("copyright brlauuu link points to GitHub Pages blog", () => {
+    const copyrightLink = screen.getByRole("link", { name: "brlauuu" });
+    expect(copyrightLink).toHaveAttribute("href", BLOG_URL);
+  });
+
+  test("brlauuu/podlog repo link still points to GitHub", () => {
+    const repoLink = screen.getByRole("link", { name: "brlauuu/podlog" });
+    expect(repoLink).toHaveAttribute(
+      "href",
+      "https://github.com/brlauuu/podlog"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Updated `@brlauuu` credits link in Footer to point to `https://brlauuu.github.io` instead of GitHub profile
- Made the copyright "brlauuu" text a clickable link to the same blog URL
- Repo link (`brlauuu/podlog`) still correctly points to GitHub

Closes #25

## Test plan
- [x] New unit tests verify all three Footer links (`@brlauuu` → blog, copyright `brlauuu` → blog, `brlauuu/podlog` → GitHub repo)
- [x] All 3 new tests pass
- [x] Existing tests unaffected (pre-existing `audio-route.test.ts` failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)