### PR TITLE
feat: host-level health monitoring with Telegram alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,14 @@ ZOMBIE_MIN_TIMEOUT_MINUTES=60  # floor when audio duration is unknown
 # TELEGRAM_BOT_TOKEN=
 # TELEGRAM_CHAT_ID=
 # NOTIFICATION_FREQUENCY=immediate  # immediate | daily | weekly
+
+# -- Health monitoring (host cron — see scripts/healthcheck.py) --
+# TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID above are used first;
+# if unset, the script falls back to UI-configured values from the DB.
+# HEALTH_CHECK_PIPELINE_URL=http://localhost:8000
+# HEALTH_CHECK_WEB_URL=http://localhost:3000
+# HEALTH_CHECK_DB_HOST=localhost
+# HEALTH_CHECK_DB_PORT=5432
+# HEALTH_CHECK_DB_USER=postgres
+# HEALTH_CHECK_DB_NAME=podlog
+# HEALTH_CHECK_ZOMBIE_THRESHOLD_MINUTES=60

--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,14 @@ shell-web:      ## Open shell in web container
 web:            ## Open web app in browser
 	open http://localhost:3000
 
+health-check:   ## Run health check once (requires python3, pg_isready, docker)
+	python3 scripts/healthcheck.py
+
+health-install: ## Install health check cron job (every 15 min)
+	bash scripts/healthcheck-install.sh
+
+health-uninstall: ## Remove health check cron job
+	crontab -l 2>/dev/null | grep -vF "healthcheck.py" | crontab - && echo "Removed healthcheck cron job"
+
 help:           ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/scripts/healthcheck-install.sh
+++ b/scripts/healthcheck-install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Install the Podlog health check as a cron job (every 15 minutes).
+# Run from the repo root: bash scripts/healthcheck-install.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HEALTHCHECK="$SCRIPT_DIR/healthcheck.py"
+LOG_FILE="${PODLOG_HEALTH_LOG:-/tmp/podlog-healthcheck.log}"
+
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 is required but not found."
+    exit 1
+fi
+
+if ! command -v pg_isready &>/dev/null; then
+    echo "Warning: pg_isready not found. Install postgresql-client for DB checks."
+fi
+
+CRON_LINE="*/15 * * * * python3 $HEALTHCHECK >> $LOG_FILE 2>&1"
+
+# Check if already installed
+if crontab -l 2>/dev/null | grep -qF "healthcheck.py"; then
+    echo "Cron job already exists. Updating..."
+    # Remove old entry, add new
+    crontab -l 2>/dev/null | grep -vF "healthcheck.py" | { cat; echo "$CRON_LINE"; } | crontab -
+else
+    # Append to existing crontab
+    (crontab -l 2>/dev/null; echo "$CRON_LINE") | crontab -
+fi
+
+echo "Installed cron job (every 15 minutes):"
+echo "  $CRON_LINE"
+echo ""
+echo "Logs: $LOG_FILE"
+echo ""
+echo "To uninstall: crontab -e and remove the podlog-healthcheck line"
+echo "To run manually: python3 $HEALTHCHECK"

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""
+Podlog system health monitor — runs via host cron every 15 minutes.
+
+Checks:
+  1. PostgreSQL (pg_isready)
+  2. Pipeline API (GET /api/health)
+  3. Web app (HTTP check on :3000)
+  4. Worker (docker compose ps)
+  5. Zombie jobs (picked_at older than threshold)
+
+Sends Telegram alerts only on state transitions (up->down, down->up) to
+avoid alert fatigue. Telegram credentials are resolved with the same
+priority as the rest of Podlog: .env values override DB (UI) values.
+
+Requires: python3, docker, pg_isready (from postgresql-client), curl.
+"""
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_DIR = SCRIPT_DIR.parent
+ENV_FILE = REPO_DIR / ".env"
+STATE_FILE = Path.home() / ".podlog-health-state.json"
+COMPOSE_PROJECT_DIR = REPO_DIR  # where docker-compose.yml lives
+
+# Services to check via docker compose ps
+DOCKER_SERVICES = ["db", "pipeline", "worker", "web"]
+
+# Defaults (overridden by .env)
+DEFAULT_PIPELINE_URL = "http://localhost:8000"
+DEFAULT_WEB_URL = "http://localhost:3000"
+DEFAULT_DB_HOST = "localhost"
+DEFAULT_DB_PORT = "5432"
+DEFAULT_DB_USER = "postgres"
+DEFAULT_ZOMBIE_THRESHOLD_MINUTES = 60
+DEFAULT_HTTP_TIMEOUT = 10  # seconds
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [healthcheck] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("podlog-healthcheck")
+
+
+# ---------------------------------------------------------------------------
+# .env parsing
+# ---------------------------------------------------------------------------
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a .env file into a dict. Ignores comments and blank lines."""
+    env = {}
+    if not path.exists():
+        return env
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        # Strip inline comments (only if preceded by whitespace)
+        for i, ch in enumerate(value):
+            if ch == "#" and i > 0 and value[i - 1] in (" ", "\t"):
+                value = value[:i]
+                break
+        value = value.strip().strip("'\"")
+        env[key] = value
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Telegram credentials resolution: .env > DB (UI) > None
+# ---------------------------------------------------------------------------
+
+def resolve_telegram_credentials(env: dict[str, str]) -> tuple[str | None, str | None]:
+    """Resolve Telegram bot token and chat ID.
+
+    Priority: .env values override DB/UI values. If .env has them, use those.
+    Otherwise, try to read from the DB notification_settings JSON blob.
+    """
+    bot_token = env.get("TELEGRAM_BOT_TOKEN") or None
+    chat_id = env.get("TELEGRAM_CHAT_ID") or None
+
+    if bot_token and chat_id:
+        return bot_token, chat_id
+
+    # Fall back to DB (UI-configured values)
+    db_token, db_chat_id = _read_telegram_from_db(env)
+    if not bot_token:
+        bot_token = db_token
+    if not chat_id:
+        chat_id = db_chat_id
+
+    return bot_token, chat_id
+
+
+def _read_telegram_from_db(env: dict[str, str]) -> tuple[str | None, str | None]:
+    """Read telegram credentials from the system_state table."""
+    password = env.get("POSTGRES_PASSWORD", "")
+    db_host = env.get("HEALTH_CHECK_DB_HOST", DEFAULT_DB_HOST)
+    db_port = env.get("HEALTH_CHECK_DB_PORT", DEFAULT_DB_PORT)
+    db_user = env.get("HEALTH_CHECK_DB_USER", DEFAULT_DB_USER)
+    db_name = env.get("HEALTH_CHECK_DB_NAME", "podlog")
+
+    try:
+        result = subprocess.run(
+            [
+                "psql",
+                "-h", db_host,
+                "-p", db_port,
+                "-U", db_user,
+                "-d", db_name,
+                "-t", "-A",
+                "-c", "SELECT value FROM system_state WHERE key = 'notification_settings'",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**os.environ, "PGPASSWORD": password},
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None, None
+        settings = json.loads(result.stdout.strip())
+        return settings.get("telegram_bot_token"), settings.get("telegram_chat_id")
+    except Exception as exc:
+        logger.debug("Could not read Telegram creds from DB: %s", exc)
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Health checks
+# ---------------------------------------------------------------------------
+
+def check_db(env: dict[str, str]) -> tuple[str, str]:
+    """Check PostgreSQL via pg_isready. Returns (status, detail)."""
+    password = env.get("POSTGRES_PASSWORD", "")
+    db_host = env.get("HEALTH_CHECK_DB_HOST", DEFAULT_DB_HOST)
+    db_port = env.get("HEALTH_CHECK_DB_PORT", DEFAULT_DB_PORT)
+    db_user = env.get("HEALTH_CHECK_DB_USER", DEFAULT_DB_USER)
+
+    try:
+        result = subprocess.run(
+            ["pg_isready", "-h", db_host, "-p", db_port, "-U", db_user],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**os.environ, "PGPASSWORD": password},
+        )
+        if result.returncode == 0:
+            return "up", "accepting connections"
+        return "down", result.stdout.strip() or result.stderr.strip() or "not ready"
+    except FileNotFoundError:
+        return "down", "pg_isready not found — install postgresql-client"
+    except Exception as exc:
+        return "down", str(exc)
+
+
+def check_http(name: str, url: str) -> tuple[str, str]:
+    """Check an HTTP endpoint. Returns (status, detail)."""
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=DEFAULT_HTTP_TIMEOUT) as resp:
+            if resp.status < 400:
+                return "up", f"HTTP {resp.status}"
+            return "down", f"HTTP {resp.status}"
+    except Exception as exc:
+        return "down", str(exc)
+
+
+def check_docker_service(service: str) -> tuple[str, str]:
+    """Check if a docker compose service is running. Returns (status, detail)."""
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "ps", "--format", "json", service],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=COMPOSE_PROJECT_DIR,
+        )
+        if result.returncode != 0:
+            return "down", result.stderr.strip() or "docker compose ps failed"
+
+        output = result.stdout.strip()
+        if not output:
+            return "down", "service not found in compose"
+
+        # docker compose ps --format json may return one JSON object per line
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                info = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            state = info.get("State", "").lower()
+            health = info.get("Health", "").lower()
+            if state == "running":
+                if health and health != "healthy":
+                    return "degraded", f"running but {health}"
+                return "up", f"running ({health or 'no healthcheck'})"
+            return "down", f"state={state}"
+
+        return "down", "could not parse service status"
+    except FileNotFoundError:
+        return "down", "docker not found"
+    except Exception as exc:
+        return "down", str(exc)
+
+
+def check_zombie_jobs(env: dict[str, str]) -> tuple[str, str]:
+    """Check for zombie jobs (picked for too long). Returns (status, detail)."""
+    password = env.get("POSTGRES_PASSWORD", "")
+    db_host = env.get("HEALTH_CHECK_DB_HOST", DEFAULT_DB_HOST)
+    db_port = env.get("HEALTH_CHECK_DB_PORT", DEFAULT_DB_PORT)
+    db_user = env.get("HEALTH_CHECK_DB_USER", DEFAULT_DB_USER)
+    db_name = env.get("HEALTH_CHECK_DB_NAME", "podlog")
+    threshold = int(env.get("HEALTH_CHECK_ZOMBIE_THRESHOLD_MINUTES", DEFAULT_ZOMBIE_THRESHOLD_MINUTES))
+
+    query = (
+        "SELECT jq.id, jq.task, jq.picked_at, e.title AS episode_title "
+        "FROM job_queue jq "
+        "LEFT JOIN episodes e ON e.id = jq.episode_id "
+        f"WHERE jq.status = 'picked' AND jq.picked_at < NOW() - INTERVAL '{threshold} minutes'"
+    )
+
+    try:
+        result = subprocess.run(
+            [
+                "psql",
+                "-h", db_host,
+                "-p", db_port,
+                "-U", db_user,
+                "-d", db_name,
+                "-t", "-A", "-F", "|",
+                "-c", query,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**os.environ, "PGPASSWORD": password},
+        )
+        if result.returncode != 0:
+            return "unknown", f"query failed: {result.stderr.strip()}"
+
+        lines = [l.strip() for l in result.stdout.strip().splitlines() if l.strip()]
+        if not lines:
+            return "clear", "no zombie jobs"
+
+        zombies = []
+        for line in lines:
+            parts = line.split("|")
+            job_id = parts[0] if len(parts) > 0 else "?"
+            task = parts[1] if len(parts) > 1 else "?"
+            picked_at = parts[2] if len(parts) > 2 else "?"
+            episode = parts[3] if len(parts) > 3 else "?"
+            zombies.append(f"job {job_id}: {task} (picked {picked_at}, episode: {episode})")
+
+        return "zombies", f"{len(zombies)} zombie job(s): " + "; ".join(zombies)
+    except FileNotFoundError:
+        return "unknown", "psql not found — install postgresql-client"
+    except Exception as exc:
+        return "unknown", str(exc)
+
+
+# ---------------------------------------------------------------------------
+# State tracking — only alert on transitions
+# ---------------------------------------------------------------------------
+
+def load_state() -> dict:
+    """Load previous health state from disk."""
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def save_state(state: dict) -> None:
+    """Persist health state to disk."""
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Telegram alerting
+# ---------------------------------------------------------------------------
+
+def send_telegram(bot_token: str, chat_id: str, message: str) -> bool:
+    """Send a Telegram message. Returns True on success."""
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    payload = json.dumps({
+        "chat_id": chat_id,
+        "text": message,
+        "parse_mode": "Markdown",
+    }).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status == 200
+    except Exception as exc:
+        logger.error("Telegram send failed: %s", exc)
+        return False
+
+
+def format_alert(transitions: list[tuple[str, str, str, str]], timestamp: str) -> str:
+    """Format state transitions into a Telegram message.
+
+    Each transition is (service, old_status, new_status, detail).
+    """
+    lines = [f"*Podlog Health Alert*\n_{timestamp}_\n"]
+
+    downs = [t for t in transitions if t[2] in ("down", "degraded", "zombies")]
+    ups = [t for t in transitions if t[2] in ("up", "clear")]
+
+    if downs:
+        for service, old_st, new_st, detail in downs:
+            if new_st == "zombies":
+                lines.append(f"  `{service}`: {detail}")
+            else:
+                icon = "DEGRADED" if new_st == "degraded" else "DOWN"
+                lines.append(f"  `{service}`: *{icon}* — {detail}")
+
+    if ups:
+        for service, old_st, new_st, detail in ups:
+            if service == "zombie_jobs":
+                lines.append(f"  `{service}`: cleared (was: {old_st})")
+            else:
+                lines.append(f"  `{service}`: recovered")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_checks(env: dict[str, str]) -> dict[str, tuple[str, str]]:
+    """Run all health checks. Returns {service: (status, detail)}."""
+    results = {}
+
+    # 1. Database via pg_isready
+    results["db"] = check_db(env)
+
+    # 2. Pipeline API
+    pipeline_url = env.get("HEALTH_CHECK_PIPELINE_URL", DEFAULT_PIPELINE_URL)
+    results["pipeline"] = check_http("pipeline", f"{pipeline_url}/api/health")
+
+    # 3. Web app
+    web_url = env.get("HEALTH_CHECK_WEB_URL", DEFAULT_WEB_URL)
+    results["web"] = check_http("web", web_url)
+
+    # 4. Worker via docker compose ps
+    results["worker"] = check_docker_service("worker")
+
+    # 5. Zombie jobs
+    results["zombie_jobs"] = check_zombie_jobs(env)
+
+    return results
+
+
+def main() -> None:
+    env = parse_env_file(ENV_FILE)
+    bot_token, chat_id = resolve_telegram_credentials(env)
+
+    if not bot_token or not chat_id:
+        logger.error(
+            "Telegram credentials not found in .env or DB. "
+            "Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID in .env or configure via the UI."
+        )
+        sys.exit(1)
+
+    results = run_checks(env)
+    prev_state = load_state()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    transitions = []
+    new_state = {}
+
+    for service, (status, detail) in results.items():
+        new_state[service] = status
+        old_status = prev_state.get(service)
+
+        # Normalize: treat None (first run) as "up"/"clear" so we don't alert on startup
+        if old_status is None:
+            if status in ("up", "clear"):
+                continue  # no transition, all good
+            # First run and service is already down — alert
+            transitions.append((service, "unknown", status, detail))
+        elif old_status != status:
+            transitions.append((service, old_status, status, detail))
+
+    save_state(new_state)
+
+    # Log current state
+    for service, (status, detail) in results.items():
+        logger.info("%s: %s (%s)", service, status, detail)
+
+    if transitions:
+        message = format_alert(transitions, now)
+        logger.info("State transitions detected, sending alert")
+        send_telegram(bot_token, chat_id, message)
+    else:
+        logger.info("No state transitions — no alert needed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_healthcheck.py
+++ b/scripts/test_healthcheck.py
@@ -1,0 +1,288 @@
+"""Unit tests for scripts/healthcheck.py — state transitions and alerting logic."""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import healthcheck
+
+
+# ---------------------------------------------------------------------------
+# parse_env_file
+# ---------------------------------------------------------------------------
+
+class TestParseEnvFile:
+    def test_basic_parsing(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "KEY1=value1\n"
+            "KEY2=value2\n"
+            "# comment\n"
+            "\n"
+            "KEY3=value with spaces\n"
+        )
+        result = healthcheck.parse_env_file(env_file)
+        assert result == {"KEY1": "value1", "KEY2": "value2", "KEY3": "value with spaces"}
+
+    def test_inline_comments(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("PORT=5432 # postgres port\n")
+        result = healthcheck.parse_env_file(env_file)
+        assert result["PORT"] == "5432"
+
+    def test_quoted_values(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('TOKEN="abc123"\nOTHER=\'def456\'\n')
+        result = healthcheck.parse_env_file(env_file)
+        assert result["TOKEN"] == "abc123"
+        assert result["OTHER"] == "def456"
+
+    def test_missing_file(self, tmp_path):
+        result = healthcheck.parse_env_file(tmp_path / "nonexistent")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+class TestStateTransitions:
+    """Verify that alerts fire only on state transitions, not steady state."""
+
+    def test_first_run_all_up_no_alert(self):
+        """First run with everything healthy should not trigger any alert."""
+        prev_state = {}
+        results = {
+            "db": ("up", "accepting connections"),
+            "pipeline": ("up", "HTTP 200"),
+            "web": ("up", "HTTP 200"),
+            "worker": ("up", "running (healthy)"),
+            "zombie_jobs": ("clear", "no zombie jobs"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert transitions == []
+
+    def test_first_run_service_down_alerts(self):
+        """First run with a service down should alert."""
+        prev_state = {}
+        results = {
+            "db": ("down", "not ready"),
+            "pipeline": ("up", "HTTP 200"),
+            "web": ("up", "HTTP 200"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("clear", "no zombie jobs"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 1
+        assert transitions[0][0] == "db"
+        assert transitions[0][2] == "down"
+
+    def test_up_to_down_transition(self):
+        """Service going from up to down should trigger alert."""
+        prev_state = {"db": "up", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "clear"}
+        results = {
+            "db": ("up", "ok"),
+            "pipeline": ("down", "connection refused"),
+            "web": ("up", "ok"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("clear", "no zombies"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 1
+        assert transitions[0] == ("pipeline", "up", "down", "connection refused")
+
+    def test_down_to_up_recovery(self):
+        """Service recovering should trigger a recovery alert."""
+        prev_state = {"db": "down", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "clear"}
+        results = {
+            "db": ("up", "accepting connections"),
+            "pipeline": ("up", "ok"),
+            "web": ("up", "ok"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("clear", "no zombies"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 1
+        assert transitions[0] == ("db", "down", "up", "accepting connections")
+
+    def test_steady_state_no_alert(self):
+        """No changes should not trigger any alert."""
+        prev_state = {"db": "up", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "clear"}
+        results = {
+            "db": ("up", "ok"),
+            "pipeline": ("up", "ok"),
+            "web": ("up", "ok"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("clear", "no zombies"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert transitions == []
+
+    def test_steady_state_all_down_no_repeat_alert(self):
+        """If everything was already down, don't re-alert."""
+        prev_state = {"db": "down", "pipeline": "down", "web": "down", "worker": "down", "zombie_jobs": "clear"}
+        results = {
+            "db": ("down", "not ready"),
+            "pipeline": ("down", "refused"),
+            "web": ("down", "refused"),
+            "worker": ("down", "exited"),
+            "zombie_jobs": ("clear", "no zombies"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert transitions == []
+
+    def test_zombie_detection_transition(self):
+        """Zombie jobs appearing should trigger alert."""
+        prev_state = {"db": "up", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "clear"}
+        results = {
+            "db": ("up", "ok"),
+            "pipeline": ("up", "ok"),
+            "web": ("up", "ok"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("zombies", "1 zombie job(s): job 42: transcribe (picked 2h ago)"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 1
+        assert transitions[0][0] == "zombie_jobs"
+        assert transitions[0][2] == "zombies"
+
+    def test_zombie_cleared_transition(self):
+        """Zombies clearing should trigger recovery alert."""
+        prev_state = {"db": "up", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "zombies"}
+        results = {
+            "db": ("up", "ok"),
+            "pipeline": ("up", "ok"),
+            "web": ("up", "ok"),
+            "worker": ("up", "running"),
+            "zombie_jobs": ("clear", "no zombie jobs"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 1
+        assert transitions[0] == ("zombie_jobs", "zombies", "clear", "no zombie jobs")
+
+    def test_multiple_transitions(self):
+        """Multiple services changing at once should all be reported."""
+        prev_state = {"db": "up", "pipeline": "up", "web": "up", "worker": "up", "zombie_jobs": "clear"}
+        results = {
+            "db": ("down", "not ready"),
+            "pipeline": ("down", "refused"),
+            "web": ("up", "ok"),
+            "worker": ("down", "exited"),
+            "zombie_jobs": ("clear", "no zombies"),
+        }
+        transitions = _compute_transitions(prev_state, results)
+        assert len(transitions) == 3
+        services = {t[0] for t in transitions}
+        assert services == {"db", "pipeline", "worker"}
+
+
+# ---------------------------------------------------------------------------
+# Alert formatting
+# ---------------------------------------------------------------------------
+
+class TestAlertFormatting:
+    def test_down_alert_contains_service(self):
+        transitions = [("pipeline", "up", "down", "connection refused")]
+        msg = healthcheck.format_alert(transitions, "2026-04-03 12:00:00 UTC")
+        assert "pipeline" in msg
+        assert "DOWN" in msg
+        assert "connection refused" in msg
+
+    def test_recovery_alert(self):
+        transitions = [("db", "down", "up", "accepting connections")]
+        msg = healthcheck.format_alert(transitions, "2026-04-03 12:00:00 UTC")
+        assert "db" in msg
+        assert "recovered" in msg
+
+    def test_zombie_alert(self):
+        transitions = [("zombie_jobs", "clear", "zombies", "2 zombie job(s): details")]
+        msg = healthcheck.format_alert(transitions, "2026-04-03 12:00:00 UTC")
+        assert "zombie_jobs" in msg
+        assert "2 zombie job(s)" in msg
+
+
+# ---------------------------------------------------------------------------
+# State file persistence
+# ---------------------------------------------------------------------------
+
+class TestStatePersistence:
+    def test_save_and_load(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(healthcheck, "STATE_FILE", state_file)
+
+        healthcheck.save_state({"db": "up", "pipeline": "down"})
+        loaded = healthcheck.load_state()
+        assert loaded == {"db": "up", "pipeline": "down"}
+
+    def test_load_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(healthcheck, "STATE_FILE", tmp_path / "nonexistent.json")
+        assert healthcheck.load_state() == {}
+
+    def test_load_corrupt_file(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        state_file.write_text("not json{{{")
+        monkeypatch.setattr(healthcheck, "STATE_FILE", state_file)
+        assert healthcheck.load_state() == {}
+
+
+# ---------------------------------------------------------------------------
+# Telegram credential resolution
+# ---------------------------------------------------------------------------
+
+class TestTelegramResolution:
+    def test_env_values_take_priority(self):
+        env = {"TELEGRAM_BOT_TOKEN": "env-token", "TELEGRAM_CHAT_ID": "env-chat"}
+        with patch.object(healthcheck, "_read_telegram_from_db", return_value=("db-token", "db-chat")) as mock_db:
+            token, chat_id = healthcheck.resolve_telegram_credentials(env)
+        assert token == "env-token"
+        assert chat_id == "env-chat"
+        # Should not even call DB since both env values are present
+        mock_db.assert_not_called()
+
+    def test_falls_back_to_db(self):
+        env = {}
+        with patch.object(healthcheck, "_read_telegram_from_db", return_value=("db-token", "db-chat")):
+            token, chat_id = healthcheck.resolve_telegram_credentials(env)
+        assert token == "db-token"
+        assert chat_id == "db-chat"
+
+    def test_partial_env_partial_db(self):
+        env = {"TELEGRAM_BOT_TOKEN": "env-token"}
+        with patch.object(healthcheck, "_read_telegram_from_db", return_value=(None, "db-chat")):
+            token, chat_id = healthcheck.resolve_telegram_credentials(env)
+        assert token == "env-token"
+        assert chat_id == "db-chat"
+
+    def test_no_credentials_anywhere(self):
+        env = {}
+        with patch.object(healthcheck, "_read_telegram_from_db", return_value=(None, None)):
+            token, chat_id = healthcheck.resolve_telegram_credentials(env)
+        assert token is None
+        assert chat_id is None
+
+
+# ---------------------------------------------------------------------------
+# Helper — extract transition logic from main() for testability
+# ---------------------------------------------------------------------------
+
+def _compute_transitions(prev_state: dict, results: dict[str, tuple[str, str]]) -> list[tuple[str, str, str, str]]:
+    """Replicate the transition detection logic from main()."""
+    transitions = []
+    for service, (status, detail) in results.items():
+        old_status = prev_state.get(service)
+        if old_status is None:
+            if status in ("up", "clear"):
+                continue
+            transitions.append((service, "unknown", status, detail))
+        elif old_status != status:
+            transitions.append((service, old_status, status, detail))
+    return transitions
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Standalone Python script (`scripts/healthcheck.py`) run via host cron every 15 minutes
- Checks: PostgreSQL (pg_isready), pipeline API (/api/health), web app (HTTP :3000), worker (docker compose ps), zombie jobs (picked_at > threshold)
- Telegram credentials: `.env` values override DB/UI-configured values; if `.env` has no Telegram vars, falls back to whatever the user set in the notification settings UI
- State tracking in `~/.podlog-health-state.json` — only alerts on transitions (up->down, down->up) to avoid spam
- Recovery messages when services come back up
- Makefile targets: `make health-check`, `make health-install`, `make health-uninstall`

## Files

| File | Purpose |
|------|---------|
| `scripts/healthcheck.py` | Main health check script (no project deps, stdlib only) |
| `scripts/healthcheck-install.sh` | Installs cron job (every 15 min) |
| `scripts/test_healthcheck.py` | 23 unit tests |
| `.env.example` | Documents new health check env vars |
| `Makefile` | New health-check/install/uninstall targets |

## Test plan

- [x] 23 new unit tests pass (state transitions, alert formatting, credential resolution, env parsing, state persistence)
- [x] 206 existing pipeline tests unaffected
- [ ] Manual: `make health-check` with services up/down
- [ ] Manual: `make health-install` to verify cron entry

Closes #118

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>