### PR TITLE
fix: add podcast and episode links to search export formats

### DIFF
--- a/apps/web/src/app/search/print/page.tsx
+++ b/apps/web/src/app/search/print/page.tsx
@@ -29,6 +29,8 @@ export default async function PrintPage({
         return {
           episodeTitle: ep.episodeTitle,
           feedTitle: feed.feedTitle,
+          episodeUrl: ep.episodeUrl,
+          audioUrl: ep.audioUrl,
           mentionCount: ep.mentionCount,
           mentions: mentions.mentions,
         };
@@ -68,6 +70,10 @@ export default async function PrintPage({
           .matched { font-size: 13px; color: #111; margin: 0 0 4px 0; line-height: 1.6; background: #fef9c3; padding: 2px 4px; border-radius: 3px; }
           .matched b:first-child { color: #111; font-weight: 600; }
           .matched b { font-weight: 700; }
+          .episode-links { font-size: 12px; color: #6b7280; margin: 0 0 12px 0; }
+          .episode-links a { color: #3b82f6; text-decoration: none; }
+          .episode-links a:hover { text-decoration: underline; }
+          @media print { .episode-links a { color: #3b82f6; } .episode-links a::after { content: " (" attr(href) ")"; font-size: 9px; color: #9ca3af; } }
           .footer { border-top: 1px solid #d1d5db; padding-top: 12px; margin-top: 32px; text-align: center; font-size: 11px; color: #9ca3af; }
           .print-btn {
             position: fixed; top: 16px; right: 16px;
@@ -96,6 +102,14 @@ export default async function PrintPage({
             <p className="episode-meta">
               {ep.feedTitle} &middot; {ep.mentionCount} mention
               {ep.mentionCount !== 1 ? "s" : ""}
+            </p>
+            <p className="episode-links">
+              {ep.episodeUrl && (
+                <><a href={ep.episodeUrl} target="_blank" rel="noopener noreferrer">Episode page</a>{ep.audioUrl ? " · " : ""}</>
+              )}
+              {ep.audioUrl && (
+                <a href={ep.audioUrl} target="_blank" rel="noopener noreferrer">RSS audio</a>
+              )}
             </p>
 
             {ep.mentions.map((mention, mIdx) => (

--- a/apps/web/src/components/DownloadReportButton.tsx
+++ b/apps/web/src/components/DownloadReportButton.tsx
@@ -72,6 +72,8 @@ function generateMarkdown(
       const first = results[0];
       lines.push(`## ${first.episodeTitle ?? "Unknown Episode"}`);
       lines.push(`*${first.feedTitle ?? "Unknown Podcast"}*`);
+      if (first.episodeUrl) lines.push(`Episode: ${first.episodeUrl}`);
+      if (first.audioUrl) lines.push(`RSS audio: ${first.audioUrl}`);
       lines.push("");
       for (const r of results) {
         const speaker = r.speakerDisplay ?? r.speakerLabel ?? "";
@@ -87,6 +89,8 @@ function generateMarkdown(
       for (const ep of feed.episodes) {
         lines.push(`## ${ep.episodeTitle}`);
         lines.push(`*${feed.feedTitle}* — ${ep.mentionCount} mention${ep.mentionCount !== 1 ? "s" : ""}`);
+        if (ep.episodeUrl) lines.push(`Episode: ${ep.episodeUrl}`);
+        if (ep.audioUrl) lines.push(`RSS audio: ${ep.audioUrl}`);
         lines.push("");
       }
     }
@@ -133,6 +137,8 @@ function generatePlainText(
       lines.push("────────────────────────────────────────");
       lines.push(`${first.episodeTitle ?? "Unknown Episode"}`);
       lines.push(`${first.feedTitle ?? "Unknown Podcast"}`);
+      if (first.episodeUrl) lines.push(`Episode: ${first.episodeUrl}`);
+      if (first.audioUrl) lines.push(`RSS audio: ${first.audioUrl}`);
       lines.push("");
       for (const r of results) {
         const speaker = r.speakerDisplay ?? r.speakerLabel ?? "";
@@ -148,6 +154,8 @@ function generatePlainText(
       lines.push("");
       for (const ep of feed.episodes) {
         lines.push(`  ${ep.episodeTitle} — ${ep.mentionCount} mentions`);
+        if (ep.episodeUrl) lines.push(`  Episode: ${ep.episodeUrl}`);
+        if (ep.audioUrl) lines.push(`  RSS audio: ${ep.audioUrl}`);
       }
       lines.push("");
     }


### PR DESCRIPTION
## Summary
Add RSS feed and episode links to all three search export formats.

## Changes
- **Markdown (.md)**: Episode URL and RSS audio link shown below each episode heading
- **Plain text (.txt)**: Same links in plain text format
- **Print/PDF**: Clickable "Episode page" and "RSS audio" links below each episode header. Print CSS appends full URLs after link text for paper output.

## Test plan
- [x] Markdown export includes episode and RSS audio URLs
- [x] Plain text export includes episode and RSS audio URLs
- [x] Print view shows clickable links below episode titles
- [x] Print view renders URLs in parentheses when printed to PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)