### PR TITLE
fix: archive status persistence and safe raw audio deletion

### DIFF
--- a/apps/pipeline/alembic/versions/007_make_processed_at_timezone_aware.py
+++ b/apps/pipeline/alembic/versions/007_make_processed_at_timezone_aware.py
@@ -1,0 +1,28 @@
+"""Make episodes.processed_at timezone-aware.
+
+Aligns the column type with other timestamp columns (e.g. Job.created_at,
+Job.retry_at) that already use TIMESTAMP WITH TIME ZONE.
+"""
+
+from alembic import op
+
+
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE episodes "
+        "ALTER COLUMN processed_at TYPE TIMESTAMP WITH TIME ZONE "
+        "USING processed_at AT TIME ZONE 'UTC'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE episodes "
+        "ALTER COLUMN processed_at TYPE TIMESTAMP WITHOUT TIME ZONE"
+    )

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -101,7 +101,7 @@ class Episode(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
-    processed_at: Mapped[datetime | None] = mapped_column()
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     feed: Mapped["Feed | None"] = relationship("Feed", back_populates="episodes")
     segments: Mapped[list["Segment"]] = relationship(

--- a/apps/pipeline/app/tasks/archive.py
+++ b/apps/pipeline/app/tasks/archive.py
@@ -34,7 +34,6 @@ def archive_episode(episode_id: str) -> str:
         if settings.archive_audio and raw_path and raw_path.exists():
             try:
                 archived_path = _compress_audio(raw_path, episode_id)
-                raw_path.unlink()  # Delete raw file after successful compression
             except OSError as exc:
                 if "No space left on device" in str(exc) or getattr(exc, "errno", None) == 28:
                     update_episode(
@@ -46,10 +45,8 @@ def archive_episode(episode_id: str) -> str:
                     logger.error(
                         '"action": "archive_disk_full", "episode_id": "%s"', episode_id
                     )
-                    return episode_id  # Raw file is preserved, no retry
+                    return episode_id
                 raise
-        elif not settings.archive_audio and raw_path and raw_path.exists():
-            raw_path.unlink()
 
         # Write flat .txt transcript (PRD-04 S4.7: include inferred names)
         segments = (
@@ -84,6 +81,23 @@ def archive_episode(episode_id: str) -> str:
             transcript_path=transcript_path,
             processed_at=datetime.now(timezone.utc),
         )
+
+        # Verify status was persisted before deleting raw audio
+        db.expire_all()
+        verified = db.query(Episode).filter(Episode.id == episode_id).first()
+        if verified is None or verified.status != "done":
+            logger.error(
+                '"action": "archive_status_verify_failed", "episode_id": "%s", "status": "%s"',
+                episode_id, verified.status if verified else "NOT_FOUND",
+            )
+            raise RuntimeError(
+                f"Episode {episode_id} status update to 'done' did not persist "
+                f"(current status: {verified.status if verified else 'NOT_FOUND'})"
+            )
+
+        # Safe to delete raw audio now that status is confirmed
+        if raw_path and raw_path.exists():
+            raw_path.unlink()
 
         logger.info('"action": "archive_complete", "episode_id": "%s"', episode_id)
         return episode_id

--- a/apps/pipeline/app/tasks/helpers.py
+++ b/apps/pipeline/app/tasks/helpers.py
@@ -10,7 +10,11 @@ logger = logging.getLogger(__name__)
 def update_episode(db, episode_id: str, **kwargs) -> None:
     """Update episode fields with automatic updated_at timestamp."""
     kwargs.setdefault("updated_at", datetime.now(timezone.utc))
-    db.query(Episode).filter(Episode.id == episode_id).update(kwargs)
+    episode = db.query(Episode).filter(Episode.id == episode_id).first()
+    if episode is None:
+        raise RuntimeError(f"Episode {episode_id} not found for update")
+    for key, value in kwargs.items():
+        setattr(episode, key, value)
     db.commit()
 
 


### PR DESCRIPTION
## Summary
- Fix `update_episode` to use ORM-level attribute assignment instead of `Query.update()` bulk operation, which has known `synchronize_session` edge cases in SQLAlchemy 2.0+
- Move raw audio file deletion to **after** episode status is confirmed persisted as `done`, preventing permanent audio loss if the status update fails
- Add post-commit verification re-query before deleting raw files
- Make `processed_at` column timezone-aware (`TIMESTAMP WITH TIME ZONE`) to match other timestamp columns

## Test plan
- [ ] Deploy and process a new episode end-to-end — verify it reaches `done` status
- [ ] Verify raw audio is deleted only after status confirmation
- [ ] Run Alembic migration on existing DB — confirm `processed_at` values preserved correctly
- [ ] Run the DB recovery SQL for the 10 stuck episodes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)