### PR TITLE
feat: link queue items to episode page

### DIFF
--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -181,7 +181,13 @@ function EpisodeRow({
         onClick={isFailed ? () => setExpanded(!expanded) : undefined}
       >
         <td className="px-3 py-2 text-sm">
-          {job.title ?? "Untitled"}
+          <Link
+            href={`/episodes/${job.episode_id}`}
+            className="hover:text-primary hover:underline transition-colors"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {job.title ?? "Untitled"}
+          </Link>
         </td>
         <td className="px-3 py-2 text-sm text-muted-foreground hidden sm:table-cell">
           {job.feed_title ?? "—"}


### PR DESCRIPTION
## Summary
Make episode titles in the queue page clickable links to `/episodes/[id]`.

## Changes
- `QueueStatus.tsx`: Wrap episode title in a `<Link>` with hover styling
- `stopPropagation` on the link click prevents toggling error expansion on failed rows

## Test plan
- [ ] Click episode title in queue → navigates to episode page
- [ ] Click failed episode title → navigates (doesn't toggle error panel)
- [ ] Click anywhere else on failed row → still toggles error panel
- [ ] Works for all statuses (pending, active, done, failed)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)