### PR TITLE
fix: notification settings lost after page revisit

### DIFF
--- a/apps/web/src/app/api/notifications/settings/route.ts
+++ b/apps/web/src/app/api/notifications/settings/route.ts
@@ -4,7 +4,7 @@ import { PIPELINE_API } from "@/lib/pipeline";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const resp = await fetch(`${PIPELINE_API}/api/notifications/settings`);
+  const resp = await fetch(`${PIPELINE_API}/api/notifications/settings`, { cache: "no-store" });
   const data = await resp.json();
   return NextResponse.json(data, { status: resp.status });
 }


### PR DESCRIPTION
## Summary
- Added `cache: "no-store"` to the `fetch()` call in the notification settings GET proxy route
- Root cause: Next.js caches `fetch()` responses by default, even inside `force-dynamic` route handlers. The initial GET (returning empty settings) was cached, so revisiting the page always returned stale data regardless of saves.

## Changes
- `apps/web/src/app/api/notifications/settings/route.ts` — one-line fix: `{ cache: "no-store" }` on the pipeline fetch

## Testing
- Verified the pipeline API returns correct settings: `curl localhost:3000/api/notifications/settings` shows saved values with masked tokens
- Same pattern already used in the health check proxy route (`apps/web/src/app/api/pipeline/health/route.ts`)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)