### PR TITLE
feat: add reprocess button and fix inference banner

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import EpisodeDescription from "@/components/EpisodeDescription";
 import TranscriptSection from "@/components/TranscriptSection";
 import BackToSearchLink from "@/components/BackToSearchLink";
+import ReprocessButton from "@/components/ReprocessButton";
 
 export const dynamic = "force-dynamic";
 
@@ -88,7 +89,10 @@ export default async function EpisodePage({ params }: { params: { id: string } }
             &larr; {episode.feed_title ?? "Podcast"}
           </Link>
         )}
-        <h1 className="text-xl font-semibold mt-2">{episode.title ?? "Untitled Episode"}</h1>
+        <div className="flex items-center gap-3 mt-2">
+          <h1 className="text-xl font-semibold">{episode.title ?? "Untitled Episode"}</h1>
+          <ReprocessButton episodeId={episode.id} status={episode.status} />
+        </div>
         <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
           {episode.published_at && (
             <span>{new Date(episode.published_at).toLocaleDateString()}</span>
@@ -164,8 +168,8 @@ export default async function EpisodePage({ params }: { params: { id: string } }
         </Card>
       )}
 
-      {/* PRD-04 §8.1: inference error banner */}
-      {episode.inference_error && episode.status === "done" && (
+      {/* PRD-04 §8.1: inference error banner — suppress if any segment has inferred names (#56) */}
+      {episode.inference_error && episode.status === "done" && !segments.some(s => s.inferred) && (
         <Card className="border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950">
           <CardContent className="p-3 flex items-start gap-2">
             <Info size={16} className="text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />

--- a/apps/web/src/components/ReprocessButton.tsx
+++ b/apps/web/src/components/ReprocessButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { RefreshCw } from "lucide-react";
+
+interface ReprocessButtonProps {
+  episodeId: string;
+  status: string;
+}
+
+export default function ReprocessButton({ episodeId, status }: ReprocessButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  if (status !== "done" && status !== "failed") return null;
+
+  async function handleReprocess() {
+    if (!window.confirm("Re-queue this episode for full reprocessing?")) return;
+
+    setLoading(true);
+    try {
+      const resp = await fetch(`/api/episodes/${episodeId}/retry`, { method: "POST" });
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => null);
+        throw new Error(data?.detail ?? `Request failed (${resp.status})`);
+      }
+      router.refresh();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : "Failed to reprocess episode");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleReprocess}
+      disabled={loading}
+      className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
+    >
+      <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+      {loading ? "Reprocessing..." : "Reprocess"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Two episode page fixes:

1. **Reprocess button (#55)** — New `ReprocessButton` client component shown on done/failed episodes. Confirms before re-queueing via the existing retry API. Shows loading state with spinning icon.

2. **Fix inference banner (#56)** — The "Speaker name inference was unavailable" banner now checks if any segment has `inferred === true` before showing. Previously it only checked `inference_error`, which could be set even when inference partially succeeded.

## Test plan
- [ ] Reprocess button visible on done and failed episodes, hidden on in-progress ones
- [ ] Clicking Reprocess shows confirmation dialog, then re-queues on confirm
- [ ] Inference banner hidden when inferred names exist despite inference_error being set
- [ ] Inference banner still shows when no inferred names exist and inference_error is set

Closes #55
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)