### PR TITLE
docs: update CLAUDE.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Podlog is a self-hosted podcast transcription and search app. It downloads episodes from RSS feeds, transcribes them with Whisper, labels speakers with pyannote, and provides a web UI to search across all transcripts. Single user, local only, runs entirely in Docker.
 
-**Phase:** Core pipeline is operational. Episodes are being ingested, transcribed, diarized, chunked, and archived. 218+ unit tests pass. 9 Alembic migrations applied. Web UI serves search, queue dashboard, and feed management.
+**Phase:** Core pipeline is operational. Episodes are being ingested, transcribed, diarized, chunked, and archived. 240 pipeline + 81 web tests pass. 10 Alembic migrations applied. Web UI serves search, queue dashboard, feed management, and an Ask AI feature.
 
 ## Documentation
 
@@ -23,8 +23,8 @@ When making decisions, reference PRD sections (e.g. "per PRD-01 §5.4") rather t
 
 ```
 podlog/
-├── docker-compose.yml              # Production-like local stack (7 services)
-├── docker-compose.test.yml         # Test stack with db_test, mock_rss
+├── docker-compose.yml              # Production-like local stack (5 services)
+├── docker-compose.test.yml         # Test stack with db_test, mock_rss, test runner
 ├── .env.example                    # All config vars documented
 ├── Makefile                        # make up / down / build / test / etc.
 ├── apps/
@@ -34,17 +34,17 @@ podlog/
 │   │   │   ├── config.py           # pydantic-settings, all env vars
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments, speaker_names)
 │   │   │   ├── database.py         # Engine + session factory
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, notifications)
 │   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive)
-│   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment)
-│   │   │   └── scheduler.py        # Periodic feed polling
-│   │   ├── alembic/                # Database migrations
+│   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, notifications)
+│   │   │   └── worker.py           # Background job worker
+│   │   ├── alembic/                # Database migrations (10 applied)
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 14 (App Router)
-│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds
-│       ├── src/app/api/            # API routes: search, feeds, queue, audio serving, speaker rename
-│       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, etc.
-│       └── src/lib/                # db.ts (pg pool), search.ts (FTS query), timestamp.ts
+│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds, /ask, /search, /notifications
+│       ├── src/app/api/            # API routes: search, feeds, queue, audio, speaker rename, wizard, notifications
+│       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, SetupWizard, etc.
+│       └── src/lib/                # db.ts (pg pool), search.ts (FTS query), timestamp.ts, pipeline.ts
 └── prds/                           # Specifications and risk register
 ```
 
@@ -56,10 +56,11 @@ podlog/
 | Task queue | PostgreSQL-backed job queue | Sequential processing (concurrency=1) to avoid OOM |
 | Transcription | `openai/whisper-large-v3` via `transformers` | Explicit unload before diarization — mandatory |
 | Diarization | `pyannote/speaker-diarization-3.1` | Requires HF_TOKEN; graceful failure path |
+| LLM inference | Ollama (local) | RAG-based Ask AI feature; default model configurable via `OLLAMA_MODEL` |
 | Database | PostgreSQL 15 | FTS via `to_tsvector` + GIN index |
 | ORM | SQLAlchemy 2.0 + Alembic | Migrations auto-run on pipeline startup |
 | Web app | Next.js 14 (App Router) | `output: 'standalone'` for Docker |
-| Styling | Tailwind CSS + shadcn/ui | Dark mode via `class` strategy |
+| Styling | Tailwind CSS + shadcn/ui | Dark mode via `class` strategy; 12 shadcn/ui components installed |
 | Data fetching | TanStack React Query | Polling for queue status |
 | DB client (web) | `pg` (node-postgres) raw SQL | Direct PostgreSQL queries for search |
 
@@ -76,19 +77,19 @@ podlog/
 ```bash
 cp .env.example .env   # Edit: set POSTGRES_PASSWORD and HF_TOKEN
 make build             # Build Docker images
-make up                # Start all 7 services
+make up                # Start all 5 services
 make logs              # Follow logs
 make test-unit         # Run unit tests
 make shell-db          # Open psql shell
 ```
 
-Services: web (:3000), pipeline API (:8000).
+Services: web (:3000), pipeline API (:8000), ollama (:11434).
 
 ## Conventions
 
 - **Python style:** Ruff for linting, 100 char line length, type hints everywhere, structured JSON logging to stdout.
 - **TypeScript style:** ESLint + Next.js config, `@/*` path alias for imports, strict mode.
-- **Naming:** Display name is "Podlog". Database name is `podlog`. Docker services use short names (db, pipeline, worker, web).
+- **Naming:** Display name is "Podlog". Database name is `podlog`. Docker services use short names (db, pipeline, worker, ollama, web).
 - **Testing:**
   - Pipeline: `pytest` — unit tests mock DB/models, integration tests use a real test DB.
   - Web: `jest` + `@testing-library/react` for unit, `playwright` for e2e.
@@ -98,14 +99,17 @@ Services: web (:3000), pipeline API (:8000).
 ## Current State & What's Next
 
 **Done:**
-- Full project scaffold committed (88 files, all services defined)
-- SQLAlchemy models with all fields including `updated_at`
-- All pipeline task implementations (download, transcribe, diarize, chunk, embed, infer, archive)
-- All FastAPI endpoints (feeds, episodes, queue, health)
-- All Next.js pages, API routes, and components
-- Unit test stubs with real test logic for alignment, RSS, retry, timestamp, path validation
+- Full pipeline: ingest, download, transcribe, diarize, chunk, embed, infer, archive
+- All FastAPI endpoints (feeds, episodes, queue, health, ask, notifications, backfill)
+- All Next.js pages, API routes, and components (search, ask, queue, feeds, episodes, notifications)
+- 240 pipeline tests + 81 web tests passing
+- 10 Alembic migrations applied
+- 12 shadcn/ui components installed
+- Setup wizard for first-run onboarding
+- RAG-based Ask AI feature via Ollama
+- Speaker merge/rename UI
+- Notification settings
 
 **Not yet done:**
 - Integration and e2e test bodies (stubs exist, some skipped)
 - Full end-to-end pipeline smoke test in CI
-- shadcn/ui component library (using radix primitives directly)


### PR DESCRIPTION
## Summary
- Fixed service count (5, not 7), replaced stale scheduler.py with worker.py, added Ollama to tech stack/ports
- Updated test counts (240 + 81), migration count (10), noted 12 shadcn/ui components
- Rewrote Done/Not-yet-done to reflect current features (Ask AI, wizard, speaker merge, notifications)

## Test plan
- [x] Verified all facts against live codebase (docker-compose.yml, file tree, test suite output)
- [x] No code changes — documentation only

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)