### PR TITLE
feat: episode-centric search with dialogue context and polished export

### DIFF
--- a/apps/web/src/app/search/print/PrintButton.tsx
+++ b/apps/web/src/app/search/print/PrintButton.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+export default function PrintButton() {
+  return (
+    <button
+      className="no-print"
+      style={{
+        position: "fixed", top: 16, right: 16,
+        fontFamily: "-apple-system, sans-serif", fontSize: 13,
+        background: "#3b82f6", color: "white", border: "none",
+        padding: "8px 16px", borderRadius: 6, cursor: "pointer",
+      }}
+      onClick={() => window.print()}
+    >
+      Print / Save as PDF
+    </button>
+  );
+}

--- a/apps/web/src/app/search/print/page.tsx
+++ b/apps/web/src/app/search/print/page.tsx
@@ -1,0 +1,142 @@
+import { notFound } from "next/navigation";
+import { searchMentions, searchGrouped } from "@/lib/search";
+import { formatTimestamp } from "@/lib/timestamp";
+import PrintButton from "./PrintButton";
+
+export const dynamic = "force-dynamic";
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, "");
+}
+
+export default async function PrintPage({
+  searchParams,
+}: {
+  searchParams: { q?: string };
+}) {
+  const query = searchParams.q;
+  if (!query) notFound();
+
+  // Fetch all episodes that match
+  const grouped = await searchGrouped(query, null, 1, 100);
+  if (grouped.feeds.length === 0) notFound();
+
+  // Fetch mentions with context for each episode
+  const allEpisodeMentions = await Promise.all(
+    grouped.feeds.flatMap((feed) =>
+      feed.episodes.map(async (ep) => {
+        const mentions = await searchMentions(query, ep.episodeId);
+        return {
+          episodeTitle: ep.episodeTitle,
+          feedTitle: feed.feedTitle,
+          mentionCount: ep.mentionCount,
+          mentions: mentions.mentions,
+        };
+      })
+    )
+  );
+
+  return (
+    <html>
+      <head>
+        <title>Podlog Search Report — &ldquo;{query}&rdquo;</title>
+        <style>{`
+          @media print {
+            body { font-size: 11pt; }
+            .no-print { display: none !important; }
+            .mention-card { break-inside: avoid; }
+          }
+          body {
+            font-family: Georgia, 'Times New Roman', serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 32px 24px;
+            color: #1a1a1a;
+            line-height: 1.6;
+          }
+          h1 { font-family: -apple-system, sans-serif; font-size: 22px; margin: 0; }
+          h2 { font-family: -apple-system, sans-serif; font-size: 16px; margin: 0 0 4px 0; }
+          .header { text-align: center; border-bottom: 2px solid #e5e7eb; padding-bottom: 20px; margin-bottom: 28px; }
+          .meta { font-size: 13px; color: #6b7280; margin: 6px 0 0 0; }
+          .episode { margin-bottom: 28px; }
+          .episode + .episode { border-top: 1px solid #e5e7eb; padding-top: 20px; }
+          .episode-meta { font-size: 12px; color: #6b7280; margin: 0 0 12px 0; }
+          .mention-card { margin-bottom: 16px; padding-left: 12px; border-left: 3px solid #e5e7eb; }
+          .mention-label { font-size: 11px; color: #9ca3af; margin: 0 0 6px 0; font-family: monospace; }
+          .context { font-size: 13px; color: #9ca3af; margin: 0 0 4px 0; line-height: 1.6; }
+          .context b { color: #6b7280; font-weight: 600; }
+          .matched { font-size: 13px; color: #111; margin: 0 0 4px 0; line-height: 1.6; background: #fef9c3; padding: 2px 4px; border-radius: 3px; }
+          .matched b:first-child { color: #111; font-weight: 600; }
+          .matched b { font-weight: 700; }
+          .footer { border-top: 1px solid #d1d5db; padding-top: 12px; margin-top: 32px; text-align: center; font-size: 11px; color: #9ca3af; }
+          .print-btn {
+            position: fixed; top: 16px; right: 16px;
+            font-family: -apple-system, sans-serif; font-size: 13px;
+            background: #3b82f6; color: white; border: none;
+            padding: 8px 16px; border-radius: 6px; cursor: pointer;
+          }
+          .print-btn:hover { background: #2563eb; }
+        `}</style>
+      </head>
+      <body>
+        <PrintButton />
+
+        <div className="header">
+          <h1>Podlog Search Report</h1>
+          <p className="meta">
+            Search term: <b>&ldquo;{query}&rdquo;</b> &middot;{" "}
+            {grouped.totalMentions} mentions across {grouped.totalEpisodes} episodes
+            &middot; {new Date().toLocaleDateString()}
+          </p>
+        </div>
+
+        {allEpisodeMentions.map((ep, epIdx) => (
+          <div key={epIdx} className="episode">
+            <h2>{ep.episodeTitle}</h2>
+            <p className="episode-meta">
+              {ep.feedTitle} &middot; {ep.mentionCount} mention
+              {ep.mentionCount !== 1 ? "s" : ""}
+            </p>
+
+            {ep.mentions.map((mention, mIdx) => (
+              <div key={mIdx} className="mention-card">
+                <p className="mention-label">
+                  Mention {mIdx + 1} — at {formatTimestamp(mention.startTime)}
+                </p>
+
+                {mention.contextBefore.map((ctx, i) => (
+                  <p key={`b-${i}`} className="context">
+                    <b>
+                      {ctx.speakerDisplay ?? "Speaker"} [{formatTimestamp(ctx.startTime)}]:
+                    </b>{" "}
+                    {ctx.text}
+                  </p>
+                ))}
+
+                <p className="matched">
+                  <b>
+                    {mention.speakerDisplay ?? "Speaker"} [{formatTimestamp(mention.startTime)}]:
+                  </b>{" "}
+                  <span dangerouslySetInnerHTML={{ __html: mention.snippet }} />
+                </p>
+
+                {mention.contextAfter.map((ctx, i) => (
+                  <p key={`a-${i}`} className="context">
+                    <b>
+                      {ctx.speakerDisplay ?? "Speaker"} [{formatTimestamp(ctx.startTime)}]:
+                    </b>{" "}
+                    {ctx.text}
+                  </p>
+                ))}
+              </div>
+            ))}
+          </div>
+        ))}
+
+        <div className="footer">
+          Generated by Podlog &middot; {new Date().toLocaleDateString()}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/components/DownloadReportButton.tsx
+++ b/apps/web/src/components/DownloadReportButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, FileText, FileJson, FileSpreadsheet } from "lucide-react";
+import { Download, FileText, Printer, Type } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,8 +11,6 @@ import {
 import type { SearchResult, GroupedSearchResult } from "@/lib/search";
 import { formatTimestamp } from "@/lib/timestamp";
 
-type ExportFormat = "csv" | "json" | "markdown";
-
 interface DownloadReportButtonProps {
   query: string;
   viewMode: "flat" | "grouped";
@@ -20,150 +18,12 @@ interface DownloadReportButtonProps {
   groupedResults?: GroupedSearchResult;
 }
 
-/** Strip HTML tags from ts_headline snippets. */
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "");
 }
 
-
-/** Escape a field for CSV: wrap in quotes if it contains comma, quote, or newline. */
-function csvEscape(value: string): string {
-  if (/[",\n\r]/.test(value)) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
-}
-
-function generateCsv(
-  query: string,
-  flatResults?: SearchResult[],
-  groupedResults?: GroupedSearchResult,
-): string {
-  const rows: string[][] = [];
-  const header = ["Podcast", "Episode", "Timestamp", "Speaker", "Snippet"];
-  rows.push(header);
-
-  if (flatResults && flatResults.length > 0) {
-    for (const r of flatResults) {
-      rows.push([
-        r.feedTitle ?? "",
-        r.episodeTitle ?? "",
-        formatTimestamp(r.startTime),
-        r.speakerDisplay ?? r.speakerLabel ?? "",
-        stripHtml(r.snippet),
-      ]);
-    }
-  } else if (groupedResults) {
-    for (const feed of groupedResults.feeds) {
-      for (const ep of feed.episodes) {
-        rows.push([
-          feed.feedTitle,
-          ep.episodeTitle,
-          "",
-          "",
-          `${ep.mentionCount} mention${ep.mentionCount !== 1 ? "s" : ""}`,
-        ]);
-      }
-    }
-  }
-
-  return rows.map((row) => row.map(csvEscape).join(",")).join("\n");
-}
-
-function generateJson(
-  query: string,
-  flatResults?: SearchResult[],
-  groupedResults?: GroupedSearchResult,
-): string {
-  const report: Record<string, unknown> = {
-    query,
-    exportedAt: new Date().toISOString(),
-  };
-
-  if (flatResults && flatResults.length > 0) {
-    report.totalResults = flatResults.length;
-    report.results = flatResults.map((r) => ({
-      podcast: r.feedTitle,
-      episode: r.episodeTitle,
-      episodeId: r.episodeId,
-      timestamp: formatTimestamp(r.startTime),
-      startTime: r.startTime,
-      endTime: r.endTime,
-      speaker: r.speakerDisplay ?? r.speakerLabel ?? null,
-      snippet: stripHtml(r.snippet),
-    }));
-  } else if (groupedResults) {
-    report.totalFeeds = groupedResults.totalFeeds;
-    report.totalEpisodes = groupedResults.totalEpisodes;
-    report.totalMentions = groupedResults.totalMentions;
-    report.feeds = groupedResults.feeds.map((feed) => ({
-      feedTitle: feed.feedTitle,
-      mentionCount: feed.mentionCount,
-      episodes: feed.episodes.map((ep) => ({
-        episodeTitle: ep.episodeTitle,
-        episodeId: ep.episodeId,
-        mentionCount: ep.mentionCount,
-      })),
-    }));
-  }
-
-  return JSON.stringify(report, null, 2);
-}
-
-function generateMarkdown(
-  query: string,
-  flatResults?: SearchResult[],
-  groupedResults?: GroupedSearchResult,
-): string {
-  const lines: string[] = [];
-  lines.push(`# Search Report`);
-  lines.push("");
-  lines.push(`**Query:** ${query}`);
-  lines.push(`**Exported:** ${new Date().toISOString()}`);
-  lines.push("");
-
-  if (flatResults && flatResults.length > 0) {
-    lines.push(`**Total results:** ${flatResults.length}`);
-    lines.push("");
-
-    // Group by episode for readability
-    const byEpisode = new Map<string, SearchResult[]>();
-    for (const r of flatResults) {
-      const key = r.episodeId;
-      if (!byEpisode.has(key)) byEpisode.set(key, []);
-      byEpisode.get(key)!.push(r);
-    }
-
-    for (const results of Array.from(byEpisode.values())) {
-      const first = results[0];
-      lines.push(`## ${first.feedTitle ?? "Unknown Podcast"} - ${first.episodeTitle ?? "Unknown Episode"}`);
-      lines.push("");
-      for (const r of results) {
-        const speaker = r.speakerDisplay ?? r.speakerLabel ?? "";
-        const speakerPrefix = speaker ? `**${speaker}:** ` : "";
-        lines.push(`- \`${formatTimestamp(r.startTime)}\` ${speakerPrefix}${stripHtml(r.snippet)}`);
-      }
-      lines.push("");
-    }
-  } else if (groupedResults) {
-    lines.push(
-      `**Found in** ${groupedResults.totalFeeds} podcast${groupedResults.totalFeeds !== 1 ? "s" : ""}, ` +
-      `${groupedResults.totalEpisodes} episode${groupedResults.totalEpisodes !== 1 ? "s" : ""} ` +
-      `(${groupedResults.totalMentions} mention${groupedResults.totalMentions !== 1 ? "s" : ""})`
-    );
-    lines.push("");
-
-    for (const feed of groupedResults.feeds) {
-      lines.push(`## ${feed.feedTitle}`);
-      lines.push("");
-      for (const ep of feed.episodes) {
-        lines.push(`- **${ep.episodeTitle}** — ${ep.mentionCount} mention${ep.mentionCount !== 1 ? "s" : ""}`);
-      }
-      lines.push("");
-    }
-  }
-
-  return lines.join("\n");
+function sanitizeFilename(query: string): string {
+  return query.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 50);
 }
 
 function downloadFile(content: string, filename: string, mimeType: string) {
@@ -178,8 +38,127 @@ function downloadFile(content: string, filename: string, mimeType: string) {
   URL.revokeObjectURL(url);
 }
 
-function sanitizeFilename(query: string): string {
-  return query.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 50);
+function generateMarkdown(
+  query: string,
+  flatResults?: SearchResult[],
+  groupedResults?: GroupedSearchResult,
+): string {
+  const lines: string[] = [];
+  lines.push("# Podlog Search Report");
+  lines.push("");
+  lines.push(`**Search term:** "${query}"`);
+
+  if (groupedResults) {
+    lines.push(
+      `**Found in** ${groupedResults.totalEpisodes} episode${groupedResults.totalEpisodes !== 1 ? "s" : ""} ` +
+      `across ${groupedResults.totalFeeds} podcast${groupedResults.totalFeeds !== 1 ? "s" : ""} ` +
+      `(${groupedResults.totalMentions} mention${groupedResults.totalMentions !== 1 ? "s" : ""})`
+    );
+  } else if (flatResults) {
+    lines.push(`**Total results:** ${flatResults.length}`);
+  }
+
+  lines.push(`**Exported:** ${new Date().toLocaleDateString()}`);
+  lines.push("");
+
+  if (flatResults && flatResults.length > 0) {
+    const byEpisode = new Map<string, SearchResult[]>();
+    for (const r of flatResults) {
+      if (!byEpisode.has(r.episodeId)) byEpisode.set(r.episodeId, []);
+      byEpisode.get(r.episodeId)!.push(r);
+    }
+
+    for (const results of Array.from(byEpisode.values())) {
+      const first = results[0];
+      lines.push(`## ${first.episodeTitle ?? "Unknown Episode"}`);
+      lines.push(`*${first.feedTitle ?? "Unknown Podcast"}*`);
+      lines.push("");
+      for (const r of results) {
+        const speaker = r.speakerDisplay ?? r.speakerLabel ?? "";
+        const speakerPrefix = speaker ? `**${speaker}** ` : "";
+        lines.push(`> \`${formatTimestamp(r.startTime)}\` ${speakerPrefix}${stripHtml(r.snippet)}`);
+        lines.push("");
+      }
+      lines.push("---");
+      lines.push("");
+    }
+  } else if (groupedResults) {
+    for (const feed of groupedResults.feeds) {
+      for (const ep of feed.episodes) {
+        lines.push(`## ${ep.episodeTitle}`);
+        lines.push(`*${feed.feedTitle}* — ${ep.mentionCount} mention${ep.mentionCount !== 1 ? "s" : ""}`);
+        lines.push("");
+      }
+    }
+  }
+
+  lines.push("---");
+  lines.push("*Generated by Podlog*");
+  return lines.join("\n");
+}
+
+function generatePlainText(
+  query: string,
+  flatResults?: SearchResult[],
+  groupedResults?: GroupedSearchResult,
+): string {
+  const lines: string[] = [];
+  lines.push("PODLOG SEARCH REPORT");
+  lines.push("====================");
+  lines.push("");
+  lines.push(`Search term: "${query}"`);
+
+  if (groupedResults) {
+    lines.push(
+      `Found in ${groupedResults.totalEpisodes} episodes ` +
+      `across ${groupedResults.totalFeeds} podcasts ` +
+      `(${groupedResults.totalMentions} mentions)`
+    );
+  } else if (flatResults) {
+    lines.push(`Total results: ${flatResults.length}`);
+  }
+
+  lines.push(`Exported: ${new Date().toLocaleDateString()}`);
+  lines.push("");
+
+  if (flatResults && flatResults.length > 0) {
+    const byEpisode = new Map<string, SearchResult[]>();
+    for (const r of flatResults) {
+      if (!byEpisode.has(r.episodeId)) byEpisode.set(r.episodeId, []);
+      byEpisode.get(r.episodeId)!.push(r);
+    }
+
+    for (const results of Array.from(byEpisode.values())) {
+      const first = results[0];
+      lines.push("────────────────────────────────────────");
+      lines.push(`${first.episodeTitle ?? "Unknown Episode"}`);
+      lines.push(`${first.feedTitle ?? "Unknown Podcast"}`);
+      lines.push("");
+      for (const r of results) {
+        const speaker = r.speakerDisplay ?? r.speakerLabel ?? "";
+        const speakerPrefix = speaker ? `${speaker}: ` : "";
+        lines.push(`  [${formatTimestamp(r.startTime)}] ${speakerPrefix}${stripHtml(r.snippet)}`);
+      }
+      lines.push("");
+    }
+  } else if (groupedResults) {
+    for (const feed of groupedResults.feeds) {
+      lines.push("────────────────────────────────────────");
+      lines.push(feed.feedTitle);
+      lines.push("");
+      for (const ep of feed.episodes) {
+        lines.push(`  ${ep.episodeTitle} — ${ep.mentionCount} mentions`);
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push("Generated by Podlog");
+  return lines.join("\n");
+}
+
+function openPrintView(query: string) {
+  window.open(`/search/print?q=${encodeURIComponent(query)}`, "_blank");
 }
 
 export default function DownloadReportButton({
@@ -194,25 +173,24 @@ export default function DownloadReportButton({
 
   if (!hasResults) return null;
 
-  function handleExport(format: ExportFormat) {
+  function handleExport(format: "markdown" | "text" | "print") {
     const safeQuery = sanitizeFilename(query);
     const flat = viewMode === "flat" ? flatResults : undefined;
     const grouped = viewMode === "grouped" ? groupedResults : undefined;
 
     switch (format) {
-      case "csv": {
-        const content = generateCsv(query, flat, grouped);
-        downloadFile(content, `podlog-search-${safeQuery}.csv`, "text/csv;charset=utf-8");
-        break;
-      }
-      case "json": {
-        const content = generateJson(query, flat, grouped);
-        downloadFile(content, `podlog-search-${safeQuery}.json`, "application/json");
-        break;
-      }
       case "markdown": {
         const content = generateMarkdown(query, flat, grouped);
         downloadFile(content, `podlog-search-${safeQuery}.md`, "text/markdown;charset=utf-8");
+        break;
+      }
+      case "text": {
+        const content = generatePlainText(query, flat, grouped);
+        downloadFile(content, `podlog-search-${safeQuery}.txt`, "text/plain;charset=utf-8");
+        break;
+      }
+      case "print": {
+        openPrintView(query);
         break;
       }
     }
@@ -226,18 +204,27 @@ export default function DownloadReportButton({
           Export
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => handleExport("csv")}>
-          <FileSpreadsheet size={14} />
-          CSV
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => handleExport("json")}>
-          <FileJson size={14} />
-          JSON
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => handleExport("markdown")}>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem onClick={() => handleExport("markdown")} className="gap-2">
           <FileText size={14} />
-          Markdown
+          <div>
+            <div className="text-sm">Markdown (.md)</div>
+            <div className="text-[11px] text-muted-foreground">Speaker-attributed dialogue</div>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("text")} className="gap-2">
+          <Type size={14} />
+          <div>
+            <div className="text-sm">Plain Text (.txt)</div>
+            <div className="text-[11px] text-muted-foreground">Simple format, no markup</div>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("print")} className="gap-2">
+          <Printer size={14} />
+          <div>
+            <div className="text-sm">Print / PDF</div>
+            <div className="text-[11px] text-muted-foreground">Styled view for browser print</div>
+          </div>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/EpisodeMentionList.tsx
+++ b/apps/web/src/components/EpisodeMentionList.tsx
@@ -1,34 +1,138 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ExternalLink, FileText, Play } from "lucide-react";
+import { FileText, Play } from "lucide-react";
 import Link from "next/link";
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
 import { formatTimestamp } from "@/lib/timestamp";
-import type { EpisodeMentions } from "@/lib/search";
+import type { EpisodeMentions, ContextSegment, Mention } from "@/lib/search";
 import { basename } from "@/lib/utils";
 
 interface Props {
   query: string;
   episodeId: string;
   episodeTitle: string;
-  audioUrl: string;
   audioLocalPath: string | null;
-  episodeUrl: string | null;
   feedTitle: string;
+  /** How many mentions to show expanded initially */
+  initialExpanded?: number;
+}
+
+function ContextLine({ seg, dimmed }: { seg: ContextSegment; dimmed: boolean }) {
+  return (
+    <div className={`flex gap-2 ${dimmed ? "opacity-50" : ""}`}>
+      <span className="text-[11px] font-mono text-muted-foreground shrink-0 pt-0.5 w-12 text-right">
+        {formatTimestamp(seg.startTime)}
+      </span>
+      <div className="min-w-0 flex-1 text-sm leading-relaxed">
+        {seg.speakerDisplay && (
+          <span className="font-semibold text-foreground mr-1">
+            {seg.speakerDisplay}:
+          </span>
+        )}
+        <span className="text-muted-foreground">{seg.text}</span>
+      </div>
+    </div>
+  );
+}
+
+function MentionCard({
+  mention,
+  index,
+  total,
+  episodeId,
+  audioLocalPath,
+  episodeTitle,
+  feedTitle,
+  query,
+}: {
+  mention: Mention;
+  index: number;
+  total: number;
+  episodeId: string;
+  audioLocalPath: string | null;
+  episodeTitle: string;
+  feedTitle: string;
+  query: string;
+}) {
+  const { playEpisode } = useAudioPlayer();
+  const queryParam = query ? `?q=${encodeURIComponent(query)}` : "";
+
+  function handlePlay() {
+    if (!audioLocalPath) return;
+    playEpisode(episodeId, basename(audioLocalPath), mention.startTime, episodeTitle, feedTitle);
+  }
+
+  return (
+    <div className="border border-border rounded-lg bg-background overflow-hidden">
+      {/* Header */}
+      <div className="px-3 py-2 bg-muted/50 border-b border-border flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          Mention {index + 1} of {total} &middot;{" "}
+          <span className="font-mono text-primary">{formatTimestamp(mention.startTime)}</span>
+        </span>
+        <div className="flex items-center gap-2">
+          {audioLocalPath && (
+            <button
+              onClick={handlePlay}
+              className="inline-flex items-center gap-1 text-[11px] border border-border px-2 py-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Play size={10} /> Play
+            </button>
+          )}
+          <Link
+            href={`/episodes/${episodeId}${queryParam}#t-${Math.floor(mention.startTime)}`}
+            className="inline-flex items-center gap-1 text-[11px] border border-border px-2 py-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <FileText size={10} /> Episode
+          </Link>
+        </div>
+      </div>
+
+      {/* Dialogue context */}
+      <div className="px-3 py-2.5 space-y-1.5">
+        {/* Context before */}
+        {mention.contextBefore.map((seg, i) => (
+          <ContextLine key={`before-${i}`} seg={seg} dimmed />
+        ))}
+
+        {/* Matched turn (highlighted) */}
+        <div className="flex gap-2 bg-yellow-50 dark:bg-yellow-950/30 rounded-md px-2 py-1.5 -mx-2">
+          <span className="text-[11px] font-mono text-muted-foreground shrink-0 pt-0.5 w-12 text-right">
+            {formatTimestamp(mention.startTime)}
+          </span>
+          <div className="min-w-0 flex-1 text-sm leading-relaxed">
+            {mention.speakerDisplay && (
+              <span className="font-semibold text-foreground mr-1">
+                {mention.speakerDisplay}:
+              </span>
+            )}
+            <span
+              className="text-foreground [&_b]:font-semibold [&_b]:bg-yellow-200 [&_b]:dark:bg-yellow-800 [&_b]:px-0.5 [&_b]:rounded-sm"
+              dangerouslySetInnerHTML={{ __html: mention.snippet }}
+            />
+          </div>
+        </div>
+
+        {/* Context after */}
+        {mention.contextAfter.map((seg, i) => (
+          <ContextLine key={`after-${i}`} seg={seg} dimmed />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default function EpisodeMentionList({
   query,
   episodeId,
   episodeTitle,
-  audioUrl,
   audioLocalPath,
-  episodeUrl,
   feedTitle,
+  initialExpanded = 2,
 }: Props) {
-  const { playEpisode } = useAudioPlayer();
-  const queryParam = query ? `?q=${encodeURIComponent(query)}` : "";
+  const [showAll, setShowAll] = useState(false);
 
   const { data, isLoading } = useQuery<EpisodeMentions>({
     queryKey: ["mentions", query, episodeId],
@@ -41,17 +145,11 @@ export default function EpisodeMentionList({
     staleTime: 60_000,
   });
 
-  function handlePlayLocally(startTime: number) {
-    if (!audioLocalPath) return;
-    const safeName = basename(audioLocalPath);
-    playEpisode(episodeId, safeName, startTime, episodeTitle, feedTitle);
-  }
-
   if (isLoading) {
     return (
       <div className="space-y-2 py-2">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="h-10 bg-muted rounded animate-pulse" />
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="h-24 bg-muted rounded-lg animate-pulse" />
         ))}
       </div>
     );
@@ -63,60 +161,34 @@ export default function EpisodeMentionList({
     );
   }
 
+  const visibleMentions = showAll
+    ? data.mentions
+    : data.mentions.slice(0, initialExpanded);
+  const hiddenCount = data.mentions.length - initialExpanded;
+
   return (
-    <div className="space-y-1.5 py-2">
-      {data.mentions.map((mention) => (
-        <div
+    <div className="space-y-3 py-2">
+      {visibleMentions.map((mention, i) => (
+        <MentionCard
           key={mention.id}
-          className="flex items-start gap-3 rounded px-3 py-2 text-sm hover:bg-accent/30 transition-colors"
-        >
-          <span className="shrink-0 font-mono text-xs text-muted-foreground pt-0.5 w-14 text-right">
-            {formatTimestamp(mention.startTime)}
-          </span>
-
-          <div className="min-w-0 flex-1">
-            {mention.speakerDisplay && (
-              <span className="font-medium text-foreground mr-1.5">
-                {mention.speakerDisplay}:
-              </span>
-            )}
-            <span
-              className="text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground"
-              dangerouslySetInnerHTML={{ __html: mention.snippet }}
-            />
-          </div>
-
-          <div className="flex items-center gap-1.5 shrink-0">
-            <Link
-              href={`/episodes/${episodeId}${queryParam}#t-${Math.floor(mention.startTime)}`}
-              title="Go to episode at this timestamp"
-              className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <FileText size={13} />
-            </Link>
-            {audioLocalPath && (
-              <button
-                onClick={() => handlePlayLocally(mention.startTime)}
-                title="Play in embedded player"
-                className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <Play size={13} />
-              </button>
-            )}
-            {audioUrl && (
-              <a
-                href={`${audioUrl}#t=${Math.floor(mention.startTime)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Listen on RSS audio at this timestamp"
-                className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <ExternalLink size={13} />
-              </a>
-            )}
-          </div>
-        </div>
+          mention={mention}
+          index={i}
+          total={data.mentions.length}
+          episodeId={episodeId}
+          audioLocalPath={audioLocalPath}
+          episodeTitle={episodeTitle}
+          feedTitle={feedTitle}
+          query={query}
+        />
       ))}
+      {!showAll && hiddenCount > 0 && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="text-sm text-primary hover:underline w-full text-center py-1"
+        >
+          Show {hiddenCount} more mention{hiddenCount !== 1 ? "s" : ""}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/FeedGroupCard.tsx
+++ b/apps/web/src/components/FeedGroupCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronRight, ExternalLink, Radio, FileText, FlaskConical } from "lucide-react";
+import { ChevronRight, ExternalLink, FlaskConical } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import EpisodeMentionList from "@/components/EpisodeMentionList";
@@ -13,8 +13,11 @@ interface Props {
   query: string;
 }
 
+/**
+ * Episode-centric search result cards grouped under a feed header.
+ * Episodes expand to show mentions with dialogue context.
+ */
 export default function FeedGroupCard({ feed, query }: Props) {
-  const [expandedFeed, setExpandedFeed] = useState(true);
   const [expandedEpisodes, setExpandedEpisodes] = useState<Set<string>>(
     new Set()
   );
@@ -23,100 +26,79 @@ export default function FeedGroupCard({ feed, query }: Props) {
   function toggleEpisode(episodeId: string) {
     setExpandedEpisodes((prev) => {
       const next = new Set(prev);
-      if (next.has(episodeId)) {
-        next.delete(episodeId);
-      } else {
-        next.add(episodeId);
-      }
+      if (next.has(episodeId)) next.delete(episodeId);
+      else next.add(episodeId);
       return next;
     });
   }
 
   return (
-    <Card className="overflow-hidden">
-      {/* Feed header */}
-      <button
-        onClick={() => setExpandedFeed((v) => !v)}
-        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent/30 transition-colors text-left"
-      >
-        <ChevronRight
-          size={16}
-          className={`shrink-0 text-muted-foreground transition-transform duration-200 ${
-            expandedFeed ? "rotate-90" : ""
-          }`}
-        />
-        <Radio size={16} className="shrink-0 text-primary" />
-        <span className="font-medium truncate flex-1">{feed.feedTitle}</span>
+    <div className="space-y-2">
+      {/* Feed header — minimal, not collapsible */}
+      <div className="flex items-center gap-2 px-1">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {feed.feedTitle}
+        </span>
         {feed.feedMode === "test" && (
-          <Badge variant="outline" className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
+          <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
             <FlaskConical size={9} />
             Test
           </Badge>
         )}
-        <span className="text-xs text-muted-foreground shrink-0">
+        <span className="text-[11px] text-muted-foreground">
           {feed.mentionCount} mention{feed.mentionCount !== 1 ? "s" : ""} in{" "}
           {feed.episodes.length} episode{feed.episodes.length !== 1 ? "s" : ""}
         </span>
-      </button>
+      </div>
 
-      {/* Episode list */}
-      {expandedFeed && (
-        <div className="border-t border-border">
-          {feed.episodes.map((episode) => {
-            const isExpanded = expandedEpisodes.has(episode.episodeId);
+      {/* Episode cards */}
+      {feed.episodes.map((episode) => {
+        const isExpanded = expandedEpisodes.has(episode.episodeId);
 
-            return (
-              <div key={episode.episodeId} className="border-b border-border last:border-b-0">
-                {/* Episode row */}
-                <div className="flex items-center gap-0 pl-11 hover:bg-accent/30 transition-colors">
-                  <button
-                    onClick={() => toggleEpisode(episode.episodeId)}
-                    className="flex items-center gap-3 px-4 py-2.5 pl-0 flex-1 min-w-0 text-left"
-                  >
-                    <ChevronRight
-                      size={14}
-                      className={`shrink-0 text-muted-foreground transition-transform duration-200 ${
-                        isExpanded ? "rotate-90" : ""
-                      }`}
-                    />
-                    <FileText size={14} className="shrink-0 text-muted-foreground" />
-                    <span className="text-sm truncate flex-1">
-                      {episode.episodeTitle}
-                    </span>
-                  </button>
-                  <span className="text-xs text-muted-foreground shrink-0">
-                    {episode.mentionCount} mention
-                    {episode.mentionCount !== 1 ? "s" : ""}
-                  </span>
-                  <Link
-                    href={`/episodes/${episode.episodeId}${queryParam}`}
-                    title="Go to episode"
-                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground px-3 py-2.5 shrink-0 transition-colors"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <ExternalLink size={12} />
-                  </Link>
-                </div>
+        return (
+          <Card key={episode.episodeId} className="overflow-hidden">
+            <div className="flex items-center gap-0 hover:bg-accent/30 transition-colors">
+              <button
+                onClick={() => toggleEpisode(episode.episodeId)}
+                className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 text-left"
+              >
+                <ChevronRight
+                  size={14}
+                  className={`shrink-0 text-muted-foreground transition-transform duration-200 ${
+                    isExpanded ? "rotate-90" : ""
+                  }`}
+                />
+                <span className="text-sm font-medium truncate flex-1">
+                  {episode.episodeTitle}
+                </span>
+              </button>
+              <span className="text-xs text-muted-foreground shrink-0 tabular-nums bg-muted/50 px-2 py-0.5 rounded">
+                {episode.mentionCount}
+              </span>
+              <Link
+                href={`/episodes/${episode.episodeId}${queryParam}`}
+                title="Go to episode"
+                className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground px-3 py-3 shrink-0 transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink size={13} />
+              </Link>
+            </div>
 
-                {/* Expanded mentions */}
-                {isExpanded && (
-                  <div className="pl-16 pr-4 pb-2">
-                    <EpisodeMentionList
-                      query={query}
-                      episodeId={episode.episodeId}
-                      episodeTitle={episode.episodeTitle}
-                      audioUrl={episode.audioUrl}
-                      audioLocalPath={episode.audioLocalPath}
-                      episodeUrl={episode.episodeUrl}
-                      feedTitle={feed.feedTitle}
-                    />
-                  </div>
-                )}
+            {isExpanded && (
+              <div className="px-4 pb-3 border-t border-border">
+                <EpisodeMentionList
+                  query={query}
+                  episodeId={episode.episodeId}
+                  episodeTitle={episode.episodeTitle}
+                  audioLocalPath={episode.audioLocalPath}
+                  feedTitle={feed.feedTitle}
+                />
               </div>
-            );
-          })}
-        </div>
-      )}
-    </Card>
+            )}
+          </Card>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -32,6 +32,14 @@ export interface EpisodeMentions {
   mentions: Mention[];
 }
 
+export interface ContextSegment {
+  startTime: number;
+  endTime: number;
+  speakerLabel: string | null;
+  speakerDisplay: string | null;
+  text: string;
+}
+
 export interface Mention {
   id: number;
   startTime: number;
@@ -39,7 +47,10 @@ export interface Mention {
   speakerLabel: string | null;
   speakerDisplay: string | null;
   snippet: string;
+  text: string;
   rank: number;
+  contextBefore: ContextSegment[];
+  contextAfter: ContextSegment[];
 }
 
 // ── Flat search types ───────────────────────────────────────
@@ -280,13 +291,14 @@ export async function searchGrouped(
 }
 
 /**
- * Fetch matching speaker turns for one episode (loaded on expand).
- * Each result is a deduplicated speaker turn with all occurrences highlighted.
+ * Fetch matching speaker turns for one episode with surrounding context.
+ * Returns 1-2 turns before and after each match for dialogue context.
  */
 export async function searchMentions(
   query: string,
   episodeId: string
 ): Promise<EpisodeMentions> {
+  // Fetch all speaker turns for this episode with match info in one query
   const result = await pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
     SELECT
@@ -295,27 +307,68 @@ export async function searchMentions(
       t.end_time,
       t.speaker_label,
       COALESCE(sn.display_name, t.speaker_label) AS speaker_display,
-      ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12') AS snippet,
-      ts_rank(to_tsvector('english', t.full_text), query) AS rank
+      t.full_text,
+      CASE WHEN to_tsvector('english', t.full_text) @@ query THEN true ELSE false END AS is_match,
+      CASE WHEN to_tsvector('english', t.full_text) @@ query
+        THEN ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12')
+        ELSE '' END AS snippet,
+      CASE WHEN to_tsvector('english', t.full_text) @@ query
+        THEN ts_rank(to_tsvector('english', t.full_text), query)
+        ELSE 0 END AS rank
     FROM speaker_turns t
     LEFT JOIN speaker_names sn ON sn.episode_id = t.episode_id AND sn.speaker_label = t.speaker_label,
       plainto_tsquery('english', $1) AS query
     WHERE t.episode_id = $2
-      AND to_tsvector('english', t.full_text) @@ query
     ORDER BY t.start_time ASC`,
     [query, episodeId]
   );
 
-  return {
-    episodeId,
-    mentions: result.rows.map((row) => ({
+  const allTurns = result.rows;
+  const matchIndices = allTurns
+    .map((row, i) => (row.is_match ? i : -1))
+    .filter((i) => i >= 0);
+
+  const CONTEXT_SIZE = 2;
+
+  function toContextSegment(row: typeof allTurns[0]): ContextSegment {
+    return {
+      startTime: parseFloat(row.start_time),
+      endTime: parseFloat(row.end_time),
+      speakerLabel: row.speaker_label,
+      speakerDisplay: row.speaker_display,
+      text: row.full_text,
+    };
+  }
+
+  const mentions: Mention[] = matchIndices.map((idx) => {
+    const row = allTurns[idx];
+
+    // Gather context turns, skipping other matches
+    const before: ContextSegment[] = [];
+    for (let i = idx - 1; i >= 0 && before.length < CONTEXT_SIZE; i--) {
+      if (!allTurns[i].is_match) before.unshift(toContextSegment(allTurns[i]));
+      else break; // stop at adjacent match to avoid overlap
+    }
+
+    const after: ContextSegment[] = [];
+    for (let i = idx + 1; i < allTurns.length && after.length < CONTEXT_SIZE; i++) {
+      if (!allTurns[i].is_match) after.push(toContextSegment(allTurns[i]));
+      else break;
+    }
+
+    return {
       id: row.id,
       startTime: parseFloat(row.start_time),
       endTime: parseFloat(row.end_time),
       speakerLabel: row.speaker_label,
       speakerDisplay: row.speaker_display,
       snippet: row.snippet,
+      text: row.full_text,
       rank: parseFloat(row.rank),
-    })),
-  };
+      contextBefore: before,
+      contextAfter: after,
+    };
+  });
+
+  return { episodeId, mentions };
 }


### PR DESCRIPTION
## Summary
Redesign the search results page to be episode-centric with expandable dialogue context around each mention, and replace export formats with Markdown, Plain Text, and Print/PDF.

## Changes

### Backend (`search.ts`)
- `searchMentions` now fetches all speaker turns for the episode in one query, marks matches, and attaches 1-2 context turns before/after each match
- New `ContextSegment` type for context turns
- `Mention` type extended with `text`, `contextBefore`, `contextAfter`

### Frontend Components
- **FeedGroupCard** — simplified to episode-centric cards under minimal feed headers (no collapsible feed sections)
- **EpisodeMentionList** — redesigned with `MentionCard` showing:
  - Context before (dimmed)
  - Matched turn (yellow highlight, search term bolded)
  - Context after (dimmed)
  - Play and Episode action buttons
  - "Show N more mentions" collapse (first 2 expanded by default)
- **DownloadReportButton** — replaced CSV/JSON/Markdown with:
  - Markdown (.md) — speaker-attributed dialogue
  - Plain Text (.txt) — simple format
  - Print / PDF — opens styled print view in new tab

### New Route
- `/search/print?q=...` — print-optimized page with full report: header, episode sections, speaker-attributed dialogue with highlighted terms, context segments

## Test plan
- [x] Grouped view shows episodes as cards with mention counts
- [x] Expanding episode loads mentions with dialogue context
- [x] Matched turns are highlighted, context turns are dimmed
- [x] Play button starts audio at correct timestamp
- [x] Episode link navigates to transcript at timestamp
- [x] "Show N more" expands remaining mentions
- [x] Markdown export downloads with speaker-attributed dialogue
- [x] Plain text export downloads clean text
- [x] Print view opens in new tab with styled report
- [x] Print view has "Print / Save as PDF" button
- [ ] Flat view still works (unchanged)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)