### PR TITLE
feat: add RAG /api/ask endpoint with SSE streaming

### DIFF
--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -1,0 +1,97 @@
+"""
+POST /api/ask — RAG endpoint with SSE streaming (issue #116).
+
+Retrieves relevant transcript chunks, builds a citation-aware prompt,
+and streams the LLM response from Ollama as Server-Sent Events.
+
+SSE event types:
+  sources  — retrieved chunks (sent first)
+  token    — streamed LLM token
+  error    — error message
+  done     — stream complete
+"""
+import json
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.database import SessionLocal
+from app.services.rag import (
+    DEFAULT_MODEL,
+    build_prompt,
+    check_model_available,
+    chunks_to_sources,
+    retrieve_chunks,
+    stream_ollama_response,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class AskRequest(BaseModel):
+    question: str
+    model: str | None = None
+    feed_id: str | None = None
+
+
+def _sse_event(event: str, data: dict | str) -> str:
+    payload = json.dumps(data) if isinstance(data, dict) else data
+    return f"event: {event}\ndata: {payload}\n\n"
+
+
+async def _stream_ask(question: str, model: str, feed_id: str | None):
+    db = SessionLocal()
+    try:
+        # 1. Retrieve relevant chunks
+        chunks = retrieve_chunks(db, question, feed_id=feed_id)
+
+        if not chunks:
+            yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
+            yield _sse_event("done", {})
+            return
+
+        # 2. Send sources first
+        sources = chunks_to_sources(chunks)
+        yield _sse_event("sources", sources)
+
+        # 3. Build prompt and stream response
+        messages = build_prompt(question, chunks)
+
+        async for token in stream_ollama_response(messages, model=model):
+            yield _sse_event("token", {"content": token})
+
+        yield _sse_event("done", {})
+
+    except Exception as exc:
+        logger.error(
+            '"action": "ask_error", "question": "%s", "error": "%s"',
+            question[:100],
+            str(exc),
+        )
+        yield _sse_event("error", {"message": f"Error generating answer: {type(exc).__name__}"})
+        yield _sse_event("done", {})
+    finally:
+        db.close()
+
+
+@router.post("/ask")
+async def ask_endpoint(req: AskRequest):
+    model = req.model or DEFAULT_MODEL
+
+    # Validate model availability
+    if not await check_model_available(model):
+        return StreamingResponse(
+            iter([_sse_event("error", {"message": f"Model '{model}' is not available. Run: make ollama-pull"}),
+                  _sse_event("done", {})]),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    return StreamingResponse(
+        _stream_ask(req.question, model, req.feed_id),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/apps/pipeline/app/main.py
+++ b/apps/pipeline/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api import backfill, feeds, episodes, queue, health, embed, notifications
+from app.api import ask, backfill, feeds, episodes, queue, health, embed, notifications
 from app.services.events import bus
 from app.services.digest import register_notification_handlers
 
@@ -45,4 +45,5 @@ app.include_router(queue.router, prefix="/api")
 app.include_router(health.router, prefix="/api")
 app.include_router(embed.router, prefix="/api")
 app.include_router(notifications.router, prefix="/api")
+app.include_router(ask.router, prefix="/api")
 app.include_router(backfill.router, prefix="/api")

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -1,0 +1,178 @@
+"""
+RAG retrieval and prompt construction for the /api/ask endpoint (issue #116).
+
+Retrieves relevant transcript chunks by embedding similarity, builds a
+citation-aware prompt, and streams the LLM response from Ollama.
+"""
+import json
+import logging
+from dataclasses import dataclass
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.services.embed import embed_query
+
+logger = logging.getLogger(__name__)
+
+TOP_K = 8
+SIMILARITY_THRESHOLD = 0.3
+DEFAULT_MODEL = "qwen2.5:3b"
+
+SYSTEM_PROMPT = """You are a helpful assistant that answers questions about podcast transcripts.
+
+RULES:
+- Answer ONLY based on the provided transcript excerpts below.
+- If the excerpts don't contain enough information, say so clearly.
+- Cite your sources using the format [Episode Title, MM:SS] after each claim.
+- Be concise and direct."""
+
+
+@dataclass
+class ChunkResult:
+    chunk_id: int
+    episode_id: str
+    episode_title: str
+    speaker_label: str | None
+    start_time: float
+    end_time: float
+    text: str
+    similarity: float
+
+
+def retrieve_chunks(
+    db: Session,
+    question: str,
+    top_k: int = TOP_K,
+    feed_id: str | None = None,
+) -> list[ChunkResult]:
+    """Retrieve top-K chunks by cosine similarity to the question embedding."""
+    embedding = embed_query(question)
+    embedding_str = f"[{','.join(str(x) for x in embedding)}]"
+
+    feed_filter = "AND e.feed_id = :feed_id" if feed_id else ""
+    params: dict = {"embedding": embedding_str, "top_k": top_k, "threshold": SIMILARITY_THRESHOLD}
+    if feed_id:
+        params["feed_id"] = feed_id
+
+    query = text(f"""
+        SELECT
+            c.id AS chunk_id,
+            c.episode_id,
+            e.title AS episode_title,
+            c.speaker_label,
+            c.start_time,
+            c.end_time,
+            c.text,
+            1 - (c.embedding <=> :embedding::vector) AS similarity
+        FROM chunks c
+        JOIN episodes e ON c.episode_id = e.id
+        WHERE c.embedding IS NOT NULL
+            {feed_filter}
+        ORDER BY c.embedding <=> :embedding::vector
+        LIMIT :top_k
+    """)
+
+    rows = db.execute(query, params).fetchall()
+    return [
+        ChunkResult(
+            chunk_id=row.chunk_id,
+            episode_id=row.episode_id,
+            episode_title=row.episode_title or "Untitled Episode",
+            speaker_label=row.speaker_label,
+            start_time=row.start_time,
+            end_time=row.end_time,
+            text=row.text,
+            similarity=row.similarity,
+        )
+        for row in rows
+        if row.similarity >= SIMILARITY_THRESHOLD
+    ]
+
+
+def _format_timestamp(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}:{s:02d}"
+
+
+def build_prompt(question: str, chunks: list[ChunkResult]) -> list[dict]:
+    """Build chat messages for Ollama with retrieved context."""
+    context_parts = []
+    for i, c in enumerate(chunks, 1):
+        ts = _format_timestamp(c.start_time)
+        speaker = f" ({c.speaker_label})" if c.speaker_label else ""
+        context_parts.append(
+            f"[{i}] {c.episode_title}, {ts}{speaker}:\n{c.text}"
+        )
+
+    context = "\n\n".join(context_parts)
+    user_msg = f"""Transcript excerpts:
+
+{context}
+
+Question: {question}"""
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_msg},
+    ]
+
+
+def chunks_to_sources(chunks: list[ChunkResult]) -> list[dict]:
+    """Convert chunks to a serializable sources list for the SSE stream."""
+    return [
+        {
+            "chunk_id": c.chunk_id,
+            "episode_id": c.episode_id,
+            "episode_title": c.episode_title,
+            "speaker_label": c.speaker_label,
+            "start_time": c.start_time,
+            "end_time": c.end_time,
+            "timestamp": _format_timestamp(c.start_time),
+            "text": c.text[:200],
+            "similarity": round(c.similarity, 3),
+        }
+        for c in chunks
+    ]
+
+
+async def stream_ollama_response(
+    messages: list[dict],
+    model: str = DEFAULT_MODEL,
+):
+    """Stream chat completion from Ollama. Yields token strings."""
+    url = f"{settings.ollama_url}/api/chat"
+    payload = {
+        "model": model,
+        "messages": messages,
+        "stream": True,
+    }
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=120, write=10, pool=10)) as client:
+        async with client.stream("POST", url, json=payload) as resp:
+            if resp.status_code != 200:
+                body = await resp.aread()
+                raise RuntimeError(f"Ollama returned {resp.status_code}: {body.decode()}")
+            async for line in resp.aiter_lines():
+                if not line:
+                    continue
+                data = json.loads(line)
+                if content := data.get("message", {}).get("content"):
+                    yield content
+                if data.get("done"):
+                    return
+
+
+async def check_model_available(model: str) -> bool:
+    """Check if a model is available in Ollama."""
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(f"{settings.ollama_url}/api/tags")
+            if resp.status_code != 200:
+                return False
+            models = resp.json().get("models", [])
+            return any(m.get("name", "").startswith(model) for m in models)
+    except Exception:
+        return False

--- a/apps/pipeline/tests/unit/test_rag.py
+++ b/apps/pipeline/tests/unit/test_rag.py
@@ -1,0 +1,161 @@
+"""Unit tests for RAG retrieval, prompt construction, and SSE streaming."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.rag import (
+    ChunkResult,
+    build_prompt,
+    chunks_to_sources,
+    _format_timestamp,
+)
+
+client = TestClient(app)
+
+
+def _make_chunk(**overrides) -> ChunkResult:
+    defaults = {
+        "chunk_id": 1,
+        "episode_id": "ep-1",
+        "episode_title": "Test Episode",
+        "speaker_label": "SPEAKER_00",
+        "start_time": 65.0,
+        "end_time": 90.0,
+        "text": "This is a test transcript chunk.",
+        "similarity": 0.85,
+    }
+    defaults.update(overrides)
+    return ChunkResult(**defaults)
+
+
+class TestFormatTimestamp:
+    def test_under_one_minute(self):
+        assert _format_timestamp(45.0) == "0:45"
+
+    def test_over_one_minute(self):
+        assert _format_timestamp(125.7) == "2:05"
+
+    def test_zero(self):
+        assert _format_timestamp(0) == "0:00"
+
+    def test_exact_minute(self):
+        assert _format_timestamp(60.0) == "1:00"
+
+
+class TestBuildPrompt:
+    def test_builds_system_and_user_messages(self):
+        chunks = [_make_chunk(), _make_chunk(chunk_id=2, start_time=120.0, speaker_label=None)]
+        messages = build_prompt("What was discussed?", chunks)
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert "transcript" in messages[0]["content"].lower()
+        assert messages[1]["role"] == "user"
+        assert "What was discussed?" in messages[1]["content"]
+
+    def test_includes_chunk_metadata(self):
+        chunks = [_make_chunk(episode_title="My Podcast", start_time=65.0, speaker_label="SPEAKER_00")]
+        messages = build_prompt("test?", chunks)
+        user_content = messages[1]["content"]
+
+        assert "My Podcast" in user_content
+        assert "1:05" in user_content
+        assert "SPEAKER_00" in user_content
+
+    def test_empty_chunks(self):
+        messages = build_prompt("test?", [])
+        assert len(messages) == 2
+        assert "Question: test?" in messages[1]["content"]
+
+
+class TestChunksToSources:
+    def test_serializes_chunks(self):
+        chunks = [_make_chunk()]
+        sources = chunks_to_sources(chunks)
+
+        assert len(sources) == 1
+        s = sources[0]
+        assert s["chunk_id"] == 1
+        assert s["episode_id"] == "ep-1"
+        assert s["timestamp"] == "1:05"
+        assert s["similarity"] == 0.85
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 500
+        sources = chunks_to_sources([_make_chunk(text=long_text)])
+        assert len(sources[0]["text"]) == 200
+
+
+class TestAskEndpoint:
+    def test_returns_sse_stream(self):
+        mock_chunks = [_make_chunk()]
+
+        with (
+            patch("app.api.ask.check_model_available", new_callable=AsyncMock, return_value=True),
+            patch("app.api.ask.retrieve_chunks", return_value=mock_chunks),
+            patch("app.api.ask.build_prompt", return_value=[{"role": "user", "content": "test"}]),
+            patch("app.api.ask.chunks_to_sources", return_value=[{"chunk_id": 1}]),
+            patch("app.api.ask.stream_ollama_response") as mock_stream,
+        ):
+            async def fake_stream(*args, **kwargs):
+                yield "Hello"
+                yield " world"
+
+            mock_stream.return_value = fake_stream()
+
+            resp = client.post("/api/ask", json={"question": "What was discussed?"})
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")
+
+            events = _parse_sse(resp.text)
+            event_types = [e["event"] for e in events]
+            assert "sources" in event_types
+            assert "token" in event_types
+            assert "done" in event_types
+
+    def test_no_chunks_returns_error_event(self):
+        with (
+            patch("app.api.ask.check_model_available", new_callable=AsyncMock, return_value=True),
+            patch("app.api.ask.retrieve_chunks", return_value=[]),
+        ):
+            resp = client.post("/api/ask", json={"question": "Unknown topic"})
+            events = _parse_sse(resp.text)
+            assert any(e["event"] == "error" for e in events)
+
+    def test_model_unavailable_returns_error(self):
+        with patch("app.api.ask.check_model_available", new_callable=AsyncMock, return_value=False):
+            resp = client.post("/api/ask", json={"question": "test", "model": "nonexistent"})
+            events = _parse_sse(resp.text)
+            assert any(e["event"] == "error" for e in events)
+            error_data = next(e for e in events if e["event"] == "error")
+            assert "nonexistent" in error_data["data"]["message"]
+
+
+def _parse_sse(text: str) -> list[dict]:
+    """Parse SSE text into a list of {event, data} dicts."""
+    events = []
+    current_event = None
+    current_data = None
+
+    for line in text.strip().split("\n"):
+        if line.startswith("event: "):
+            current_event = line[7:]
+        elif line.startswith("data: "):
+            raw = line[6:]
+            try:
+                current_data = json.loads(raw)
+            except json.JSONDecodeError:
+                current_data = raw
+        elif line == "" and current_event is not None:
+            events.append({"event": current_event, "data": current_data})
+            current_event = None
+            current_data = None
+
+    # Handle last event if no trailing newline
+    if current_event is not None:
+        events.append({"event": current_event, "data": current_data})
+
+    return events


### PR DESCRIPTION
## Summary
- New `POST /api/ask` endpoint on pipeline API with SSE streaming
- Retrieves top-K transcript chunks by embedding cosine similarity (pgvector)
- Builds citation-aware prompt instructing LLM to cite `[Episode Title, MM:SS]`
- Streams response from Ollama (`/api/chat`) as SSE events: `sources` → `token` → `done`
- Model validation before streaming (returns error if model not pulled)
- Request supports optional `model` and `feed_id` filtering

### New files
- `app/services/rag.py` — retrieval, prompt construction, Ollama streaming
- `app/api/ask.py` — SSE endpoint
- `tests/unit/test_rag.py` — 12 tests

## Test plan
- [x] 231 unit tests pass (219 existing + 12 new)
- [ ] End-to-end: `curl -N -X POST http://localhost:8000/api/ask -H 'Content-Type: application/json' -d '{"question": "..."}'`

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)