### PR TITLE
feat: add Ollama service for RAG inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ ZOMBIE_REALTIME_FACTOR=1.5
 ZOMBIE_TIMEOUT_MULTIPLIER=2.0
 ZOMBIE_MIN_TIMEOUT_MINUTES=60  # floor when audio duration is unknown
 
+# -- Ollama (RAG) --
+OLLAMA_URL=http://ollama:11434  # Ollama API endpoint for LLM inference
+
 # -- Optional overrides --
 # DATABASE_URL=postgresql://postgres:changeme@db:5432/podlog
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build logs test test-unit test-e2e migrate shell-db shell-pipeline web
+.PHONY: up down build logs test test-unit test-e2e migrate shell-db shell-pipeline web ollama-pull
 
 up:             ## Start full stack
 	docker compose up -d
@@ -39,6 +39,9 @@ shell-web:      ## Open shell in web container
 
 web:            ## Open web app in browser
 	open http://localhost:3000
+
+ollama-pull:    ## Pull default Ollama model (Qwen2.5-3B Q4)
+	docker compose exec ollama ollama pull qwen2.5:3b
 
 health-check:   ## Run health check once (requires python3, pg_isready, docker)
 	python3 scripts/healthcheck.py

--- a/apps/pipeline/app/api/health.py
+++ b/apps/pipeline/app/api/health.py
@@ -10,10 +10,12 @@ States per service:
 """
 import logging
 
+import httpx
 from fastapi import APIRouter
 from pydantic import BaseModel
 from sqlalchemy import text
 
+from app.config import settings
 from app.database import SessionLocal
 from app.models import SystemState
 
@@ -57,6 +59,16 @@ def health_check() -> HealthResponse:
     finally:
         if db is not None:
             db.close()
+
+    # Ollama
+    try:
+        resp = httpx.get(f"{settings.ollama_url}/", timeout=3)
+        if resp.status_code == 200:
+            services.append(ServiceStatus(name="Ollama", status="OK"))
+        else:
+            services.append(ServiceStatus(name="Ollama", status="DEGRADED"))
+    except Exception:
+        services.append(ServiceStatus(name="Ollama", status="DEGRADED"))
 
     # Pipeline API is implicitly OK if this endpoint responds
     services.append(ServiceStatus(name="Pipeline API", status="OK"))

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -39,6 +39,9 @@ class Settings(BaseSettings):
     zombie_timeout_multiplier: float = 2.0  # zombie after 2× expected runtime
     zombie_min_timeout_minutes: int = 60  # floor when audio duration is unknown
 
+    # Ollama (RAG — issue #115)
+    ollama_url: str = "http://ollama:11434"
+
     # Host/guest inference (PRD-04 S9)
     inference_enabled: bool = True
     spacy_model: str = "en_core_web_lg"

--- a/apps/pipeline/tests/unit/test_api.py
+++ b/apps/pipeline/tests/unit/test_api.py
@@ -22,21 +22,27 @@ def _mock_prewarm_row(done: bool):
 
 
 class TestHealthEndpoint:
+    def _mock_ollama_ok(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        return patch("app.api.health.httpx.get", return_value=mock_resp)
+
     def test_ok_when_prewarm_done(self):
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = _mock_prewarm_row(True)
-        with patch("app.api.health.SessionLocal", return_value=mock_db):
+        with patch("app.api.health.SessionLocal", return_value=mock_db), self._mock_ollama_ok():
             resp = client.get("/api/health")
             assert resp.status_code == 200
             data = resp.json()
             assert data["status"] == "OK"
             assert isinstance(data["services"], list)
             assert any(s["name"] == "Worker" and s["status"] == "OK" for s in data["services"])
+            assert any(s["name"] == "Ollama" and s["status"] == "OK" for s in data["services"])
 
     def test_warming_up_when_prewarm_not_done(self):
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = _mock_prewarm_row(False)
-        with patch("app.api.health.SessionLocal", return_value=mock_db):
+        with patch("app.api.health.SessionLocal", return_value=mock_db), self._mock_ollama_ok():
             resp = client.get("/api/health")
             assert resp.status_code == 200
             data = resp.json()
@@ -46,10 +52,21 @@ class TestHealthEndpoint:
     def test_degraded_when_db_unreachable(self):
         mock_db = MagicMock()
         mock_db.execute.side_effect = Exception("Connection refused")
-        with patch("app.api.health.SessionLocal", return_value=mock_db):
+        with patch("app.api.health.SessionLocal", return_value=mock_db), self._mock_ollama_ok():
             resp = client.get("/api/health")
             assert resp.status_code == 200
             assert resp.json()["status"] == "DEGRADED"
+
+    def test_ollama_degraded_when_unreachable(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = _mock_prewarm_row(True)
+        with patch("app.api.health.SessionLocal", return_value=mock_db), \
+             patch("app.api.health.httpx.get", side_effect=Exception("Connection refused")):
+            resp = client.get("/api/health")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "DEGRADED"
+            assert any(s["name"] == "Ollama" and s["status"] == "DEGRADED" for s in data["services"])
 
 
 class TestFeedsEndpoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,23 @@ services:
       pipeline:
         condition: service_healthy  # Ensures migrations are done before worker writes to DB
 
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 6g
+
   web:
     build: ./apps/web
     ports:
@@ -84,3 +101,4 @@ volumes:
   audio_data:
   transcript_data:
   model_cache:
+  ollama_data:


### PR DESCRIPTION
## Summary
- Add Ollama container to `docker-compose.yml` with persistent volume, health check, and 6 GB memory limit
- Add `OLLAMA_URL` config var to pipeline settings (default `http://ollama:11434`)
- Add Ollama reachability check to `/api/health` endpoint
- Add `make ollama-pull` Makefile target to download default model (Qwen2.5-3B Q4)
- Document `OLLAMA_URL` in `.env.example`

## Test plan
- [x] 219 unit tests pass (includes new Ollama health check test)
- [ ] `docker compose up` starts Ollama service
- [ ] `make ollama-pull` downloads model
- [ ] `/api/health` reports Ollama status

Closes #115

🤖 Generated with [Claude Code](https://claude.ai/code)