### PR TITLE
feat: search improvements L1-L3 — websearch syntax, trigrams, semantic search

### DIFF
--- a/apps/pipeline/Dockerfile.control
+++ b/apps/pipeline/Dockerfile.control
@@ -1,6 +1,8 @@
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    libsndfile1 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -9,7 +11,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock* ./
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --with ml --without dev --no-root --no-interaction --no-ansi
 
 COPY . .
 

--- a/apps/pipeline/alembic/versions/006_add_pgvector_and_trigram.py
+++ b/apps/pipeline/alembic/versions/006_add_pgvector_and_trigram.py
@@ -1,0 +1,40 @@
+"""Add pgvector and pg_trgm extensions, embedding column, and indexes.
+
+Supports search improvements: semantic vector search (Level 3) and
+fuzzy trigram matching (Level 2).
+"""
+
+from alembic import op
+
+
+revision = "006"
+down_revision = "4298a0b3990f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    op.execute("ALTER TABLE segments ADD COLUMN IF NOT EXISTS embedding vector(384)")
+
+    # HNSW index for fast approximate nearest neighbor search
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS segments_embedding_hnsw "
+        "ON segments USING hnsw (embedding vector_cosine_ops)"
+    )
+
+    # Trigram index for fuzzy text matching
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS segments_text_trgm "
+        "ON segments USING GIN(text gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS segments_text_trgm")
+    op.execute("DROP INDEX IF EXISTS segments_embedding_hnsw")
+    op.execute("ALTER TABLE segments DROP COLUMN IF EXISTS embedding")
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm")
+    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/apps/pipeline/app/api/embed.py
+++ b/apps/pipeline/app/api/embed.py
@@ -1,0 +1,22 @@
+"""Embedding API — exposes query embedding for the web app's semantic search."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(tags=["embed"])
+
+
+class EmbedRequest(BaseModel):
+    text: str
+
+
+class EmbedResponse(BaseModel):
+    embedding: list[float]
+
+
+@router.post("/embed", response_model=EmbedResponse)
+async def embed_text(req: EmbedRequest):
+    from app.services.embed import embed_query
+
+    embedding = embed_query(req.text)
+    return EmbedResponse(embedding=embedding)

--- a/apps/pipeline/app/main.py
+++ b/apps/pipeline/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api import feeds, episodes, queue, health
+from app.api import feeds, episodes, queue, health, embed
 
 logging.basicConfig(
     level=logging.INFO,
@@ -39,3 +39,4 @@ app.include_router(feeds.router, prefix="/api")
 app.include_router(episodes.router, prefix="/api")
 app.include_router(queue.router, prefix="/api")
 app.include_router(health.router, prefix="/api")
+app.include_router(embed.router, prefix="/api")

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from pgvector.sqlalchemy import Vector
 
 
 def _uuid() -> str:
@@ -123,6 +124,7 @@ class Segment(Base):
     start_time: Mapped[float] = mapped_column(Float, nullable=False)
     end_time: Mapped[float] = mapped_column(Float, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding = mapped_column(Vector(384), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 
     episode: Mapped["Episode"] = relationship("Episode", back_populates="segments")

--- a/apps/pipeline/app/services/embed.py
+++ b/apps/pipeline/app/services/embed.py
@@ -1,0 +1,40 @@
+"""
+Sentence embedding service for semantic search (Level 3).
+
+Uses all-MiniLM-L6-v2 (80MB, 384 dimensions) for fast CPU inference.
+Unlike Whisper/pyannote, this model is small enough to stay loaded.
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+_model = None
+MODEL_NAME = "all-MiniLM-L6-v2"
+EMBEDDING_DIM = 384
+
+
+def _load_model():
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+
+        logger.info('"action": "embed_model_load_start", "model": "%s"', MODEL_NAME)
+        _model = SentenceTransformer(MODEL_NAME)
+        logger.info('"action": "embed_model_load_complete", "model": "%s"', MODEL_NAME)
+    return _model
+
+
+def embed_texts(texts: list[str]) -> list[list[float]]:
+    """Embed a batch of texts. Returns list of 384-dim float vectors."""
+    if not texts:
+        return []
+    model = _load_model()
+    embeddings = model.encode(texts, show_progress_bar=False, normalize_embeddings=True)
+    return embeddings.tolist()
+
+
+def embed_query(text: str) -> list[float]:
+    """Embed a single search query. Returns a 384-dim float vector."""
+    model = _load_model()
+    embedding = model.encode(text, show_progress_bar=False, normalize_embeddings=True)
+    return embedding.tolist()

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -67,7 +67,7 @@ def diarize_episode(episode_id: str) -> str:
             from app.services.pyannote import unload_pipeline
             unload_pipeline()
 
-        job_queue.enqueue(db, episode_id, "infer")
+        job_queue.enqueue(db, episode_id, "embed")
         return episode_id
     finally:
         # Clean up alignment file

--- a/apps/pipeline/app/tasks/embed.py
+++ b/apps/pipeline/app/tasks/embed.py
@@ -1,0 +1,56 @@
+"""
+Embedding task — generates sentence embeddings for semantic search.
+
+Runs after diarization (segments are finalized). Embeds all segments
+for an episode in batch using all-MiniLM-L6-v2, then stores the
+384-dim vectors in the segments.embedding column via pgvector.
+"""
+import logging
+
+from app.database import SessionLocal
+from app.models import Segment
+from app.tasks.helpers import update_episode
+from app import job_queue
+
+logger = logging.getLogger(__name__)
+
+
+def embed_episode(episode_id: str) -> str:
+    db = SessionLocal()
+    try:
+        segments = (
+            db.query(Segment)
+            .filter(Segment.episode_id == episode_id)
+            .order_by(Segment.start_time)
+            .all()
+        )
+
+        if not segments:
+            logger.warning(
+                '"action": "embed_skip_no_segments", "episode_id": "%s"',
+                episode_id,
+            )
+            job_queue.enqueue(db, episode_id, "infer")
+            return episode_id
+
+        texts = [seg.text for seg in segments]
+
+        from app.services.embed import embed_texts
+
+        embeddings = embed_texts(texts)
+
+        for seg, emb in zip(segments, embeddings):
+            seg.embedding = emb
+
+        db.commit()
+
+        logger.info(
+            '"action": "embed_complete", "episode_id": "%s", "segments": %d',
+            episode_id,
+            len(segments),
+        )
+
+        job_queue.enqueue(db, episode_id, "infer")
+        return episode_id
+    finally:
+        db.close()

--- a/apps/pipeline/app/worker.py
+++ b/apps/pipeline/app/worker.py
@@ -23,6 +23,7 @@ TASK_HANDLERS: dict[str, str] = {
     "download": "app.tasks.download:download_episode",
     "transcribe": "app.tasks.transcribe:transcribe_episode",
     "diarize": "app.tasks.diarize:diarize_episode",
+    "embed": "app.tasks.embed:embed_episode",
     "infer": "app.tasks.infer:infer_speakers",
     "archive": "app.tasks.archive:archive_episode",
 }

--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -2671,7 +2671,7 @@ version = "2.4.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["ml"]
+groups = ["main", "ml"]
 files = [
     {file = "numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825"},
     {file = "numpy-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7edc794af8b36ca37ef5fcb5e0d128c7e0595c7b96a2318d1badb6fcd8ee86b1"},
@@ -3285,6 +3285,21 @@ sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-
 test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
 timezone = ["pytz (>=2024.2)"]
 xml = ["lxml (>=5.3.0)"]
+
+[[package]]
+name = "pgvector"
+version = "0.3.6"
+description = "pgvector support for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pgvector-0.3.6-py3-none-any.whl", hash = "sha256:f6c269b3c110ccb7496bac87202148ed18f34b390a0189c783e351062400a75a"},
+    {file = "pgvector-0.3.6.tar.gz", hash = "sha256:31d01690e6ea26cea8a633cde5f0f55f5b246d9c8292d68efdef8c22ec994ade"},
+]
+
+[package.dependencies]
+numpy = "*"
 
 [[package]]
 name = "pillow"
@@ -4735,6 +4750,36 @@ numpy = ">=1.26.4,<2.7"
 dev = ["click (<8.3.0)", "cython-lint (>=0.12.2)", "mypy (==1.10.0)", "pycodestyle", "ruff (>=0.12.0)", "spin", "types-psutil", "typing_extensions"]
 doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "linkify-it-py", "matplotlib (>=3.5)", "myst-nb (>=1.2.0)", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.2.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)", "tabulate"]
 test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.3.0"
+description = "Embeddings, Retrieval, and Reranking"
+optional = false
+python-versions = ">=3.10"
+groups = ["ml"]
+files = [
+    {file = "sentence_transformers-5.3.0-py3-none-any.whl", hash = "sha256:dca6b98db790274a68185d27a65801b58b4caf653a4e556b5f62827509347c7d"},
+    {file = "sentence_transformers-5.3.0.tar.gz", hash = "sha256:414a0a881f53a4df0e6cbace75f823bfcb6b94d674c42a384b498959b7c065e2"},
+]
+
+[package.dependencies]
+huggingface-hub = ">=0.20.0"
+numpy = "*"
+scikit-learn = "*"
+scipy = "*"
+torch = ">=1.11.0"
+tqdm = "*"
+transformers = ">=4.41.0,<6.0.0"
+typing_extensions = ">=4.5.0"
+
+[package.extras]
+dev = ["Pillow", "accelerate (>=0.20.3)", "datasets", "peft", "pre-commit", "pytest", "pytest-cov", "pytest-env"]
+image = ["Pillow"]
+onnx = ["optimum-onnx[onnxruntime]"]
+onnx-gpu = ["optimum-onnx[onnxruntime-gpu]"]
+openvino = ["optimum-intel[openvino]"]
+train = ["accelerate (>=0.20.3)", "datasets"]
 
 [[package]]
 name = "setuptools"
@@ -6360,4 +6405,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "e01424d278136014eb045ab937b22a9f95cfd1fc6c5753d095931c3f9ab22da7"
+content-hash = "e7fe62b480f0c9b8ddf1cdd93a90bd688e4a4102d75634c5b76a3268772c58e2"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -21,6 +21,7 @@ pydantic-settings = "^2.2.0"
 sqlalchemy = "^2.0.0"
 alembic = "^1.13.0"
 psycopg2-binary = "^2.9.9"
+pgvector = "^0.3.0"
 
 # RSS parsing
 feedparser = "^6.0.11"
@@ -42,6 +43,9 @@ soundfile = ">=0.12.0"  # Audio backend for pyannote (fallback when torchcodec u
 
 # spaCy NER for host/guest inference (PRD-04)
 spacy = "^3.7"
+
+# Sentence embeddings for semantic search (Level 3)
+sentence-transformers = ">=2.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/apps/web/src/app/api/pipeline/embed/route.ts
+++ b/apps/web/src/app/api/pipeline/embed/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PIPELINE_API = process.env.PIPELINE_API ?? "http://pipeline:8000";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const resp = await fetch(`${PIPELINE_API}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      return NextResponse.json(
+        { error: "Embedding failed" },
+        { status: resp.status }
+      );
+    }
+    const data = await resp.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Embed proxy error:", err);
+    return NextResponse.json(
+      { error: "Embedding service unavailable" },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,5 +1,26 @@
 import pool from "@/lib/db";
 
+const PIPELINE_API = process.env.PIPELINE_API ?? "http://pipeline:8000";
+
+/**
+ * Get embedding for a search query from the pipeline's embed API.
+ * Returns null if embedding service is unavailable (graceful degradation to FTS-only).
+ */
+async function getQueryEmbedding(text: string): Promise<number[] | null> {
+  try {
+    const resp = await fetch(`${PIPELINE_API}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return data.embedding;
+  } catch {
+    return null;
+  }
+}
+
 // ── Grouped search types ────────────────────────────────────
 
 export interface GroupedSearchResult {
@@ -114,9 +135,25 @@ const SPEAKER_TURNS_CTE = `
     GROUP BY episode_id, speaker_label, turn_num
   )`;
 
+// RRF constant — standard value for Reciprocal Rank Fusion
+const RRF_K = 60;
+
 /**
- * Execute full-text search against transcript segments, aggregated by speaker turn.
- * Per PRD-02 §5.1, §10. Deduplicates results so each speaker turn appears once.
+ * Truncate text to ~200 chars for vector-only result snippets.
+ */
+function truncateSnippet(text: string, maxLen = 200): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen).replace(/\s\S*$/, "") + "…";
+}
+
+/**
+ * Hybrid search: FTS + vector similarity with Reciprocal Rank Fusion.
+ *
+ * Runs keyword search (websearch_to_tsquery on speaker turns) and semantic
+ * search (pgvector cosine similarity on segments) in parallel. Results are
+ * merged using RRF so keyword-exact matches rank high while semantically
+ * similar content is also surfaced. Falls back to FTS-only if embeddings
+ * are unavailable.
  */
 export async function searchSegments(
   query: string,
@@ -125,9 +162,10 @@ export async function searchSegments(
   pageSize: number = 20,
   skipCount: boolean = false
 ): Promise<SearchPage> {
-  const offset = (page - 1) * pageSize;
+  const FETCH_LIMIT = 100; // fetch more than pageSize for RRF merging
 
-  const rowsPromise = pool.query(
+  // 1. FTS on speaker turns
+  const ftsPromise = pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
     SELECT
       t.min_id AS id,
@@ -151,15 +189,49 @@ export async function searchSegments(
     JOIN episodes e ON t.episode_id = e.id
     JOIN feeds f ON e.feed_id = f.id
     LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
-      plainto_tsquery('english', $1) AS query
+      websearch_to_tsquery('english', $1) AS query
     WHERE to_tsvector('english', t.full_text) @@ query
       AND ($2::uuid IS NULL OR f.id = $2)
     ORDER BY rank DESC
-    LIMIT $3 OFFSET $4`,
-    [query, feedId, pageSize, offset]
+    LIMIT $3`,
+    [query, feedId, FETCH_LIMIT]
   );
 
-  // Skip the expensive COUNT(*) query on page 2+ when the frontend already has the total
+  // 2. Vector similarity on raw segments (if embeddings available)
+  const embedding = await getQueryEmbedding(query);
+  const vecPromise = embedding
+    ? pool.query(
+        `SELECT
+          s.id,
+          s.start_time,
+          s.end_time,
+          s.speaker_label,
+          COALESCE(sn.display_name, s.speaker_label) AS speaker_display,
+          s.text,
+          1 - (s.embedding <=> $1::vector) AS similarity,
+          e.id AS episode_id,
+          e.title AS episode_title,
+          e.audio_url,
+          e.audio_local_path,
+          e.episode_url,
+          e.has_diarization,
+          e.diarization_error,
+          f.title AS feed_title,
+          f.mode AS feed_mode,
+          f.id AS feed_id
+        FROM segments s
+        JOIN episodes e ON s.episode_id = e.id
+        JOIN feeds f ON e.feed_id = f.id
+        LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = s.speaker_label
+        WHERE s.embedding IS NOT NULL
+          AND ($2::uuid IS NULL OR f.id = $2)
+        ORDER BY s.embedding <=> $1::vector
+        LIMIT $3`,
+        [`[${embedding.join(",")}]`, feedId, FETCH_LIMIT]
+      )
+    : Promise.resolve({ rows: [] });
+
+  // 3. Count (FTS-based, skipped on page 2+)
   const countPromise = skipCount
     ? Promise.resolve(null)
     : pool.query(
@@ -168,40 +240,95 @@ export async function searchSegments(
         FROM speaker_turns t
         JOIN episodes e ON t.episode_id = e.id
         JOIN feeds f ON e.feed_id = f.id,
-          plainto_tsquery('english', $1) AS query
+          websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND ($2::uuid IS NULL OR f.id = $2)`,
         [query, feedId]
       );
 
-  const [rowsResult, countResult] = await Promise.all([rowsPromise, countPromise]);
+  const [ftsResult, vecResult, countResult] = await Promise.all([
+    ftsPromise, vecPromise, countPromise,
+  ]);
 
-  const results: SearchResult[] = rowsResult.rows.map((row) => ({
-    id: row.id,
-    startTime: parseFloat(row.start_time),
-    endTime: parseFloat(row.end_time),
-    speakerLabel: row.speaker_label,
-    speakerDisplay: row.speaker_display,
-    snippet: row.snippet,
-    rank: parseFloat(row.rank),
-    episodeId: row.episode_id,
-    episodeTitle: row.episode_title,
-    audioUrl: row.audio_url,
-    audioLocalPath: row.audio_local_path,
-    episodeUrl: row.episode_url,
-    hasDiarization: row.has_diarization,
-    diarizationError: row.diarization_error,
-    feedTitle: row.feed_title,
-    feedMode: row.feed_mode,
-    feedId: row.feed_id,
-  }));
+  // 4. Build result map keyed by episodeId:bucketedTime for deduplication
+  type MergedEntry = SearchResult & { ftsRank?: number; vecRank?: number; rrfScore: number };
+  const merged = new Map<string, MergedEntry>();
 
-  return {
-    results,
-    total: countResult ? parseInt(countResult.rows[0].count, 10) : -1,
-    page,
-    pageSize,
-  };
+  function bucketKey(episodeId: string, startTime: number): string {
+    return `${episodeId}:${Math.floor(startTime / 30)}`; // 30-second buckets
+  }
+
+  // Add FTS results
+  ftsResult.rows.forEach((row, i) => {
+    const key = bucketKey(row.episode_id, parseFloat(row.start_time));
+    merged.set(key, {
+      id: row.id,
+      startTime: parseFloat(row.start_time),
+      endTime: parseFloat(row.end_time),
+      speakerLabel: row.speaker_label,
+      speakerDisplay: row.speaker_display,
+      snippet: row.snippet,
+      rank: parseFloat(row.rank),
+      episodeId: row.episode_id,
+      episodeTitle: row.episode_title,
+      audioUrl: row.audio_url,
+      audioLocalPath: row.audio_local_path,
+      episodeUrl: row.episode_url,
+      hasDiarization: row.has_diarization,
+      diarizationError: row.diarization_error,
+      feedTitle: row.feed_title,
+      feedMode: row.feed_mode,
+      feedId: row.feed_id,
+      ftsRank: i + 1,
+      rrfScore: 1 / (RRF_K + i + 1),
+    });
+  });
+
+  // Add/merge vector results
+  vecResult.rows.forEach((row, i) => {
+    const key = bucketKey(row.episode_id, parseFloat(row.start_time));
+    const vecScore = 1 / (RRF_K + i + 1);
+    const existing = merged.get(key);
+    if (existing) {
+      // Boost existing FTS result with vector score
+      existing.vecRank = i + 1;
+      existing.rrfScore += vecScore;
+    } else {
+      // Vector-only result (semantic match, no keyword match)
+      merged.set(key, {
+        id: row.id,
+        startTime: parseFloat(row.start_time),
+        endTime: parseFloat(row.end_time),
+        speakerLabel: row.speaker_label,
+        speakerDisplay: row.speaker_display,
+        snippet: truncateSnippet(row.text),
+        rank: parseFloat(row.similarity),
+        episodeId: row.episode_id,
+        episodeTitle: row.episode_title,
+        audioUrl: row.audio_url,
+        audioLocalPath: row.audio_local_path,
+        episodeUrl: row.episode_url,
+        hasDiarization: row.has_diarization,
+        diarizationError: row.diarization_error,
+        feedTitle: row.feed_title,
+        feedMode: row.feed_mode,
+        feedId: row.feed_id,
+        vecRank: i + 1,
+        rrfScore: vecScore,
+      });
+    }
+  });
+
+  // 5. Sort by RRF score, paginate
+  const sorted = Array.from(merged.values()).sort((a, b) => b.rrfScore - a.rrfScore);
+  const offset = (page - 1) * pageSize;
+  const results: SearchResult[] = sorted.slice(offset, offset + pageSize);
+
+  // Total: use FTS count (vector-only results are supplementary)
+  const ftsTotal = countResult ? parseInt(countResult.rows[0].count, 10) : -1;
+  const total = ftsTotal >= 0 ? Math.max(ftsTotal, sorted.length) : -1;
+
+  return { results, total, page, pageSize };
 }
 
 /**
@@ -233,7 +360,7 @@ export async function searchGrouped(
     FROM speaker_turns t
     JOIN episodes e ON t.episode_id = e.id
     JOIN feeds f ON e.feed_id = f.id,
-      plainto_tsquery('english', $1) AS query
+      websearch_to_tsquery('english', $1) AS query
     WHERE to_tsvector('english', t.full_text) @@ query
       AND ($2::uuid IS NULL OR f.id = $2)
     GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
@@ -253,7 +380,7 @@ export async function searchGrouped(
         FROM speaker_turns t
         JOIN episodes e ON t.episode_id = e.id
         JOIN feeds f ON e.feed_id = f.id,
-          plainto_tsquery('english', $1) AS query
+          websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND ($2::uuid IS NULL OR f.id = $2)`,
         [query, feedId]
@@ -326,7 +453,7 @@ export async function searchMentions(
         ELSE 0 END AS rank
     FROM speaker_turns t
     LEFT JOIN speaker_names sn ON sn.episode_id = t.episode_id AND sn.speaker_label = t.speaker_label,
-      plainto_tsquery('english', $1) AS query
+      websearch_to_tsquery('english', $1) AS query
     WHERE t.episode_id = $2
     ORDER BY t.start_time ASC`,
     [query, episodeId]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     environment:
       POSTGRES_DB: podlog
       POSTGRES_USER: postgres


### PR DESCRIPTION
## Summary
Implements search improvements from Levels 1-3 as documented in Issue #33.

## Changes

### Level 1a: websearch_to_tsquery
- Replaces `plainto_tsquery` with `websearch_to_tsquery` across all search functions
- Users can now use: `"phrase search"`, `word1 OR word2`, `-excluded`

### Level 2a: Trigram fuzzy matching
- Migration adds `pg_trgm` extension and GIN trigram index on `segments.text`
- Foundation for fuzzy search fallback (index ready, query integration in future PR)

### Level 3a+3b: Semantic search with pgvector
**Infrastructure:**
- DB image: `postgres:15-alpine` → `pgvector/pgvector:pg15`
- Migration: `vector` extension, `embedding vector(384)` column, HNSW index
- Pipeline deps: `sentence-transformers`, `pgvector` added to pyproject.toml

**Embedding pipeline:**
- New `app/services/embed.py` — loads `all-MiniLM-L6-v2` (80MB, 384 dims, CPU)
- New `app/tasks/embed.py` — embeds all segments for an episode in batch (~3s)
- Pipeline: diarize → **embed** → infer (new step)
- New `POST /api/embed` endpoint for query embedding

**Hybrid search (flat view):**
- Runs FTS on speaker turns + vector similarity on segments in parallel
- Merges with Reciprocal Rank Fusion (RRF, K=60)
- Vector results boost FTS rankings and surface semantic-only matches
- Graceful degradation: falls back to FTS-only when no embeddings available

### Level 4 (future)
Documented in Issue #77 for future RAG implementation with local LLM.

## Test plan
- [x] 91/91 unit tests pass
- [x] `websearch_to_tsquery`: OR search returns more results, phrase search works
- [x] Embed API returns 384-dim vectors
- [x] Search degrades gracefully to FTS-only when no embeddings exist
- [ ] Embeddings populated after episode re-processing (embed step runs in pipeline)
- [ ] Hybrid search re-ranks results when embeddings are available

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)