### PR TITLE
perf: skip COUNT(*) query on search page 2+

### DIFF
--- a/apps/web/src/app/api/search/grouped/route.ts
+++ b/apps/web/src/app/api/search/grouped/route.ts
@@ -12,9 +12,10 @@ export async function GET(req: NextRequest) {
   const feedId = searchParams.get("feedId") || null;
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+  const skipCount = searchParams.get("skipCount") === "true";
 
   try {
-    const result = await searchGrouped(q, feedId, page, pageSize);
+    const result = await searchGrouped(q, feedId, page, pageSize, skipCount);
     return NextResponse.json(result);
   } catch (err) {
     console.error("Grouped search error:", err);

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -12,9 +12,10 @@ export async function GET(req: NextRequest) {
   const feedId = searchParams.get("feedId") || null;
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+  const skipCount = searchParams.get("skipCount") === "true";
 
   try {
-    const result = await searchSegments(q, feedId, page, pageSize);
+    const result = await searchSegments(q, feedId, page, pageSize, skipCount);
     return NextResponse.json(result);
   } catch (err) {
     console.error("Search error:", err);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Search, List, Layers } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -38,6 +38,10 @@ function HomePageContent() {
   const [page, setPage] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>("grouped");
 
+  // Cache totals from page 1 to skip COUNT(*) on subsequent pages
+  const cachedFlatTotal = useRef<{ key: string; total: number } | null>(null);
+  const cachedGroupedTotals = useRef<{ key: string; totalFeeds: number; totalEpisodes: number; totalMentions: number } | null>(null);
+
   // Sync state when URL ?q= param changes (e.g. browser back/forward)
   useEffect(() => {
     const urlQuery = searchParams.get("q") ?? "";
@@ -48,40 +52,67 @@ function HomePageContent() {
     }
   }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Flat search query
+  // Flat search query — skip COUNT(*) on page 2+ using cached total
+  const flatCacheKey = `${submittedQuery}:${feedFilter}`;
   const flatQuery = useQuery<SearchPage>({
     queryKey: ["search", submittedQuery, feedFilter, page],
     queryFn: async () => {
       if (!submittedQuery) return { results: [], total: 0, page: 1, pageSize: PAGE_SIZE };
+      const canSkipCount = page > 1 && cachedFlatTotal.current?.key === flatCacheKey;
       const params = new URLSearchParams({
         q: submittedQuery,
         page: String(page),
         pageSize: String(PAGE_SIZE),
       });
       if (feedFilter) params.set("feedId", feedFilter);
+      if (canSkipCount) params.set("skipCount", "true");
       const resp = await fetch(`/api/search?${params}`);
       if (!resp.ok) throw new Error("Search failed");
-      return resp.json();
+      const data: SearchPage = await resp.json();
+      // Cache total from page 1, or restore from cache on page 2+
+      if (data.total >= 0) {
+        cachedFlatTotal.current = { key: flatCacheKey, total: data.total };
+      } else if (cachedFlatTotal.current?.key === flatCacheKey) {
+        data.total = cachedFlatTotal.current.total;
+      }
+      return data;
     },
     enabled: Boolean(submittedQuery) && viewMode === "flat",
     staleTime: 30_000,
   });
 
-  // Grouped search query
+  // Grouped search query — skip COUNT(*) on page 2+ using cached totals
+  const groupedCacheKey = `${submittedQuery}:${feedFilter}`;
   const groupedQuery = useQuery<GroupedSearchResult>({
     queryKey: ["search-grouped", submittedQuery, feedFilter, page],
     queryFn: async () => {
       if (!submittedQuery)
         return { feeds: [], totalFeeds: 0, totalEpisodes: 0, totalMentions: 0 };
+      const canSkipCount = page > 1 && cachedGroupedTotals.current?.key === groupedCacheKey;
       const params = new URLSearchParams({
         q: submittedQuery,
         page: String(page),
         pageSize: String(PAGE_SIZE),
       });
       if (feedFilter) params.set("feedId", feedFilter);
+      if (canSkipCount) params.set("skipCount", "true");
       const resp = await fetch(`/api/search/grouped?${params}`);
       if (!resp.ok) throw new Error("Search failed");
-      return resp.json();
+      const data: GroupedSearchResult = await resp.json();
+      // Cache totals from page 1, or restore from cache on page 2+
+      if (data.totalMentions >= 0) {
+        cachedGroupedTotals.current = {
+          key: groupedCacheKey,
+          totalFeeds: data.totalFeeds,
+          totalEpisodes: data.totalEpisodes,
+          totalMentions: data.totalMentions,
+        };
+      } else if (cachedGroupedTotals.current?.key === groupedCacheKey) {
+        data.totalFeeds = cachedGroupedTotals.current.totalFeeds;
+        data.totalEpisodes = cachedGroupedTotals.current.totalEpisodes;
+        data.totalMentions = cachedGroupedTotals.current.totalMentions;
+      }
+      return data;
     },
     enabled: Boolean(submittedQuery) && viewMode === "grouped",
     staleTime: 30_000,

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -122,54 +122,59 @@ export async function searchSegments(
   query: string,
   feedId: string | null,
   page: number,
-  pageSize: number = 20
+  pageSize: number = 20,
+  skipCount: boolean = false
 ): Promise<SearchPage> {
   const offset = (page - 1) * pageSize;
 
-  const [rowsResult, countResult] = await Promise.all([
-    pool.query(
-      `WITH ${SPEAKER_TURNS_CTE}
-      SELECT
-        t.min_id AS id,
-        t.start_time,
-        t.end_time,
-        t.speaker_label,
-        COALESCE(sn.display_name, t.speaker_label) AS speaker_display,
-        ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12') AS snippet,
-        ts_rank(to_tsvector('english', t.full_text), query) AS rank,
-        e.id AS episode_id,
-        e.title AS episode_title,
-        e.audio_url,
-        e.audio_local_path,
-        e.episode_url,
-        e.has_diarization,
-        e.diarization_error,
-        f.title AS feed_title,
-        f.mode AS feed_mode,
-        f.id AS feed_id
-      FROM speaker_turns t
-      JOIN episodes e ON t.episode_id = e.id
-      JOIN feeds f ON e.feed_id = f.id
-      LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
-        plainto_tsquery('english', $1) AS query
-      WHERE to_tsvector('english', t.full_text) @@ query
-        AND ($2::uuid IS NULL OR f.id = $2)
-      ORDER BY rank DESC
-      LIMIT $3 OFFSET $4`,
-      [query, feedId, pageSize, offset]
-    ),
-    pool.query(
-      `WITH ${SPEAKER_TURNS_CTE}
-      SELECT COUNT(*)
-      FROM speaker_turns t
-      JOIN episodes e ON t.episode_id = e.id
-      JOIN feeds f ON e.feed_id = f.id,
-        plainto_tsquery('english', $1) AS query
-      WHERE to_tsvector('english', t.full_text) @@ query
-        AND ($2::uuid IS NULL OR f.id = $2)`,
-      [query, feedId]
-    ),
-  ]);
+  const rowsPromise = pool.query(
+    `WITH ${SPEAKER_TURNS_CTE}
+    SELECT
+      t.min_id AS id,
+      t.start_time,
+      t.end_time,
+      t.speaker_label,
+      COALESCE(sn.display_name, t.speaker_label) AS speaker_display,
+      ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12') AS snippet,
+      ts_rank(to_tsvector('english', t.full_text), query) AS rank,
+      e.id AS episode_id,
+      e.title AS episode_title,
+      e.audio_url,
+      e.audio_local_path,
+      e.episode_url,
+      e.has_diarization,
+      e.diarization_error,
+      f.title AS feed_title,
+      f.mode AS feed_mode,
+      f.id AS feed_id
+    FROM speaker_turns t
+    JOIN episodes e ON t.episode_id = e.id
+    JOIN feeds f ON e.feed_id = f.id
+    LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
+      plainto_tsquery('english', $1) AS query
+    WHERE to_tsvector('english', t.full_text) @@ query
+      AND ($2::uuid IS NULL OR f.id = $2)
+    ORDER BY rank DESC
+    LIMIT $3 OFFSET $4`,
+    [query, feedId, pageSize, offset]
+  );
+
+  // Skip the expensive COUNT(*) query on page 2+ when the frontend already has the total
+  const countPromise = skipCount
+    ? Promise.resolve(null)
+    : pool.query(
+        `WITH ${SPEAKER_TURNS_CTE}
+        SELECT COUNT(*)
+        FROM speaker_turns t
+        JOIN episodes e ON t.episode_id = e.id
+        JOIN feeds f ON e.feed_id = f.id,
+          plainto_tsquery('english', $1) AS query
+        WHERE to_tsvector('english', t.full_text) @@ query
+          AND ($2::uuid IS NULL OR f.id = $2)`,
+        [query, feedId]
+      );
+
+  const [rowsResult, countResult] = await Promise.all([rowsPromise, countPromise]);
 
   const results: SearchResult[] = rowsResult.rows.map((row) => ({
     id: row.id,
@@ -193,7 +198,7 @@ export async function searchSegments(
 
   return {
     results,
-    total: parseInt(countResult.rows[0].count, 10),
+    total: countResult ? parseInt(countResult.rows[0].count, 10) : -1,
     page,
     pageSize,
   };
@@ -207,50 +212,54 @@ export async function searchGrouped(
   query: string,
   feedId: string | null,
   page: number,
-  pageSize: number = 20
+  pageSize: number = 20,
+  skipCount: boolean = false
 ): Promise<GroupedSearchResult> {
   const offset = (page - 1) * pageSize;
 
-  const [rowsResult, countResult] = await Promise.all([
-    pool.query(
-      `WITH ${SPEAKER_TURNS_CTE}
-      SELECT
-        f.id AS feed_id,
-        f.title AS feed_title,
-        f.mode AS feed_mode,
-        e.id AS episode_id,
-        e.title AS episode_title,
-        e.audio_url,
-        e.audio_local_path,
-        e.episode_url,
-        COUNT(*)::int AS mention_count,
-        MAX(ts_rank(to_tsvector('english', t.full_text), query)) AS best_rank
-      FROM speaker_turns t
-      JOIN episodes e ON t.episode_id = e.id
-      JOIN feeds f ON e.feed_id = f.id,
-        plainto_tsquery('english', $1) AS query
-      WHERE to_tsvector('english', t.full_text) @@ query
-        AND ($2::uuid IS NULL OR f.id = $2)
-      GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
-      ORDER BY best_rank DESC, mention_count DESC
-      LIMIT $3 OFFSET $4`,
-      [query, feedId, pageSize, offset]
-    ),
-    pool.query(
-      `WITH ${SPEAKER_TURNS_CTE}
-      SELECT
-        COUNT(DISTINCT e.id)::int AS total_episodes,
-        COUNT(DISTINCT f.id)::int AS total_feeds,
-        COUNT(*)::int AS total_mentions
-      FROM speaker_turns t
-      JOIN episodes e ON t.episode_id = e.id
-      JOIN feeds f ON e.feed_id = f.id,
-        plainto_tsquery('english', $1) AS query
-      WHERE to_tsvector('english', t.full_text) @@ query
-        AND ($2::uuid IS NULL OR f.id = $2)`,
-      [query, feedId]
-    ),
-  ]);
+  const rowsPromise = pool.query(
+    `WITH ${SPEAKER_TURNS_CTE}
+    SELECT
+      f.id AS feed_id,
+      f.title AS feed_title,
+      f.mode AS feed_mode,
+      e.id AS episode_id,
+      e.title AS episode_title,
+      e.audio_url,
+      e.audio_local_path,
+      e.episode_url,
+      COUNT(*)::int AS mention_count,
+      MAX(ts_rank(to_tsvector('english', t.full_text), query)) AS best_rank
+    FROM speaker_turns t
+    JOIN episodes e ON t.episode_id = e.id
+    JOIN feeds f ON e.feed_id = f.id,
+      plainto_tsquery('english', $1) AS query
+    WHERE to_tsvector('english', t.full_text) @@ query
+      AND ($2::uuid IS NULL OR f.id = $2)
+    GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
+    ORDER BY best_rank DESC, mention_count DESC
+    LIMIT $3 OFFSET $4`,
+    [query, feedId, pageSize, offset]
+  );
+
+  const countPromise = skipCount
+    ? Promise.resolve(null)
+    : pool.query(
+        `WITH ${SPEAKER_TURNS_CTE}
+        SELECT
+          COUNT(DISTINCT e.id)::int AS total_episodes,
+          COUNT(DISTINCT f.id)::int AS total_feeds,
+          COUNT(*)::int AS total_mentions
+        FROM speaker_turns t
+        JOIN episodes e ON t.episode_id = e.id
+        JOIN feeds f ON e.feed_id = f.id,
+          plainto_tsquery('english', $1) AS query
+        WHERE to_tsvector('english', t.full_text) @@ query
+          AND ($2::uuid IS NULL OR f.id = $2)`,
+        [query, feedId]
+      );
+
+  const [rowsResult, countResult] = await Promise.all([rowsPromise, countPromise]);
 
   // Group episode rows by feed
   const feedMap = new Map<string, FeedGroup>();
@@ -280,13 +289,13 @@ export async function searchGrouped(
     });
   }
 
-  const counts = countResult.rows[0];
+  const counts = countResult?.rows[0];
 
   return {
     feeds: Array.from(feedMap.values()),
-    totalFeeds: counts.total_feeds,
-    totalEpisodes: counts.total_episodes,
-    totalMentions: counts.total_mentions,
+    totalFeeds: counts?.total_feeds ?? -1,
+    totalEpisodes: counts?.total_episodes ?? -1,
+    totalMentions: counts?.total_mentions ?? -1,
   };
 }
 


### PR DESCRIPTION
## Summary
Skip the expensive COUNT(*) query on search page 2+ by caching the total from page 1 client-side.

## How it works
1. **Page 1**: Both the results query and COUNT(*) query run (as before)
2. **Frontend caches** the total in a `useRef` keyed by `query:feedFilter`
3. **Page 2+**: Frontend passes `skipCount=true`, backend skips the COUNT query and returns `total: -1`
4. **Frontend restores** the cached total, so pagination UI works normally

## Changes
- `search.ts`: `searchSegments` and `searchGrouped` accept `skipCount` boolean; when true, the COUNT promise resolves to null instead of running the query
- `route.ts` (flat + grouped): Pass through `skipCount` query parameter
- `page.tsx`: Cache totals in `useRef`, pass `skipCount=true` on page > 1, restore cached totals from `-1` sentinel

## Impact
Each page navigation after page 1 saves one full speaker_turns CTE materialization (window functions + string_agg + FTS scan over all segments). At current scale this saves ~100ms; at larger scale it avoids the heaviest query entirely.

## Test plan
- [x] Page 1 search returns real total count
- [x] Page 2 with `skipCount=true` returns `total: -1` (no COUNT query)
- [x] Frontend pagination works correctly using cached total
- [x] New search resets cache and fetches fresh count
- [x] Grouped view totals (feeds/episodes/mentions) cached and restored correctly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)