### PR TITLE
fix: isolate notification channels and fix queue display bugs

### DIFF
--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -373,22 +373,28 @@ def register_notification_handlers(bus: EventBus) -> None:
 
     def _send_immediate(event: Event, ns: dict) -> None:
         if ns.get("email_configured"):
-            send_email(
-                event,
-                to_addr=ns["notification_email_to"],
-                from_addr=ns.get("notification_email_from", "podlog@localhost"),
-                smtp_host=ns.get("smtp_host", "host.docker.internal"),
-                smtp_port=ns.get("smtp_port", 25),
-                smtp_user=ns.get("smtp_user"),
-                smtp_password=ns.get("smtp_password"),
-                use_tls=ns.get("smtp_use_tls", False),
-            )
+            try:
+                send_email(
+                    event,
+                    to_addr=ns["notification_email_to"],
+                    from_addr=ns.get("notification_email_from", "podlog@localhost"),
+                    smtp_host=ns.get("smtp_host", "host.docker.internal"),
+                    smtp_port=ns.get("smtp_port", 25),
+                    smtp_user=ns.get("smtp_user"),
+                    smtp_password=ns.get("smtp_password"),
+                    use_tls=ns.get("smtp_use_tls", False),
+                )
+            except Exception:
+                logger.exception('"action": "email_send_failed"')
         if ns.get("telegram_configured"):
-            send_telegram(
-                event,
-                bot_token=ns["telegram_bot_token"],
-                chat_id=ns["telegram_chat_id"],
-            )
+            try:
+                send_telegram(
+                    event,
+                    bot_token=ns["telegram_bot_token"],
+                    chat_id=ns["telegram_chat_id"],
+                )
+            except Exception:
+                logger.exception('"action": "telegram_send_failed"')
 
     def _handle_done(event: Event) -> None:
         ns = _get_settings()

--- a/apps/pipeline/tests/unit/test_digest_wiring.py
+++ b/apps/pipeline/tests/unit/test_digest_wiring.py
@@ -83,6 +83,70 @@ def test_done_handler_logs_event_in_digest_mode():
     mock_log.assert_called_once_with(event, mark_sent=False)
 
 
+def test_email_failure_does_not_block_telegram():
+    """If send_email raises, send_telegram should still be called."""
+    bus = EventBus()
+
+    from app.services.digest import register_notification_handlers
+
+    ns_both = {
+        "notification_frequency": "immediate",
+        "email_configured": True,
+        "telegram_configured": True,
+        "notification_email_to": "test@example.com",
+        "notification_email_from": "podlog@localhost",
+        "smtp_host": "localhost",
+        "smtp_port": 25,
+        "smtp_user": None,
+        "smtp_password": None,
+        "smtp_use_tls": False,
+        "telegram_bot_token": "fake-token",
+        "telegram_chat_id": "12345",
+    }
+
+    with patch("app.services.digest.get_notification_settings", return_value=ns_both), \
+         patch("app.services.digest.SessionLocal"), \
+         patch("app.services.digest.send_email", side_effect=Exception("SMTP error")), \
+         patch("app.services.digest.send_telegram") as mock_tg:
+        register_notification_handlers(bus)
+        event = MagicMock(spec=EpisodeDoneEvent)
+        bus._handlers[EpisodeDoneEvent][0](event)
+
+    mock_tg.assert_called_once_with(event, bot_token="fake-token", chat_id="12345")
+
+
+def test_telegram_failure_does_not_block_email():
+    """If send_telegram raises, send_email should still have been called."""
+    bus = EventBus()
+
+    from app.services.digest import register_notification_handlers
+
+    ns_both = {
+        "notification_frequency": "immediate",
+        "email_configured": True,
+        "telegram_configured": True,
+        "notification_email_to": "test@example.com",
+        "notification_email_from": "podlog@localhost",
+        "smtp_host": "localhost",
+        "smtp_port": 25,
+        "smtp_user": None,
+        "smtp_password": None,
+        "smtp_use_tls": False,
+        "telegram_bot_token": "fake-token",
+        "telegram_chat_id": "12345",
+    }
+
+    with patch("app.services.digest.get_notification_settings", return_value=ns_both), \
+         patch("app.services.digest.SessionLocal"), \
+         patch("app.services.digest.send_email") as mock_email, \
+         patch("app.services.digest.send_telegram", side_effect=Exception("Telegram error")):
+        register_notification_handlers(bus)
+        event = MagicMock(spec=EpisodeDoneEvent)
+        bus._handlers[EpisodeDoneEvent][0](event)
+
+    mock_email.assert_called_once()
+
+
 def test_failed_handler_logs_and_sends_in_digest_mode():
     """_handle_failed logs event and sends immediately when frequency is 'daily'."""
     bus = EventBus()

--- a/apps/web/src/app/api/queue/route.ts
+++ b/apps/web/src/app/api/queue/route.ts
@@ -53,6 +53,7 @@ export async function GET() {
       JOIN episodes e ON e.id = jq.episode_id
       LEFT JOIN feeds f ON f.id = e.feed_id
       WHERE jq.status = 'pending'
+        AND e.status NOT IN ('done', 'failed')
         AND NOT EXISTS (
           SELECT 1 FROM job_queue jq2
           WHERE jq2.episode_id = e.id AND jq2.status = 'picked'

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -411,7 +411,7 @@ export default function QueueStatus() {
       )}
 
       {/* Episode table */}
-      {!isEmpty && filtered.length === 0 && (q || stageFilter) && (
+      {!isEmpty && filtered.length === 0 && (q || stageFilter) && stageFilter !== "done" && (
         <div className="text-center py-8 text-muted-foreground text-sm">
           No episodes match {stageFilter ? `"${stageFilter}" filter` : "your search"}.
         </div>


### PR DESCRIPTION
## Summary

- **Notification isolation**: email and telegram delivery are now wrapped in independent try/except blocks. Previously, an email failure (e.g. `SMTPRecipientsRefused` from an empty recipient) would kill the entire handler and prevent the Telegram message from being sent.
- **Queue pending query**: excludes episodes already in `done`/`failed` status, so stale `job_queue` rows don't make completed episodes appear as pending.
- **Queue done filter**: clicking "Done" in the stage bar no longer shows a "no episodes match" message above the actual done episodes list.

## Test plan

- [x] 206 unit tests pass (including 2 new tests for notification isolation)
- [x] `test_email_failure_does_not_block_telegram` — verifies telegram sends even when email throws
- [x] `test_telegram_failure_does_not_block_email` — verifies email sends even when telegram throws
- [x] Live queue API verified: done episodes no longer appear in pending list
- [x] Worker rebuilt and running with the notification fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)