### PR TITLE
docs: health monitoring setup and postgresql-client prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Open **http://localhost:3000** — that's it.
 - [Docker](https://docs.docker.com/get-docker/) with [Compose V2](https://docs.docker.com/compose/install/)
 - A free [HuggingFace](https://huggingface.co) account with an access token
 - You **must accept the pyannote license** at [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) before diarization will work
+- `postgresql-client` (optional) — needed for host-level health monitoring (`sudo apt install postgresql-client`)
 
 ## Architecture
 
@@ -122,6 +123,7 @@ make build           # Rebuild Docker images
 make logs            # Follow logs for all services
 make test-unit       # Run unit tests (155 tests, ~2 seconds)
 make shell-db        # Open psql shell
+make health-install  # Install health monitoring cron (every 15 min)
 make help            # List all available commands
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,22 @@ The worker monitors running jobs and marks them as failed if they exceed expecte
 | `INFERENCE_ENABLED` | `true` | Whether to run spaCy NER-based speaker name inference after diarization. |
 | `SPACY_MODEL` | `en_core_web_lg` | spaCy model for named entity recognition. `en_core_web_lg` gives best results. |
 
+## Health Monitoring
+
+The host-level health check script (`scripts/healthcheck.py`) uses these settings. All are optional — defaults work for a standard Docker Compose setup.
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEALTH_CHECK_PIPELINE_URL` | `http://localhost:8000` | Pipeline API URL as seen from the host. |
+| `HEALTH_CHECK_WEB_URL` | `http://localhost:3000` | Web app URL as seen from the host. |
+| `HEALTH_CHECK_DB_HOST` | `localhost` | PostgreSQL host for `pg_isready` and zombie job queries. |
+| `HEALTH_CHECK_DB_PORT` | `5432` | PostgreSQL port. |
+| `HEALTH_CHECK_DB_USER` | `postgres` | PostgreSQL user. |
+| `HEALTH_CHECK_DB_NAME` | `podlog` | Database name. |
+| `HEALTH_CHECK_ZOMBIE_THRESHOLD_MINUTES` | `60` | Minutes a `picked` job must be running before it's flagged as a zombie. |
+
+The script uses `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from `.env` if present; otherwise falls back to the values configured in the web UI. Requires `postgresql-client` (`pg_isready`, `psql`) on the host.
+
 ## Advanced / Internal
 
 | Variable | Default | Description |

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,6 +131,9 @@ make test-e2e           Run Playwright e2e tests
 make shell-db           Open psql shell
 make shell-pipeline     Open pipeline container shell
 make shell-web          Open web container shell
+make health-check       Run health check once
+make health-install     Install health check cron job (every 15 min)
+make health-uninstall   Remove health check cron job
 make help               List all available commands
 ```
 

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -24,6 +24,15 @@ Podlog runs entirely on CPU. For detailed benchmarks and storage estimates by li
 
 3. **Accept the pyannote license** — visit [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) and click "Agree and access repository." Without this, speaker diarization will silently fail.
 
+4. **PostgreSQL client tools** (optional, for health monitoring) — needed by the host-level health check script:
+   ```bash
+   # Ubuntu/Debian
+   sudo apt install postgresql-client
+
+   # macOS
+   brew install libpq
+   ```
+
 ## Setup
 
 ```bash
@@ -69,13 +78,15 @@ No Redis, no Celery — the job queue is PostgreSQL-backed.
 ## Common Commands
 
 ```bash
-make up          # Start all services
-make down        # Stop all services
-make build       # Rebuild Docker images
-make logs        # Follow logs for all services
-make shell-db    # Open a psql shell
-make test-unit   # Run unit tests
-make help        # List all available commands
+make up              # Start all services
+make down            # Stop all services
+make build           # Rebuild Docker images
+make logs            # Follow logs for all services
+make shell-db        # Open a psql shell
+make test-unit       # Run unit tests
+make health-install  # Install health monitoring cron job (every 15 min)
+make health-check    # Run health check once (manual)
+make help            # List all available commands
 ```
 
 ---

--- a/docs/guide/09-notifications.md
+++ b/docs/guide/09-notifications.md
@@ -75,6 +75,74 @@ Configure how often you receive success notifications (failures are always sent 
 
 Set the frequency on the **General** tab in `/notifications`.
 
+## Health Monitoring
+
+Podlog includes a host-level health check script that monitors all services and sends Telegram alerts when something goes down (or recovers). It runs via cron on the host machine — not inside Docker — so it can detect when Docker services themselves are unhealthy.
+
+### What It Checks
+
+| Check | Method |
+|---|---|
+| **PostgreSQL** | `pg_isready` |
+| **Pipeline API** | HTTP GET `/api/health` |
+| **Web app** | HTTP check on port 3000 |
+| **Worker** | `docker compose ps` status |
+| **Zombie jobs** | DB query for jobs stuck in `picked` status beyond the configured threshold |
+
+### Setup
+
+1. **Install `postgresql-client`** (needed for `pg_isready` and zombie job queries):
+   ```bash
+   # Ubuntu/Debian
+   sudo apt install postgresql-client
+
+   # macOS
+   brew install libpq
+   ```
+
+2. **Configure Telegram credentials** — the health check uses the same Telegram bot token and chat ID as episode notifications. If `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are set in `.env`, those are used. Otherwise, the script falls back to whatever you configured in the web UI.
+
+3. **Install the cron job:**
+   ```bash
+   make health-install    # Installs cron entry (runs every 15 minutes)
+   ```
+
+4. **Verify it works:**
+   ```bash
+   make health-check      # Run once manually
+   ```
+
+### How Alerts Work
+
+The script tracks service state in `~/.podlog-health-state.json` and only sends Telegram messages on **state transitions**:
+
+- **Service goes down:** you get an alert with which service failed and why
+- **Service recovers:** you get a recovery message
+- **Zombie jobs detected:** you get notified about stuck jobs (even though the system will eventually catch and fail them, you'll know they exist)
+- **Steady state:** no repeated alerts (no spam if something stays down between checks)
+
+### Configuration
+
+All health check settings are optional in `.env`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEALTH_CHECK_PIPELINE_URL` | `http://localhost:8000` | Pipeline API URL as seen from the host |
+| `HEALTH_CHECK_WEB_URL` | `http://localhost:3000` | Web app URL as seen from the host |
+| `HEALTH_CHECK_DB_HOST` | `localhost` | PostgreSQL host for `pg_isready` |
+| `HEALTH_CHECK_DB_PORT` | `5432` | PostgreSQL port |
+| `HEALTH_CHECK_DB_USER` | `postgres` | PostgreSQL user |
+| `HEALTH_CHECK_DB_NAME` | `podlog` | Database name |
+| `HEALTH_CHECK_ZOMBIE_THRESHOLD_MINUTES` | `60` | Minutes before a `picked` job is considered a zombie |
+
+### Uninstall
+
+```bash
+make health-uninstall    # Removes the cron entry
+```
+
+Logs are written to `/tmp/podlog-healthcheck.log`.
+
 ## Environment Variables
 
 Notifications can also be configured via `.env` instead of the web UI. Values set in the UI override `.env` values. See [Configuration](10-configuration.md) for the full list.


### PR DESCRIPTION
## Summary

- Add `postgresql-client` as optional prerequisite in README and installation guide
- Document the health monitoring feature in the notification guide (setup, what it checks, alert behavior, configuration, uninstall)
- Add health check env vars to the configuration reference
- Add `make health-*` targets to the development guide Makefile reference
- Add `make health-install` to README common commands

## Files Changed

| File | What |
|------|------|
| `README.md` | Add `postgresql-client` prerequisite, `make health-install` command |
| `docs/guide/01-installation.md` | Add `postgresql-client` setup instructions, health check commands |
| `docs/guide/09-notifications.md` | New "Health Monitoring" section with full setup guide |
| `docs/configuration.md` | New "Health Monitoring" env vars table |
| `docs/development.md` | Add `health-check/install/uninstall` to Makefile targets |

## Test plan

- [x] All links reference existing pages
- [x] Env var names match what `scripts/healthcheck.py` actually reads
- [x] Install command verified: `sudo apt install postgresql-client`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>