### PR TITLE
fix: repair test harness env vars and broken service

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,6 +27,7 @@ services:
     command: pytest tests/ -v --cov=app --cov-report=term-missing
     environment:
       DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      TEST_DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
       MOCK_RSS_URL: http://mock_rss/feed.xml
       HF_TOKEN: ${HF_TOKEN:-}
     depends_on:
@@ -35,12 +36,15 @@ services:
       mock_rss:
         condition: service_started
 
-  web_test:
-    build: ./apps/web
-    command: npx playwright test
-    environment:
-      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
-      PIPELINE_API_URL: http://pipeline_test:8000
-    depends_on:
-      db_test:
-        condition: service_healthy
+  # web_test: disabled until a pipeline_test service is added to the test stack.
+  # The Playwright tests require a running pipeline API which is not yet available
+  # in the test composition. See issue #104 finding #2.
+  # web_test:
+  #   build: ./apps/web
+  #   command: npx playwright test
+  #   environment:
+  #     DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+  #     PIPELINE_API_URL: http://pipeline_test:8000
+  #   depends_on:
+  #     db_test:
+  #       condition: service_healthy


### PR DESCRIPTION
## Summary
- Adds TEST_DATABASE_URL env var to test service in docker-compose.test.yml
- Disables broken web_test service that references nonexistent pipeline_test
- Integration tests now actually run instead of silently skipping
- Fixes finding #2 from #104

## Test plan
- [x] Unit tests still pass (218)
- [x] Integration tests attempt to run (not skip with "TEST_DATABASE_URL not set")