### PR TITLE
fix: resolve host.docker.internal on Linux for email notifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/podlog
     ports:
       - "8000:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - audio_data:/data/audio
       - transcript_data:/data/transcripts
@@ -50,6 +52,8 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/podlog
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - audio_data:/data/audio
       - transcript_data:/data/transcripts


### PR DESCRIPTION
## Summary
- Added `extra_hosts: host.docker.internal:host-gateway` to `pipeline` and `worker` services in `docker-compose.yml`
- `host.docker.internal` only auto-resolves on Docker Desktop (Mac/Windows), not native Linux Docker — email notifications failed with `socket.gaierror: Name or service not known`

## Changes
- `docker-compose.yml` — 2 lines added to each of `pipeline` and `worker` services

## Testing
- Verified DNS resolution works inside container: `host.docker.internal` → `172.17.0.1`
- Verified test email sends successfully via local Postfix: `{"ok": true}`

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)