### PR TITLE
Fix audio player progress updates and seek controls

### DIFF
--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -4,7 +4,7 @@ const createJestConfig = nextJest({ dir: "./" });
 
 const config = createJestConfig({
   testEnvironment: "jest-environment-jsdom",
-  setupFilesAfterFramework: ["<rootDir>/jest.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },

--- a/apps/web/src/components/AudioPlayer.tsx
+++ b/apps/web/src/components/AudioPlayer.tsx
@@ -22,34 +22,34 @@ export default function AudioPlayer() {
     const audio = audioRef.current;
     if (!audio || !state.src) return;
 
-    const onLoadedMetadata = () => {
-      if (state.startTime > 0) {
-        audio.currentTime = state.startTime;
-      }
-      audio.play().catch(() => {});
-    };
-
     audio.src = state.src;
-    audio.addEventListener("loadedmetadata", onLoadedMetadata, { once: true });
     audio.load();
-
-    return () => audio.removeEventListener("loadedmetadata", onLoadedMetadata);
   }, [state.src, state.startTime]);
 
-  useEffect(() => {
+  function handleLoadedMetadata() {
     const audio = audioRef.current;
     if (!audio) return;
 
-    const onTimeUpdate = () => setCurrentTime(audio.currentTime);
-    const onDurationChange = () => setDuration(audio.duration || 0);
+    if (state.startTime > 0) {
+      audio.currentTime = state.startTime;
+    }
 
-    audio.addEventListener("timeupdate", onTimeUpdate);
-    audio.addEventListener("durationchange", onDurationChange);
-    return () => {
-      audio.removeEventListener("timeupdate", onTimeUpdate);
-      audio.removeEventListener("durationchange", onDurationChange);
-    };
-  }, []);
+    setCurrentTime(audio.currentTime);
+    setDuration(audio.duration || 0);
+    audio.play().catch(() => {});
+  }
+
+  function handleTimeUpdate() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setCurrentTime(audio.currentTime);
+  }
+
+  function handleDurationChange() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setDuration(audio.duration || 0);
+  }
 
   function handleSeek(e: React.MouseEvent<HTMLDivElement>) {
     const audio = audioRef.current;
@@ -79,7 +79,13 @@ export default function AudioPlayer() {
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-card border-t border-border z-50 shadow-lg">
-      <audio ref={audioRef} preload="metadata" />
+      <audio
+        ref={audioRef}
+        preload="metadata"
+        onLoadedMetadata={handleLoadedMetadata}
+        onTimeUpdate={handleTimeUpdate}
+        onDurationChange={handleDurationChange}
+      />
 
       {/* Progress bar — always visible, clickable */}
       <div
@@ -125,7 +131,7 @@ export default function AudioPlayer() {
             >
               {state.isPlaying ? <Pause size={18} /> : <Play size={18} className="ml-0.5" />}
             </button>
-            <button onClick={() => skip(30)} className="text-muted-foreground hover:text-foreground transition-colors" title="Forward 30s">
+            <button onClick={() => skip(15)} className="text-muted-foreground hover:text-foreground transition-colors" title="Forward 15s">
               <SkipForward size={16} />
             </button>
           </div>

--- a/apps/web/tests/unit/audio-player.test.tsx
+++ b/apps/web/tests/unit/audio-player.test.tsx
@@ -1,0 +1,104 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+
+jest.mock("lucide-react", () => {
+  const Icon = ({ "data-testid": testId }: { "data-testid"?: string }) => (
+    <svg data-testid={testId} />
+  );
+
+  return {
+    Play: () => <Icon data-testid="play-icon" />,
+    Pause: () => <Icon data-testid="pause-icon" />,
+    Volume2: () => <Icon data-testid="volume2-icon" />,
+    VolumeX: () => <Icon data-testid="volumex-icon" />,
+    ChevronUp: () => <Icon data-testid="chevronup-icon" />,
+    ChevronDown: () => <Icon data-testid="chevrondown-icon" />,
+    SkipBack: () => <Icon data-testid="skipback-icon" />,
+    SkipForward: () => <Icon data-testid="skipforward-icon" />,
+  };
+});
+
+import AudioPlayer from "@/components/AudioPlayer";
+import { AudioPlayerProvider, useAudioPlayer } from "@/components/AudioPlayerContext";
+
+function TriggerPlayback() {
+  const { playEpisode } = useAudioPlayer();
+
+  return (
+    <button
+      onClick={() => playEpisode("ep-1", "episode.mp3", 5, "Episode 1", "Podcast 1")}
+      type="button"
+    >
+      Trigger playback
+    </button>
+  );
+}
+
+describe("AudioPlayer", () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLMediaElement.prototype, "play", {
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, "load", {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  test("shows elapsed time and duration after playback is triggered", async () => {
+    render(
+      <AudioPlayerProvider>
+        <TriggerPlayback />
+        <AudioPlayer />
+      </AudioPlayerProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger playback" }));
+
+    const audio = document.querySelector("audio");
+    expect(audio).not.toBeNull();
+
+    Object.defineProperty(audio, "duration", {
+      configurable: true,
+      value: 125,
+    });
+
+    await act(async () => {
+      fireEvent(audio!, new Event("loadedmetadata"));
+    });
+
+    Object.defineProperty(audio, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 65,
+    });
+
+    act(() => {
+      fireEvent(audio!, new Event("durationchange"));
+      fireEvent(audio!, new Event("timeupdate"));
+    });
+
+    expect(screen.getByText("1:05")).toBeInTheDocument();
+    expect(screen.getByText("2:05")).toBeInTheDocument();
+  });
+
+  test("uses symmetric 15 second seek controls", () => {
+    render(
+      <AudioPlayerProvider>
+        <TriggerPlayback />
+        <AudioPlayer />
+      </AudioPlayerProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger playback" }));
+
+    expect(screen.getByTitle("Back 15s")).toBeInTheDocument();
+    expect(screen.getByTitle("Forward 15s")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fix the embedded audio player so elapsed time, total duration, and progress update after playback starts
- normalize the embedded seek controls to symmetric `-15s` / `+15s`
- add a regression test for the player lifecycle and correct the Jest setup key so the web tests load `jest-dom` consistently

Closes #82

## Verification
- `npm test -- --runInBand tests/unit/audio-player.test.tsx`
- `npm run build`

## Notes
- `npm test -- --runInBand` still has pre-existing failures outside this PR:
  - `tests/unit/audio-route.test.ts`
  - `tests/unit/grouped-search.test.ts`
