### PR TITLE
Add queue page grouping by podcast, status, and stage

### DIFF
--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -52,6 +52,7 @@ def get_queue(db: Session = Depends(get_db)) -> QueueStateResponse:
             "retry_count": ep.retry_count,
             "retry_max": ep.retry_max,
             "feed_mode": ep.feed.mode if ep.feed else None,
+            "feed_title": ep.feed.title if ep.feed else None,
         }
 
     return QueueStateResponse(

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { AlertTriangle, RefreshCw, ChevronDown, FlaskConical } from "lucide-react";
+import { useEffect, useState, useMemo, useCallback } from "react";
+import { RefreshCw, ChevronDown, ChevronRight, FlaskConical, LayoutList } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface Job {
   episode_id: string;
@@ -16,6 +23,7 @@ interface Job {
   retry_count: number;
   retry_max: number;
   feed_mode: string | null;
+  feed_title: string | null;
 }
 
 interface QueueState {
@@ -27,6 +35,14 @@ interface QueueState {
   failed_jobs: Job[];
 }
 
+type GroupMode = "status" | "podcast" | "stage";
+
+const GROUP_MODE_LABELS: Record<GroupMode, string> = {
+  status: "By Status",
+  podcast: "By Podcast",
+  stage: "By Processing Stage",
+};
+
 const ERROR_CLASS_LABELS: Record<string, string> = {
   TRANSIENT_NETWORK: "Network error",
   HTTP_ACCESS: "Access error",
@@ -37,7 +53,45 @@ const ERROR_CLASS_LABELS: Record<string, string> = {
 
 const NON_RETRYABLE = ["DISK_FULL", "OOM"];
 
-function JobCard({ job, onRetry }: { job: Job; onRetry: (taskId: string) => void }) {
+const STATUS_BADGE_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  pending: "secondary",
+  downloading: "default",
+  transcribing: "default",
+  diarizing: "default",
+  archiving: "default",
+  done: "outline",
+  failed: "destructive",
+};
+
+const STAGE_ORDER = ["pending", "downloading", "transcribing", "diarizing", "archiving", "failed"];
+
+const STAGE_LABELS: Record<string, string> = {
+  pending: "Pending",
+  downloading: "Downloading",
+  transcribing: "Transcribing",
+  diarizing: "Diarizing",
+  archiving: "Archiving",
+  failed: "Failed",
+};
+
+const STORAGE_KEY = "podlog-queue-grouping";
+
+function getStoredGroupMode(): GroupMode {
+  if (typeof window === "undefined") return "status";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "status" || stored === "podcast" || stored === "stage") return stored;
+  return "status";
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <Badge variant={STATUS_BADGE_VARIANT[status] ?? "outline"} className="text-[10px] px-1.5 py-0">
+      {status}
+    </Badge>
+  );
+}
+
+function JobCard({ job, onRetry, showStatus }: { job: Job; onRetry: (taskId: string) => void; showStatus?: boolean }) {
   const [expanded, setExpanded] = useState(false);
   const canRetry = job.celery_task_id && !NON_RETRYABLE.includes(job.error_class ?? "");
 
@@ -45,8 +99,9 @@ function JobCard({ job, onRetry }: { job: Job; onRetry: (taskId: string) => void
     <Card>
       <CardContent className="p-3 space-y-1">
         <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 flex-wrap">
             <span className="text-sm font-medium">{job.title ?? job.episode_id}</span>
+            {showStatus && <StatusBadge status={job.status} />}
             {job.feed_mode === "test" && (
               <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
                 <FlaskConical size={9} />
@@ -106,13 +161,93 @@ function JobCard({ job, onRetry }: { job: Job; onRetry: (taskId: string) => void
   );
 }
 
+interface CollapsibleGroupProps {
+  label: string;
+  count: number;
+  emptyMessage: string;
+  jobs: Job[];
+  onRetry: (taskId: string) => void;
+  showStatus?: boolean;
+  defaultOpen?: boolean;
+}
+
+function CollapsibleGroup({ label, count, emptyMessage, jobs, onRetry, showStatus, defaultOpen = true }: CollapsibleGroupProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <section>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 mb-2 group cursor-pointer w-full text-left"
+      >
+        {open ? <ChevronDown size={14} className="text-muted-foreground" /> : <ChevronRight size={14} className="text-muted-foreground" />}
+        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+          {label} ({count})
+        </h2>
+      </button>
+      {open && (
+        count === 0 ? (
+          <p className="text-sm text-muted-foreground ml-5">{emptyMessage}</p>
+        ) : (
+          <div className="space-y-2 ml-5">
+            {jobs.map((j) => (
+              <JobCard key={j.episode_id} job={j} onRetry={onRetry} showStatus={showStatus} />
+            ))}
+          </div>
+        )
+      )}
+    </section>
+  );
+}
+
+function getAllJobs(queue: QueueState): Job[] {
+  return [...queue.active_jobs, ...queue.pending_jobs, ...queue.failed_jobs];
+}
+
+function groupByPodcast(queue: QueueState): { label: string; jobs: Job[] }[] {
+  const all = getAllJobs(queue);
+  const groups = new Map<string, Job[]>();
+  for (const job of all) {
+    const key = job.feed_title ?? "Unknown Podcast";
+    const list = groups.get(key) ?? [];
+    list.push(job);
+    groups.set(key, list);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([label, jobs]) => ({ label, jobs }));
+}
+
+function groupByStage(queue: QueueState): { label: string; jobs: Job[] }[] {
+  const all = getAllJobs(queue);
+  const groups = new Map<string, Job[]>();
+  for (const stage of STAGE_ORDER) {
+    groups.set(stage, []);
+  }
+  for (const job of all) {
+    const stage = STAGE_ORDER.includes(job.status) ? job.status : "pending";
+    groups.get(stage)!.push(job);
+  }
+  return STAGE_ORDER
+    .filter((stage) => groups.get(stage)!.length > 0)
+    .map((stage) => ({ label: STAGE_LABELS[stage], jobs: groups.get(stage)! }));
+}
+
 /**
  * Queue dashboard component — PRD-02 §5.6
  * Polls /api/queue every 5s and /api/health for warm-up state.
+ * Supports grouping by status, podcast, or processing stage.
  */
 export default function QueueStatus() {
   const [queue, setQueue] = useState<QueueState | null>(null);
   const [workerStatus, setWorkerStatus] = useState<string>("OK");
+  const [groupMode, setGroupMode] = useState<GroupMode>(getStoredGroupMode);
+
+  const handleGroupChange = useCallback((value: string) => {
+    const mode = value as GroupMode;
+    setGroupMode(mode);
+    localStorage.setItem(STORAGE_KEY, mode);
+  }, []);
 
   useEffect(() => {
     async function fetchAll() {
@@ -137,6 +272,9 @@ export default function QueueStatus() {
     await fetch(`/api/pipeline/queue/${taskId}/retry`, { method: "POST" });
   }
 
+  const podcastGroups = useMemo(() => queue ? groupByPodcast(queue) : [], [queue]);
+  const stageGroups = useMemo(() => queue ? groupByStage(queue) : [], [queue]);
+
   if (!queue) {
     return (
       <div className="space-y-4">
@@ -152,6 +290,26 @@ export default function QueueStatus() {
 
   return (
     <div className="space-y-6">
+      {/* Grouping selector */}
+      <div className="flex items-center justify-end">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md border bg-background hover:bg-accent transition-colors">
+              <LayoutList size={14} />
+              {GROUP_MODE_LABELS[groupMode]}
+              <ChevronDown size={12} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuRadioGroup value={groupMode} onValueChange={handleGroupChange}>
+              <DropdownMenuRadioItem value="status">By Status</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="podcast">By Podcast</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="stage">By Processing Stage</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
       {workerStatus === "WARMING_UP" && (
         <Card className="border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950">
           <CardContent className="p-4 flex items-start gap-3">
@@ -164,54 +322,69 @@ export default function QueueStatus() {
         </Card>
       )}
 
-      <section>
-        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-          Active ({queue.active_count})
-        </h2>
-        {queue.active_jobs.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No active jobs</p>
-        ) : (
-          <div className="space-y-2">
-            {queue.active_jobs.map((j) => (
-              <JobCard key={j.episode_id} job={j} onRetry={handleRetry} />
-            ))}
-          </div>
-        )}
-      </section>
+      {/* Group by Status (default — matches original behavior) */}
+      {groupMode === "status" && (
+        <>
+          <CollapsibleGroup
+            label="Active"
+            count={queue.active_count}
+            emptyMessage="No active jobs"
+            jobs={queue.active_jobs}
+            onRetry={handleRetry}
+          />
+          <CollapsibleGroup
+            label="Pending"
+            count={queue.pending_count}
+            emptyMessage="Queue is empty"
+            jobs={queue.pending_jobs}
+            onRetry={handleRetry}
+          />
+          <CollapsibleGroup
+            label="Failed"
+            count={queue.failed_count}
+            emptyMessage="No failed jobs"
+            jobs={queue.failed_jobs}
+            onRetry={handleRetry}
+          />
+        </>
+      )}
 
-      <section>
-        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-          Pending ({queue.pending_count})
-        </h2>
-        {queue.pending_jobs.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Queue is empty</p>
+      {/* Group by Podcast */}
+      {groupMode === "podcast" && (
+        podcastGroups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No jobs in queue</p>
         ) : (
-          <div className="space-y-2">
-            {queue.pending_jobs.map((j) => (
-              <Card key={j.episode_id}>
-                <CardContent className="p-3">
-                  <span className="text-sm">{j.title ?? j.episode_id}</span>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
-      </section>
+          podcastGroups.map((group) => (
+            <CollapsibleGroup
+              key={group.label}
+              label={group.label}
+              count={group.jobs.length}
+              emptyMessage="No jobs"
+              jobs={group.jobs}
+              onRetry={handleRetry}
+              showStatus
+            />
+          ))
+        )
+      )}
 
-      <section>
-        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-          Failed ({queue.failed_count})
-        </h2>
-        {queue.failed_jobs.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No failed jobs</p>
+      {/* Group by Processing Stage */}
+      {groupMode === "stage" && (
+        stageGroups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No jobs in queue</p>
         ) : (
-          <div className="space-y-2">
-            {queue.failed_jobs.map((j) => (
-              <JobCard key={j.episode_id} job={j} onRetry={handleRetry} />
-            ))}
-          </div>
-        )}
-      </section>
+          stageGroups.map((group) => (
+            <CollapsibleGroup
+              key={group.label}
+              label={group.label}
+              count={group.jobs.length}
+              emptyMessage="No jobs"
+              jobs={group.jobs}
+              onRetry={handleRetry}
+            />
+          ))
+        )
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a dropdown selector to the queue dashboard for grouping jobs by **status** (default), **podcast feed**, or **processing stage**
- Backend returns `feed_title` in queue API responses to support podcast grouping
- Group mode selection persists across sessions via localStorage
- Collapsible groups with chevron toggle replace the previous flat section layout

Closes #37

## Test plan
- [ ] Verify the queue page loads with default "By Status" grouping matching previous behavior
- [ ] Switch to "By Podcast" and confirm jobs are grouped by feed title with status badges
- [ ] Switch to "By Processing Stage" and confirm jobs appear under pipeline stage headers
- [ ] Refresh the page and verify the selected grouping persists (localStorage)
- [ ] Confirm retry buttons work in all grouping modes
- [ ] Confirm 5-second polling continues to update the queue in all modes
- [ ] Verify the build passes: `cd apps/web && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)