### PR TITLE
fix: type annotations, status comment, and embedding status tracking

### DIFF
--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -6,6 +6,7 @@ Changes vs PRD-01 v1.1:
 """
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from sqlalchemy import (
     BigInteger,
@@ -74,7 +75,7 @@ class Episode(Base):
     transcript_path: Mapped[str | None] = mapped_column(Text)
     language: Mapped[str | None] = mapped_column(Text)
 
-    # Job state machine: pending → downloading → transcribing → diarizing → archiving → done / failed
+    # Job state machine: pending → downloading → transcribing → diarizing → chunking → embedding → inferring → archiving → done / failed
     status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
 
     # Error tracking
@@ -129,7 +130,7 @@ class Segment(Base):
     start_time: Mapped[float] = mapped_column(Float, nullable=False)
     end_time: Mapped[float] = mapped_column(Float, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
-    embedding = mapped_column(Vector(384), nullable=True)
+    embedding: Mapped[Any | None] = mapped_column(Vector(384), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 
     episode: Mapped["Episode"] = relationship("Episode", back_populates="segments")
@@ -154,7 +155,7 @@ class Chunk(Base):
     end_time: Mapped[float] = mapped_column(Float, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
     segment_ids: Mapped[list] = mapped_column(ARRAY(BigInteger), nullable=False)
-    embedding = mapped_column(Vector(384), nullable=True)
+    embedding: Mapped[Any | None] = mapped_column(Vector(384), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
         default=lambda: datetime.now(timezone.utc),

--- a/apps/pipeline/app/tasks/embed.py
+++ b/apps/pipeline/app/tasks/embed.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 def embed_episode(episode_id: str) -> str:
     db = SessionLocal()
     try:
+        update_episode(db, episode_id, status="embedding")
+
         segments = (
             db.query(Segment)
             .filter(Segment.episode_id == episode_id)


### PR DESCRIPTION
## Summary
- Add `Mapped[Any | None]` type annotation to `Segment.embedding` and `Chunk.embedding` (SQLAlchemy 2.0 style)
- Update episode status state machine comment to include `chunking`, `embedding`, and `inferring` steps
- Add `update_episode(status="embedding")` call in `embed_episode()` so queue dashboard shows correct status

## Test plan
- [x] 218 unit tests pass

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)