### PR TITLE
feat: better notification time formatting and avg stats

### DIFF
--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -15,6 +15,7 @@ from app.services.notifications import (
     _fmt_duration,
     _fmt_short_duration,
     _fmt_estimate,
+    compute_avg_processing_stats,
     estimate_queue_status,
     send_email,
     send_telegram,
@@ -78,6 +79,9 @@ class DigestData:
     items: list[DigestItem] = field(default_factory=list)
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
+    avg_transcribe_secs: float | None = None
+    avg_diarize_secs: float | None = None
+    avg_total_secs: float | None = None
 
 
 def format_digest_html(data: DigestData) -> str:
@@ -105,6 +109,21 @@ def format_digest_html(data: DigestData) -> str:
 
     est = _fmt_estimate(data.queue_estimated_secs)
 
+    avg_html = ""
+    if data.avg_transcribe_secs is not None or data.avg_diarize_secs is not None or data.avg_total_secs is not None:
+        avg_html = f"""\
+  <h3 style="margin-top: 20px; margin-bottom: 8px;">Avg Processing Time (all episodes)</h3>
+  <table style="border-collapse: collapse; width: 100%;">
+    <tr><td style="padding: 4px 12px; color: #666;">Avg transcription</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(data.avg_transcribe_secs)}</td></tr>
+    <tr style="background: #f9f9f9;">
+        <td style="padding: 4px 12px; color: #666;">Avg diarization</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(data.avg_diarize_secs)}</td></tr>
+    <tr><td style="padding: 4px 12px; color: #666;">Avg per episode</td>
+        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(data.avg_total_secs)}</td></tr>
+  </table>
+"""
+
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 600px; margin: 0 auto; padding: 16px;">
@@ -112,7 +131,7 @@ def format_digest_html(data: DigestData) -> str:
   <p style="color: #666;">{done_count} episodes processed, {failed_count} failed</p>
   <table style="border-collapse: collapse; width: 100%; margin-top: 12px;">
 {rows}  </table>
-  <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
+{avg_html}  <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
   <table style="border-collapse: collapse; width: 100%;">
     <tr><td style="padding: 4px 12px; color: #666;">Remaining</td>
         <td style="padding: 4px 12px;">{data.queue_remaining} episodes</td></tr>
@@ -145,6 +164,14 @@ def format_digest_telegram(data: DigestData) -> str:
                 f"❌ \"{item.episode_title}\" ({item.podcast_title}) — "
                 f"{item.error_class} after {item.retry_count}/{item.retry_max} retries"
             )
+
+    if data.avg_transcribe_secs is not None or data.avg_diarize_secs is not None or data.avg_total_secs is not None:
+        lines.append(
+            f"\n*Avg Processing Time (all episodes)*\n"
+            f"`Avg transcribe: {_fmt_short_duration(data.avg_transcribe_secs)}`\n"
+            f"`Avg diarize:    {_fmt_short_duration(data.avg_diarize_secs)}`\n"
+            f"`Avg per episode: {_fmt_short_duration(data.avg_total_secs)}`"
+        )
 
     est = _fmt_estimate(data.queue_estimated_secs)
     lines.append(f"\n*Queue:* {data.queue_remaining} remaining · Est. {est}")
@@ -235,6 +262,7 @@ def send_digest_if_due(now: datetime | None = None) -> None:
             return
 
         remaining, estimated = estimate_queue_status(db)
+        avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         items = []
         for row in unsent:
             payload = json.loads(row.payload)
@@ -262,6 +290,9 @@ def send_digest_if_due(now: datetime | None = None) -> None:
             items=items,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
+            avg_transcribe_secs=avg_t,
+            avg_diarize_secs=avg_d,
+            avg_total_secs=avg_total,
         )
 
         _send_digest(digest, ns)

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -27,6 +27,9 @@ class EpisodeDoneEvent(Event):
     total_duration_secs: float | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
+    avg_transcribe_secs: float | None = None
+    avg_diarize_secs: float | None = None
+    avg_total_secs: float | None = None
 
 
 @dataclass
@@ -42,6 +45,42 @@ class EpisodeFailedEvent(Event):
     retry_max: int = 3
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
+    avg_transcribe_secs: float | None = None
+    avg_diarize_secs: float | None = None
+    avg_total_secs: float | None = None
+
+
+def compute_avg_processing_stats(db: Session) -> tuple[float | None, float | None, float | None]:
+    """Compute average processing times across all completed episodes.
+
+    Returns (avg_transcribe_secs, avg_diarize_secs, avg_total_wall_secs).
+    Each value is None if no data is available for that metric.
+    """
+    done_episodes = (
+        db.query(Episode)
+        .filter(
+            Episode.status == "done",
+            Episode.processed_at.isnot(None),
+        )
+        .all()
+    )
+
+    if not done_episodes:
+        return None, None, None
+
+    transcribe_vals = [ep.transcribe_duration_secs for ep in done_episodes if ep.transcribe_duration_secs is not None]
+    diarize_vals = [ep.diarize_duration_secs for ep in done_episodes if ep.diarize_duration_secs is not None]
+    total_vals = [
+        (ep.processed_at - ep.created_at).total_seconds()
+        for ep in done_episodes
+        if ep.processed_at is not None and ep.created_at is not None
+    ]
+
+    avg_t = sum(transcribe_vals) / len(transcribe_vals) if transcribe_vals else None
+    avg_d = sum(diarize_vals) / len(diarize_vals) if diarize_vals else None
+    avg_total = sum(total_vals) / len(total_vals) if total_vals else None
+
+    return avg_t, avg_d, avg_total
 
 
 def estimate_queue_status(db: Session) -> tuple[int, float | None]:
@@ -98,24 +137,22 @@ def estimate_queue_status(db: Session) -> tuple[int, float | None]:
 
 
 def _fmt_duration(secs: float | int | None) -> str:
-    """Format seconds as h:mm:ss."""
+    """Format seconds with unit labels: 1h 30m 00s, 2m 30s, 0m 45s."""
     if secs is None:
         return "—"
     total = int(secs)
     h, remainder = divmod(total, 3600)
     m, s = divmod(remainder, 60)
-    return f"{h}:{m:02d}:{s:02d}"
+    if h > 0:
+        return f"{h}h {m:02d}m {s:02d}s"
+    return f"{m}m {s:02d}s"
 
 
 def _fmt_short_duration(secs: float | None) -> str:
-    """Format seconds as Xm Ys for shorter durations."""
+    """Format seconds as Xm Ys for shorter durations, Xh Ym Zs for longer."""
     if secs is None:
         return "—"
-    total = int(secs)
-    if total >= 3600:
-        return _fmt_duration(secs)
-    m, s = divmod(total, 60)
-    return f"{m}m {s:02d}s"
+    return _fmt_duration(secs)
 
 
 def _fmt_date(dt: datetime | None) -> str:
@@ -130,7 +167,37 @@ def _fmt_estimate(secs: float | None) -> str:
     return _fmt_duration(secs)
 
 
+def _fmt_avg_section_html(event) -> str:
+    """Render the HTML averages section if avg data is available."""
+    if event.avg_transcribe_secs is None and event.avg_diarize_secs is None and event.avg_total_secs is None:
+        return ""
+    return f"""\
+  <h3 style="margin-top: 20px; margin-bottom: 8px;">Avg Processing Time (all episodes)</h3>
+  <table style="border-collapse: collapse; width: 100%;">
+    <tr><td style="padding: 4px 12px; color: #666;">Avg transcription</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(event.avg_transcribe_secs)}</td></tr>
+    <tr style="background: #f9f9f9;">
+        <td style="padding: 4px 12px; color: #666;">Avg diarization</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(event.avg_diarize_secs)}</td></tr>
+    <tr><td style="padding: 4px 12px; color: #666;">Avg per episode</td>
+        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(event.avg_total_secs)}</td></tr>
+  </table>"""
+
+
+def _fmt_avg_section_telegram(event) -> str:
+    """Render the Telegram averages section if avg data is available."""
+    if event.avg_transcribe_secs is None and event.avg_diarize_secs is None and event.avg_total_secs is None:
+        return ""
+    return (
+        f"\n*Avg Processing Time (all episodes)*\n"
+        f"`Avg transcribe: {_fmt_short_duration(event.avg_transcribe_secs)}`\n"
+        f"`Avg diarize:    {_fmt_short_duration(event.avg_diarize_secs)}`\n"
+        f"`Avg per episode: {_fmt_short_duration(event.avg_total_secs)}`\n"
+    )
+
+
 def format_done_html(event: EpisodeDoneEvent) -> str:
+    avg_html = _fmt_avg_section_html(event)
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 520px; margin: 0 auto; padding: 16px;">
@@ -157,6 +224,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
     <tr><td style="padding: 4px 12px; color: #666;">Total</td>
         <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(event.total_duration_secs)}</td></tr>
   </table>
+{avg_html}
   <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
   <table style="border-collapse: collapse; width: 100%;">
     <tr><td style="padding: 4px 12px; color: #666;">Remaining</td>
@@ -172,6 +240,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
 
 
 def format_done_telegram(event: EpisodeDoneEvent) -> str:
+    avg_section = _fmt_avg_section_telegram(event)
     return (
         f"*✅ Episode Processed*\n\n"
         f"*Podcast:* {event.podcast_title}\n"
@@ -181,12 +250,14 @@ def format_done_telegram(event: EpisodeDoneEvent) -> str:
         f"*Processing Time*\n"
         f"`Transcription:  {_fmt_short_duration(event.transcribe_duration_secs)}`\n"
         f"`Diarization:    {_fmt_short_duration(event.diarize_duration_secs)}`\n"
-        f"`Total:          {_fmt_short_duration(event.total_duration_secs)}`\n\n"
+        f"`Total:          {_fmt_short_duration(event.total_duration_secs)}`\n"
+        f"{avg_section}\n"
         f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"
     )
 
 
 def format_failed_html(event: EpisodeFailedEvent) -> str:
+    avg_html = _fmt_avg_section_html(event)
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 520px; margin: 0 auto; padding: 16px;">
@@ -213,6 +284,7 @@ def format_failed_html(event: EpisodeFailedEvent) -> str:
     <tr><td style="padding: 4px 12px; color: #666;">Retries</td>
         <td style="padding: 4px 12px;">{event.retry_count}/{event.retry_max}</td></tr>
   </table>
+{avg_html}
   <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
   <table style="border-collapse: collapse; width: 100%;">
     <tr><td style="padding: 4px 12px; color: #666;">Remaining</td>
@@ -228,6 +300,7 @@ def format_failed_html(event: EpisodeFailedEvent) -> str:
 
 
 def format_failed_telegram(event: EpisodeFailedEvent) -> str:
+    avg_section = _fmt_avg_section_telegram(event)
     return (
         f"*❌ Episode Failed*\n\n"
         f"*Podcast:* {event.podcast_title}\n"
@@ -237,7 +310,8 @@ def format_failed_telegram(event: EpisodeFailedEvent) -> str:
         f"*Error*\n"
         f"`Class:    {event.error_class}`\n"
         f"`Details:  {event.error_message}`\n"
-        f"`Retries:  {event.retry_count}/{event.retry_max}`\n\n"
+        f"`Retries:  {event.retry_count}/{event.retry_max}`\n"
+        f"{avg_section}\n"
         f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"
     )
 

--- a/apps/pipeline/app/tasks/archive.py
+++ b/apps/pipeline/app/tasks/archive.py
@@ -14,7 +14,7 @@ from app.config import settings
 from app.database import SessionLocal
 from app.models import Episode, Segment, SpeakerName
 from app.services.events import bus
-from app.services.notifications import EpisodeDoneEvent, estimate_queue_status
+from app.services.notifications import EpisodeDoneEvent, compute_avg_processing_stats, estimate_queue_status
 from app.tasks.helpers import update_episode
 
 logger = logging.getLogger(__name__)
@@ -99,6 +99,7 @@ def archive_episode(episode_id: str) -> str:
 
         # Emit notification event
         remaining, estimated = estimate_queue_status(db)
+        avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         total_secs = (
             (verified.processed_at - episode.created_at).total_seconds()
             if verified.processed_at else None
@@ -114,6 +115,9 @@ def archive_episode(episode_id: str) -> str:
             total_duration_secs=total_secs,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
+            avg_transcribe_secs=avg_t,
+            avg_diarize_secs=avg_d,
+            avg_total_secs=avg_total,
         ))
 
         # Safe to delete raw audio now that status is confirmed

--- a/apps/pipeline/app/tasks/helpers.py
+++ b/apps/pipeline/app/tasks/helpers.py
@@ -4,7 +4,7 @@ import logging
 
 from app.models import Episode
 from app.services.events import bus
-from app.services.notifications import EpisodeFailedEvent, estimate_queue_status
+from app.services.notifications import EpisodeFailedEvent, compute_avg_processing_stats, estimate_queue_status
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ def mark_failed(db, episode_id: str, error_class: str, error_message: str) -> No
     episode = db.query(Episode).filter(Episode.id == episode_id).first()
     if episode and episode.retry_count >= episode.retry_max:
         remaining, estimated = estimate_queue_status(db)
+        avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         bus.emit(EpisodeFailedEvent(
             episode_id=episode_id,
             episode_title=episode.title or "",
@@ -49,4 +50,7 @@ def mark_failed(db, episode_id: str, error_class: str, error_message: str) -> No
             retry_max=episode.retry_max,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
+            avg_transcribe_secs=avg_t,
+            avg_diarize_secs=avg_d,
+            avg_total_secs=avg_total,
         ))

--- a/apps/pipeline/tests/unit/test_digest_formatting.py
+++ b/apps/pipeline/tests/unit/test_digest_formatting.py
@@ -81,3 +81,40 @@ def test_format_digest_html_unknown_queue_estimate():
     data.queue_estimated_secs = None
     html = format_digest_html(data)
     assert "unknown" in html.lower()
+
+
+def test_format_digest_html_contains_averages():
+    data = _make_digest_data()
+    data.avg_transcribe_secs = 125.0
+    data.avg_diarize_secs = 70.0
+    data.avg_total_secs = 220.0
+    html = format_digest_html(data)
+    assert "Avg" in html or "Average" in html
+    assert "2m 05s" in html  # avg transcribe
+    assert "1m 10s" in html  # avg diarize
+    assert "3m 40s" in html  # avg total
+
+
+def test_format_digest_telegram_contains_averages():
+    data = _make_digest_data()
+    data.avg_transcribe_secs = 125.0
+    data.avg_diarize_secs = 70.0
+    data.avg_total_secs = 220.0
+    md = format_digest_telegram(data)
+    assert "Avg" in md or "Average" in md
+    assert "2m 05s" in md
+    assert "3m 40s" in md
+
+
+def test_format_digest_html_duration_uses_unit_labels():
+    """Episode durations in digest should use unit labels like 1h 00m 00s."""
+    data = _make_digest_data()
+    html = format_digest_html(data)
+    assert "1h 00m 00s" in html  # first item: 3600s
+
+
+def test_format_digest_telegram_duration_uses_unit_labels():
+    """Episode durations in digest should use unit labels."""
+    data = _make_digest_data()
+    md = format_digest_telegram(data)
+    assert "1h 00m 00s" in md  # first item: 3600s

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -4,6 +4,9 @@ from datetime import datetime, timezone
 from app.services.notifications import (
     EpisodeDoneEvent,
     EpisodeFailedEvent,
+    _fmt_duration,
+    _fmt_short_duration,
+    _fmt_estimate,
     format_done_html,
     format_done_telegram,
     format_failed_html,
@@ -46,7 +49,7 @@ def test_format_done_html_contains_key_info():
     html = format_done_html(_make_done_event())
     assert "Tech Talk" in html
     assert "How AI Works" in html
-    assert "1:00:00" in html  # duration
+    assert "1h 00m 00s" in html  # duration with unit labels
     assert "2m 00s" in html or "2m 01s" in html  # transcribe time ~120s
     assert "1m 00s" in html  # diarize time ~60s
     assert "5" in html  # queue remaining
@@ -57,7 +60,7 @@ def test_format_done_telegram_contains_key_info():
     md = format_done_telegram(_make_done_event())
     assert "Tech Talk" in md
     assert "How AI Works" in md
-    assert "1:00:00" in md
+    assert "1h 00m 00s" in md  # duration with unit labels
     assert "5" in md
 
 
@@ -88,3 +91,87 @@ def test_format_done_telegram_unknown_queue_estimate():
     event.queue_estimated_secs = None
     md = format_done_telegram(event)
     assert "unknown" in md.lower()
+
+
+# --- Duration formatting with unit labels ---
+
+
+def test_fmt_duration_hours():
+    """h:mm:ss format should use unit labels like 1h 30m 00s."""
+    assert _fmt_duration(5400) == "1h 30m 00s"
+
+
+def test_fmt_duration_minutes_only():
+    """Durations under 1 hour should omit the hours component."""
+    assert _fmt_duration(150) == "2m 30s"
+
+
+def test_fmt_duration_seconds_only():
+    """Very short durations should show 0m Xs."""
+    assert _fmt_duration(45) == "0m 45s"
+
+
+def test_fmt_duration_none():
+    assert _fmt_duration(None) == "—"
+
+
+def test_fmt_duration_zero():
+    assert _fmt_duration(0) == "0m 00s"
+
+
+def test_fmt_short_duration_over_one_hour():
+    """Short duration formatter should also use unit labels for >= 1hr."""
+    assert _fmt_short_duration(3661.0) == "1h 01m 01s"
+
+
+def test_fmt_estimate_uses_unit_labels():
+    """Queue estimate should use unit labels, not bare h:mm:ss."""
+    result = _fmt_estimate(7200.0)
+    assert result == "2h 00m 00s"
+
+
+# --- Average processing stats in notifications ---
+
+
+def test_format_done_html_contains_averages():
+    event = _make_done_event()
+    event.avg_transcribe_secs = 130.0
+    event.avg_diarize_secs = 65.0
+    event.avg_total_secs = 210.0
+    html = format_done_html(event)
+    assert "Average" in html or "Avg" in html
+    assert "2m 10s" in html  # avg transcribe: 130s
+    assert "1m 05s" in html  # avg diarize: 65s
+    assert "3m 30s" in html  # avg total: 210s
+
+
+def test_format_done_telegram_contains_averages():
+    event = _make_done_event()
+    event.avg_transcribe_secs = 130.0
+    event.avg_diarize_secs = 65.0
+    event.avg_total_secs = 210.0
+    md = format_done_telegram(event)
+    assert "Avg" in md or "Average" in md
+    assert "2m 10s" in md
+    assert "1m 05s" in md
+    assert "3m 30s" in md
+
+
+def test_format_done_html_no_averages_when_none():
+    """When avg fields are None, averages section should show dash or be absent."""
+    event = _make_done_event()
+    event.avg_transcribe_secs = None
+    event.avg_diarize_secs = None
+    event.avg_total_secs = None
+    html = format_done_html(event)
+    # Should not crash, and should still contain the basic info
+    assert "Tech Talk" in html
+
+
+def test_format_failed_telegram_contains_averages():
+    event = _make_failed_event()
+    event.avg_transcribe_secs = 130.0
+    event.avg_diarize_secs = 65.0
+    event.avg_total_secs = 210.0
+    md = format_failed_telegram(event)
+    assert "Avg" in md or "Average" in md

--- a/apps/pipeline/tests/unit/test_notifications.py
+++ b/apps/pipeline/tests/unit/test_notifications.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from app.services.notifications import (
     EpisodeDoneEvent,
     EpisodeFailedEvent,
+    compute_avg_processing_stats,
     estimate_queue_status,
 )
 
@@ -26,6 +27,29 @@ def test_episode_done_event_fields():
     assert event.queue_remaining == 5
 
 
+def test_episode_done_event_has_avg_fields():
+    """EpisodeDoneEvent should accept avg processing stat fields."""
+    event = EpisodeDoneEvent(
+        episode_id="ep1",
+        episode_title="Test",
+        podcast_title="Pod",
+        avg_transcribe_secs=120.0,
+        avg_diarize_secs=60.0,
+        avg_total_secs=200.0,
+    )
+    assert event.avg_transcribe_secs == 120.0
+    assert event.avg_diarize_secs == 60.0
+    assert event.avg_total_secs == 200.0
+
+
+def test_episode_done_event_avg_fields_default_none():
+    """Avg fields should default to None for backward compat."""
+    event = EpisodeDoneEvent(episode_id="ep1")
+    assert event.avg_transcribe_secs is None
+    assert event.avg_diarize_secs is None
+    assert event.avg_total_secs is None
+
+
 def test_episode_failed_event_fields():
     event = EpisodeFailedEvent(
         episode_id="ep1",
@@ -42,6 +66,19 @@ def test_episode_failed_event_fields():
     )
     assert event.error_class == "OOM"
     assert event.retry_count == 3
+
+
+def test_episode_failed_event_has_avg_fields():
+    """EpisodeFailedEvent should accept avg processing stat fields."""
+    event = EpisodeFailedEvent(
+        episode_id="ep1",
+        avg_transcribe_secs=100.0,
+        avg_diarize_secs=50.0,
+        avg_total_secs=180.0,
+    )
+    assert event.avg_transcribe_secs == 100.0
+    assert event.avg_diarize_secs == 50.0
+    assert event.avg_total_secs == 180.0
 
 
 def test_estimate_queue_status_with_history():
@@ -81,6 +118,70 @@ def test_estimate_queue_status_with_history():
     assert remaining == 3
     # rate = 1800 / 3600 = 0.5, queued audio = 3600, estimate = 3600 * 0.5 = 1800
     assert estimated == 1800.0
+
+
+def test_compute_avg_processing_stats_with_data():
+    """Should compute averages across all done episodes."""
+    db = MagicMock()
+
+    ep1 = MagicMock(
+        transcribe_duration_secs=100.0,
+        diarize_duration_secs=50.0,
+        created_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        processed_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),  # 300s total
+    )
+    ep2 = MagicMock(
+        transcribe_duration_secs=200.0,
+        diarize_duration_secs=100.0,
+        created_at=datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
+        processed_at=datetime(2026, 1, 2, 0, 10, tzinfo=timezone.utc),  # 600s total
+    )
+
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+    query_mock.all.return_value = [ep1, ep2]
+    db.query.return_value = query_mock
+
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
+    assert avg_t == 150.0   # (100 + 200) / 2
+    assert avg_d == 75.0    # (50 + 100) / 2
+    assert avg_total == 450.0  # (300 + 600) / 2
+
+
+def test_compute_avg_processing_stats_no_data():
+    """Should return (None, None, None) when no done episodes exist."""
+    db = MagicMock()
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+    query_mock.all.return_value = []
+    db.query.return_value = query_mock
+
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
+    assert avg_t is None
+    assert avg_d is None
+    assert avg_total is None
+
+
+def test_compute_avg_processing_stats_partial_data():
+    """Should handle episodes with missing transcribe/diarize durations."""
+    db = MagicMock()
+
+    ep1 = MagicMock(
+        transcribe_duration_secs=100.0,
+        diarize_duration_secs=None,  # diarization failed
+        created_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        processed_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),
+    )
+
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+    query_mock.all.return_value = [ep1]
+    db.query.return_value = query_mock
+
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
+    assert avg_t == 100.0
+    assert avg_d is None  # no diarize data at all
+    assert avg_total == 300.0
 
 
 def test_estimate_queue_status_no_history():


### PR DESCRIPTION
## Summary
- Notification messages (Telegram, email, digest) now show durations with explicit unit labels (`1h 30m 00s`) instead of ambiguous `1:00:00` format
- Added average processing times (transcription, diarization, total per episode) computed across **all** completed episodes, shown in both immediate notifications and digests
- Averages section is omitted gracefully when no historical data exists yet

## Changes
- `notifications.py`: New `compute_avg_processing_stats()` queries all done episodes; updated `_fmt_duration` to use unit labels; added `_fmt_avg_section_html/telegram` helpers; added `avg_*` fields to both event dataclasses
- `digest.py`: `DigestData` gets avg fields; HTML and Telegram digest templates include averages section; `send_digest_if_due` computes and passes avg stats
- `archive.py` / `helpers.py`: Wire `compute_avg_processing_stats()` into event emission for done and failed notifications
- 15 new tests covering duration formatting, avg computation (with data, no data, partial data), and avg display in all template formats

## Test plan
- [x] All 196 unit tests pass
- [x] Verified Telegram output renders cleanly with unit labels and averages section
- [ ] Send a test notification via Settings > Telegram > Test after deploy to verify real formatting

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)