### PR TITLE
fix: avg processing time and queue estimate inflated by queue wait

### DIFF
--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -70,10 +70,11 @@ def compute_avg_processing_stats(db: Session) -> tuple[float | None, float | Non
 
     transcribe_vals = [ep.transcribe_duration_secs for ep in done_episodes if ep.transcribe_duration_secs is not None]
     diarize_vals = [ep.diarize_duration_secs for ep in done_episodes if ep.diarize_duration_secs is not None]
+    # Total = transcribe + diarize (actual processing time, excludes queue wait)
     total_vals = [
-        (ep.processed_at - ep.created_at).total_seconds()
+        (ep.transcribe_duration_secs or 0) + (ep.diarize_duration_secs or 0)
         for ep in done_episodes
-        if ep.processed_at is not None and ep.created_at is not None
+        if ep.transcribe_duration_secs is not None or ep.diarize_duration_secs is not None
     ]
 
     avg_t = sum(transcribe_vals) / len(transcribe_vals) if transcribe_vals else None
@@ -112,18 +113,21 @@ def estimate_queue_status(db: Session) -> tuple[int, float | None]:
     if not recent:
         return remaining, None
 
-    # Compute duration-weighted processing rate
-    total_wall = 0.0
+    # Compute duration-weighted processing rate using actual processing time
+    # (transcribe + diarize), not wall clock which includes queue wait
+    total_processing = 0.0
     total_audio = 0.0
     for ep in recent:
-        wall_secs = (ep.processed_at - ep.created_at).total_seconds()
-        total_wall += wall_secs
+        processing_secs = (ep.transcribe_duration_secs or 0) + (ep.diarize_duration_secs or 0)
+        if processing_secs <= 0:
+            continue
+        total_processing += processing_secs
         total_audio += ep.duration_secs
 
     if total_audio == 0:
         return remaining, None
 
-    rate = total_wall / total_audio  # wall seconds per audio second
+    rate = total_processing / total_audio  # processing seconds per audio second
 
     # Sum duration of queued episodes
     queued_episodes = (

--- a/apps/pipeline/tests/unit/test_notifications.py
+++ b/apps/pipeline/tests/unit/test_notifications.py
@@ -86,13 +86,12 @@ def test_estimate_queue_status_with_history():
     db = MagicMock()
 
     # Mock recent completed episodes: 2 episodes, each 1800s audio, each took 900s to process
-    # Processing rate = 1800s total wall / 3600s total audio = 0.5 wall-per-audio-sec
+    # (600s transcribe + 300s diarize = 900s actual processing per episode)
+    # Processing rate = 1800s total processing / 3600s total audio = 0.5 per audio sec
     recent_done = MagicMock()
     recent_done.all.return_value = [
-        MagicMock(duration_secs=1800, created_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                  processed_at=datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc)),  # 900s
-        MagicMock(duration_secs=1800, created_at=datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                  processed_at=datetime(2026, 1, 1, 1, 15, tzinfo=timezone.utc)),  # 900s
+        MagicMock(duration_secs=1800, transcribe_duration_secs=600.0, diarize_duration_secs=300.0),
+        MagicMock(duration_secs=1800, transcribe_duration_secs=600.0, diarize_duration_secs=300.0),
     ]
 
     # Mock queued episodes: 3 episodes, each 1200s audio = 3600s total audio
@@ -116,25 +115,24 @@ def test_estimate_queue_status_with_history():
 
     remaining, estimated = estimate_queue_status(db)
     assert remaining == 3
-    # rate = 1800 / 3600 = 0.5, queued audio = 3600, estimate = 3600 * 0.5 = 1800
+    # rate = 1800 processing / 3600 audio = 0.5, queued audio = 3600, estimate = 3600 * 0.5 = 1800
     assert estimated == 1800.0
 
 
 def test_compute_avg_processing_stats_with_data():
-    """Should compute averages across all done episodes."""
+    """Should compute averages across all done episodes.
+
+    Total per episode = transcribe + diarize (not wall clock).
+    """
     db = MagicMock()
 
     ep1 = MagicMock(
         transcribe_duration_secs=100.0,
         diarize_duration_secs=50.0,
-        created_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-        processed_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),  # 300s total
     )
     ep2 = MagicMock(
         transcribe_duration_secs=200.0,
         diarize_duration_secs=100.0,
-        created_at=datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
-        processed_at=datetime(2026, 1, 2, 0, 10, tzinfo=timezone.utc),  # 600s total
     )
 
     query_mock = MagicMock()
@@ -145,7 +143,7 @@ def test_compute_avg_processing_stats_with_data():
     avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
     assert avg_t == 150.0   # (100 + 200) / 2
     assert avg_d == 75.0    # (50 + 100) / 2
-    assert avg_total == 450.0  # (300 + 600) / 2
+    assert avg_total == 225.0  # ((100+50) + (200+100)) / 2
 
 
 def test_compute_avg_processing_stats_no_data():
@@ -169,8 +167,6 @@ def test_compute_avg_processing_stats_partial_data():
     ep1 = MagicMock(
         transcribe_duration_secs=100.0,
         diarize_duration_secs=None,  # diarization failed
-        created_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-        processed_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),
     )
 
     query_mock = MagicMock()
@@ -181,7 +177,7 @@ def test_compute_avg_processing_stats_partial_data():
     avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
     assert avg_t == 100.0
     assert avg_d is None  # no diarize data at all
-    assert avg_total == 300.0
+    assert avg_total == 100.0  # transcribe only (diarize treated as 0)
 
 
 def test_estimate_queue_status_no_history():


### PR DESCRIPTION
## Summary

- `compute_avg_processing_stats()` and `estimate_queue_status()` were using `processed_at - created_at` (wall clock) to calculate processing time
- `created_at` is when the episode was added to the DB, not when processing started — if episodes sit in the queue for hours/days, that wait time was included
- Now uses `transcribe_duration_secs + diarize_duration_secs` which reflects actual work done

This fixes the 225h+ "Avg per episode" and inflated "Est. time left" in Telegram notifications.

## Test plan

- [x] 205 unit tests pass (1 pre-existing failure unrelated to this change)
- [x] Updated test expectations to match new calculation

Closes #118

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>