### PR TITLE
docs: update all PRDs to match current codebase

### DIFF
--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-01 — Ingestion Pipeline  
-**Version:** 1.2
-**Status:** Draft
+**Version:** 1.3
+**Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.3 — Updated tech stack to reflect actual implementation: Celery+Redis replaced by PostgreSQL-backed job queue; Whisper via transformers replaced by WhisperX (CTranslate2); Celery Beat replaced by polling loop in worker.py; Flower removed. Added Ollama for RAG inference. Updated architecture diagram. Removed stale env vars (REDIS_URL, CELERY_CONCURRENCY). Moved semantic search and faster Whisper from Future to Done. Updated default model to large-v3-turbo.
 - v1.2 — Renamed project from PodSearch to Podlog. Added `updated_at` field to episodes table (prerequisite for GAP-01 zombie job detection). Added `DISK_HEADROOM_BYTES` environment variable for disk space pre-check (GAP-06). Database name changed from `podsearch` to `podlog`.
 - v1.1 — Added auto-retry logic (OQ-02 resolved), disk-full handling (OQ-03 resolved), diarization failure persistence (OQ-04 resolved), model pre-warm step, memory sequencing requirement for Whisper+pyannote, pipeline container healthcheck, path traversal mitigation for audio serving.
 
@@ -30,7 +31,6 @@ Podcast listeners who want to search, reference, or revisit specific moments in 
 
 ### Non-Goals (for this PRD)
 - Named speaker identification (deferred to post-MVP UI feature)
-- Semantic / vector search (deferred to V2)
 - Authentication or remote access (covered in PRD-02)
 - Public API surface (internal only)
 
@@ -87,11 +87,12 @@ Podcast listeners who want to search, reference, or revisit specific moments in 
 
 ### 5.4 Transcription (Speech-to-Text)
 
-- Model: `openai/whisper-large-v3` loaded via HuggingFace `transformers` library (open weights, downloadable on first run).
+- Model: WhisperX with CTranslate2 backend + wav2vec2 word-level alignment, optimized for CPU inference.
+- Default model: `large-v3-turbo` (configurable via `WHISPER_MODEL` env var: tiny|base|small|medium|large-v3|large-v3-turbo).
 - The model is downloaded once and cached in a persistent Docker volume.
-- **Memory management:** Whisper is loaded into memory for transcription and **explicitly unloaded** (removed from memory and `torch.cuda.empty_cache()` / `gc.collect()` called) before pyannote is loaded for diarization. The two models must never be resident in memory simultaneously. This is mandatory on CPU-only machines to avoid OOM.
+- **Memory management:** Whisper is loaded into memory for transcription and **explicitly unloaded** (removed from memory and `gc.collect()` called) before pyannote is loaded for diarization. The two models must never be resident in memory simultaneously. This is mandatory on CPU-only machines to avoid OOM.
 - Transcription produces: text segments, each with `start_time` (seconds), `end_time` (seconds), and `text`.
-- Word-level timestamps are stored where available (Whisper can produce these with `return_timestamps="word"`).
+- Word-level timestamps are produced via WhisperX's wav2vec2 alignment step.
 - Language detection is automatic; detected language is stored per episode.
 - Transcription progress (segment count / estimated total) is surfaced to the queue.
 
@@ -144,20 +145,9 @@ The flat file is always written on successful transcription, regardless of diari
 
 ### 5.9 Task Queue & Error Classification
 
-- Task runner: **Celery** with **Redis** as the broker and result backend.
-- Queue monitoring UI: **Flower** (accessible at `http://localhost:5555`).
+- Task runner: **PostgreSQL-backed job queue** (no external broker). Jobs are stored in the `episodes` table with status tracking.
 - Jobs are processed sequentially by default (one worker, concurrency=1) to avoid memory exhaustion on CPU-only machines running Whisper.
 - Job states: `PENDING` → `DOWNLOADING` → `TRANSCRIBING` → `DIARIZING` → `ARCHIVING` → `DONE` / `FAILED`.
-- Custom state metadata is pushed to Celery's result backend so the UI can poll it:
-  ```json
-  {
-    "stage": "DOWNLOADING",
-    "progress": 42,
-    "retry_count": 1,
-    "retry_max": 3,
-    "error_class": null
-  }
-  ```
 - **Error classification:** All failures are tagged with an `error_class` field stored in the database and surfaced in the queue UI:
 
 | `error_class`        | Meaning                               | Auto-retry?              |
@@ -174,9 +164,8 @@ The flat file is always written on successful transcription, regardless of diari
 
 ### 5.10 Scheduler
 
-- Library: **Celery Beat** (ships with Celery, no additional dependency).
-- A periodic task runs every 24 hours to poll all registered feeds for new episodes.
-- The schedule is configurable via environment variable `FEED_POLL_INTERVAL_HOURS` (default: 24).
+- A polling loop in `worker.py` runs every `FEED_POLL_INTERVAL_HOURS` (default: 24) to poll all registered feeds for new episodes.
+- No external scheduler dependency — the worker process handles both job processing and periodic polling.
 
 ### 5.11 Model Pre-Warm
 
@@ -196,7 +185,7 @@ The flat file is always written on successful transcription, regardless of diari
 | Reliability   | Failed jobs must not block the queue. Errors must be classified, logged, and surfaced.                                                              |
 | Disk space    | Compressed audio archive uses ~30 MB/hour. User is responsible for disk management.                                                                 |
 | Portability   | All services run in Docker. No host dependencies beyond Docker and Docker Compose.                                                                  |
-| Open source   | All code is MIT licensed. pyannote model requires user to accept its own license separately. HF_TOKEN is required and is the user's responsibility. |
+| Open source   | All code is O'Saasy licensed. pyannote model requires user to accept its own license separately. HF_TOKEN is required and is the user's responsibility. |
 | Idempotency   | Re-running ingestion on an already-processed episode is a no-op.                                                                                    |
 | Observability | All pipeline steps log structured JSON to stdout, captured by Docker. Error class is always included in log output.                                 |
 | Memory safety | Whisper and pyannote models must never be loaded simultaneously. Explicit unload + GC between stages is mandatory.                                  |
@@ -238,7 +227,7 @@ CREATE TABLE episodes (
     retry_max           INTEGER NOT NULL DEFAULT 3,
     has_diarization     BOOLEAN DEFAULT false,
     diarization_error   TEXT,          -- populated if diarization failed; null if succeeded or not yet attempted
-    celery_task_id      TEXT,
+    job_picked_at       TIMESTAMPTZ,   -- when the worker started processing
     created_at          TIMESTAMPTZ DEFAULT now(),
     updated_at          TIMESTAMPTZ DEFAULT now(),  -- updated on every status change; used for zombie job detection (GAP-01)
     processed_at        TIMESTAMPTZ,
@@ -281,12 +270,12 @@ CREATE TABLE speaker_names (
 | Component        | Choice                                       | Rationale                                    |
 | ---------------- | -------------------------------------------- | -------------------------------------------- |
 | Language         | Python 3.11                                  | Best ecosystem for ML/audio tooling          |
-| STT              | `openai/whisper-large-v3` via `transformers` | Best open-weight accuracy; CPU compatible    |
+| STT              | WhisperX (CTranslate2 + wav2vec2 alignment)  | Faster CPU inference; word-level timestamps  |
 | Diarization      | `pyannote/speaker-diarization-3.1`           | Industry standard; HuggingFace native        |
 | Audio processing | `ffmpeg` (via `ffmpeg-python`)               | Universal format support                     |
-| Task queue       | Celery 5 + Redis 7                           | Mature, well-documented; Beat for scheduling |
-| Queue UI         | Flower                                       | Ships with Celery; zero config               |
-| Database         | PostgreSQL 15                                | Full-text search built-in; ACID              |
+| Task queue       | PostgreSQL-backed job queue                   | No external broker needed; jobs in episodes table |
+| LLM inference    | Ollama (local)                               | RAG-based Ask AI feature; configurable model |
+| Database         | PostgreSQL 15 (pgvector)                     | Full-text search + vector embeddings; ACID   |
 | ORM              | SQLAlchemy 2.0 + Alembic                     | Migrations, async support                    |
 | Containerization | Docker + Docker Compose                      | Single `docker compose up` experience        |
 | Config           | `pydantic-settings`                          | Type-safe env var parsing                    |
@@ -299,20 +288,22 @@ CREATE TABLE speaker_names (
 ┌─────────────────────────────────────────────────────────┐
 │                    Docker Compose                        │
 │                                                         │
-│  ┌──────────┐    ┌──────────┐    ┌──────────────────┐  │
-│  │  Redis   │◄───│  Celery  │───►│   PostgreSQL     │  │
-│  │ (broker) │    │  Worker  │    │   (transcripts,  │  │
-│  └──────────┘    │          │    │    metadata)     │  │
-│                  │ pre-warm │    └──────────────────┘  │
-│  ┌──────────┐    │ download │                          │
-│  │  Flower  │    │ whisper  │    ┌──────────────────┐  │
-│  │:5555     │    │ [unload] │───►│  /data volume    │  │
-│  └──────────┘    │ pyannote │    │  audio/archive/  │  │
-│                  │ ffmpeg   │    │  transcripts/    │  │
-│  ┌──────────────┐└──────────┘    │  models/         │  │
-│  │  Celery Beat │     ▲          └──────────────────┘  │
-│  │ (scheduler)  │─────┘                                │
-│  └──────────────┘                                      │
+│                  ┌──────────┐    ┌──────────────────┐  │
+│                  │  Worker  │───►│   PostgreSQL 15   │  │
+│                  │          │    │   (pgvector)      │  │
+│                  │ pre-warm │    │   transcripts,    │  │
+│                  │ download │    │   metadata,       │  │
+│                  │ whisperx │    │   job queue       │  │
+│                  │ [unload] │    └──────────────────┘  │
+│                  │ pyannote │                           │
+│                  │ ffmpeg   │    ┌──────────────────┐  │
+│                  │ polling  │───►│  /data volume    │  │
+│                  └──────────┘    │  audio/archive/  │  │
+│                                  │  transcripts/    │  │
+│  ┌──────────┐                    │  models/         │  │
+│  │  Ollama  │                    └──────────────────┘  │
+│  │ :11434   │                                          │
+│  └──────────┘                                          │
 │                                                         │
 │  ┌──────────────────────────────────────────────────┐  │
 │  │  FastAPI (Internal API — consumed by PRD-02 UI)  │  │
@@ -323,8 +314,8 @@ CREATE TABLE speaker_names (
 ```
 
 **Data flow for a single episode:**
-1. Feed poller (Celery Beat) or user action → episode record inserted with `status=pending`
-2. Worker pre-warm complete → Celery worker picks up task
+1. Feed poller (worker polling loop) or user action → episode record inserted with `status=pending`
+2. Worker pre-warm complete → worker picks up task from PostgreSQL job queue
 3. Downloads audio → updates `status=downloading`; auto-retries on transient failures (max 3)
 4. `ffmpeg` converts to 16kHz WAV
 5. Whisper transcribes → segments written to DB → updates `status=transcribing`
@@ -358,10 +349,10 @@ GET    /api/health                   Health check — includes worker warm-up st
 
 ## 11. Feature Roadmap
 
-### MVP (Phase 1)
-- Single Celery worker processing one episode at a time
-- RSS feed addition and 24-hour polling
-- Whisper transcription with timestamps
+### MVP (Phase 1) — Done
+- Single worker processing one episode at a time (PostgreSQL-backed job queue)
+- RSS feed addition and 24-hour polling (worker polling loop)
+- WhisperX transcription with word-level timestamps (CTranslate2 backend)
 - Sequential model loading (Whisper unloaded before pyannote)
 - Model pre-warm step with `WARMING_UP` health state
 - pyannote diarization with SPEAKER_N labels; graceful failure path
@@ -369,21 +360,21 @@ GET    /api/health                   Health check — includes worker warm-up st
 - Flat .txt transcript file output (with/without speaker labels)
 - Audio archived to MP3 64kbps; disk-full handled gracefully
 - Auto-retry on transient access failures (max 3, exponential backoff)
-- Flower dashboard for queue visibility
 - FastAPI internal API
 - Docker Compose setup with single `docker compose up`
 
-### V1 (Phase 2)
-- Progress polling endpoint for live transcription progress in web UI
-- Configurable Whisper model size (tiny/base/small/medium/large-v3) via env var
-- Manual episode re-processing (force re-transcribe)
-- Feed pause/resume (stop polling without deleting)
+### V1 (Phase 2) — Done
+- Configurable Whisper model size (tiny/base/small/medium/large-v3/large-v3-turbo) via env var
+- Semantic search with embeddings (pgvector)
+- RAG-based Ask AI feature via Ollama
+- Chunking and embedding pipeline tasks
+- Notification system (email, Telegram)
+- Zombie job detection
 
 ### Future
-- Semantic search with embeddings (pgvector + sentence-transformers)
 - GPU support via Docker NVIDIA runtime flag
-- Faster Whisper inference via `faster-whisper` (CTranslate2 backend, 2-4x speedup on CPU)
 - Episode chapter detection
+- Feed pause/resume (stop polling without deleting)
 
 ---
 
@@ -434,18 +425,19 @@ GET    /api/health                   Health check — includes worker warm-up st
 
 ```env
 # Required
-DATABASE_URL=postgresql://postgres:password@db:5432/podlog
-REDIS_URL=redis://redis:6379/0
+POSTGRES_PASSWORD=changeme
 HF_TOKEN=hf_xxxxxxxxxxxx
 
 # Optional
-WHISPER_MODEL=large-v3             # tiny|base|small|medium|large-v3 (default: large-v3)
+WHISPER_MODEL=large-v3-turbo       # tiny|base|small|medium|large-v3|large-v3-turbo
+WHISPER_COMPUTE_TYPE=int8          # int8 (fast, recommended for CPU) | float32 (accurate)
+WHISPER_BATCH_SIZE=16              # WhisperX batched inference batch size
 DATA_DIR=/data
 ARCHIVE_AUDIO=true
 AUDIO_ARCHIVE_BITRATE=64k
 FEED_POLL_INTERVAL_HOURS=24
-CELERY_CONCURRENCY=1
 RETRY_MAX=3                        # Max auto-retries for transient failures (default: 3)
 RETRY_BACKOFF_BASE=30              # Base backoff seconds; actual = base * 2^(attempt-1)
 DISK_HEADROOM_BYTES=2147483648     # 2 GB minimum free space before download starts (GAP-06)
+OLLAMA_URL=http://ollama:11434     # Ollama API endpoint for LLM inference
 ```

--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -33,7 +33,7 @@ Once podcast transcripts are stored in the database (PRD-01), users need a simpl
 
 ### Non-Goals (V1)
 - User accounts or authentication (deferred to V2)
-- Semantic / vector search (deferred to V2)
+- Semantic / vector search (implemented — see search.ts grouped search)
 - Mobile app (web-only, but responsive)
 - Public deployment (local only in V1)
 - Search result grouping by episode (deferred to V1)
@@ -493,7 +493,6 @@ const { playEpisode } = useAudioPlayer();
 
 ### V2 (Phase 3)
 - **Authentication:** NextAuth.js + JWT, invite-only
-- **Semantic search:** `pgvector` + `sentence-transformers`
 - **Public deployment support:** Caddy reverse proxy, SSL, production Docker Compose profile
 
 ---

--- a/prds/PRD-03-infrastructure.md
+++ b/prds/PRD-03-infrastructure.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-03 — Infrastructure & DevOps  
-**Version:** 1.2
-**Status:** Draft
+**Version:** 1.3
+**Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.3 — Major update to match actual implementation: Celery/Redis/Flower/Beat removed; PostgreSQL-backed job queue with worker.py. Redis service and volumes removed from docker-compose. Single Dockerfile replaced by Dockerfile.control and Dockerfile.worker. Repo structure updated with actual files (removed scheduler.py, celery_app.py, SearchBar.tsx, SpeakerLabel.tsx; added worker.py and current component list). Test stack updated (no redis_test). License corrected to O'Saasy. Makefile updated with all current targets. Ollama service added. .env.example updated to match actual vars.
 - v1.2 — Renamed project from PodSearch to Podlog. Database name changed to `podlog`. Added `redis_test` service to `docker-compose.test.yml`. Changed `beat` dependency from `- worker` to `pipeline: service_healthy`. Added `CELERY_CONCURRENCY` env var interpolation in worker command. Added `DISK_HEADROOM_BYTES` to `.env.example`. Repository root directory renamed from `podsearch/` to `podlog/`.
 - v1.1 — Pipeline service healthcheck added; `web` dependency changed from `service_started` to `service_healthy` to close migration race condition; `docker-compose.yml` updated to reflect new `error_class`, `retry_count`, `diarization_error` schema fields; model pre-warm documented in worker startup.
 
@@ -28,55 +29,63 @@ podlog/
 ├── .env                            # gitignored
 ├── Makefile
 ├── README.md
-├── LICENSE                         # MIT
+├── LICENSE                         # O'Saasy
 │
 ├── apps/
 │   ├── pipeline/
-│   │   ├── Dockerfile
+│   │   ├── Dockerfile.control      # FastAPI API server
+│   │   ├── Dockerfile.worker       # ML worker (WhisperX, pyannote)
 │   │   ├── pyproject.toml
+│   │   ├── poetry.lock
 │   │   ├── alembic/
 │   │   │   ├── env.py
-│   │   │   └── versions/
+│   │   │   └── versions/           # 10 migrations
 │   │   ├── app/
 │   │   │   ├── main.py
 │   │   │   ├── config.py
 │   │   │   ├── database.py
-│   │   │   ├── models.py           # Includes error_class, retry_count, diarization_error
+│   │   │   ├── models.py
+│   │   │   ├── job_queue.py        # PostgreSQL-backed job queue
+│   │   │   ├── worker.py           # Background job worker + feed polling loop
 │   │   │   ├── api/
 │   │   │   │   ├── feeds.py
 │   │   │   │   ├── episodes.py
 │   │   │   │   ├── queue.py
-│   │   │   │   └── health.py       # Returns WARMING_UP | OK
+│   │   │   │   ├── health.py       # Returns WARMING_UP | OK
+│   │   │   │   ├── ask.py          # RAG-based Ask AI endpoint
+│   │   │   │   ├── notifications.py
+│   │   │   │   └── backfill.py
 │   │   │   ├── tasks/
-│   │   │   │   ├── celery_app.py
 │   │   │   │   ├── ingest.py
 │   │   │   │   ├── download.py     # Auto-retry logic with error classification
 │   │   │   │   ├── transcribe.py   # Explicit model unload after transcription
 │   │   │   │   ├── diarize.py      # Graceful failure path
+│   │   │   │   ├── chunk.py        # Transcript chunking for embeddings
+│   │   │   │   ├── embed.py        # Vector embedding generation
+│   │   │   │   ├── infer.py        # Host/guest inference
 │   │   │   │   ├── archive.py      # Disk-full handling
 │   │   │   │   └── prewarm.py      # Model pre-warm on worker startup
-│   │   │   ├── services/
-│   │   │   │   ├── rss.py
-│   │   │   │   ├── whisper.py
-│   │   │   │   ├── pyannote.py
-│   │   │   │   └── alignment.py    # Majority-overlap timestamp merging
-│   │   │   └── scheduler.py
+│   │   │   └── services/
+│   │   │       ├── rss.py
+│   │   │       ├── whisper.py      # WhisperX (CTranslate2 backend)
+│   │   │       ├── pyannote.py
+│   │   │       ├── alignment.py    # Majority-overlap timestamp merging
+│   │   │       ├── chunking.py
+│   │   │       ├── embed.py
+│   │   │       ├── rag.py          # Ollama RAG service
+│   │   │       ├── inference.py
+│   │   │       ├── notifications.py
+│   │   │       └── events.py
 │   │   └── tests/
 │   │       ├── fixtures/
-│   │       │   └── sample.mp3
 │   │       ├── unit/
-│   │       │   ├── test_rss.py
-│   │       │   ├── test_alignment.py
-│   │       │   ├── test_retry.py   # Error classification and retry logic
-│   │       │   └── test_api.py
 │   │       ├── integration/
-│   │       │   └── test_pipeline.py
 │   │       └── e2e/
-│   │           └── test_full_flow.py
 │   │
 │   └── web/
 │       ├── Dockerfile
 │       ├── package.json
+│       ├── package-lock.json
 │       ├── next.config.ts
 │       ├── tailwind.config.ts      # dark mode: 'class' strategy
 │       ├── src/
@@ -86,27 +95,39 @@ podlog/
 │       │   │   ├── podcasts/
 │       │   │   ├── episodes/[id]/
 │       │   │   ├── queue/
+│       │   │   ├── feeds/
+│       │   │   ├── ask/
+│       │   │   ├── search/
+│       │   │   ├── notifications/
 │       │   │   └── api/
-│       │   │       ├── search/
+│       │   │       ├── search/     # grouped + mentions routes
 │       │   │       ├── feeds/
 │       │   │       ├── queue/
+│       │   │       ├── wizard/
+│       │   │       ├── notifications/
 │       │   │       └── audio/
 │       │   │           └── [episodeId]/
 │       │   │               └── [filename]/
 │       │   │                   └── route.ts  # Path-validated audio serving
 │       │   ├── components/
-│       │   │   ├── ui/
-│       │   │   ├── SearchBar.tsx
-│       │   │   ├── SearchResult.tsx        # Includes diarization warning badge
-│       │   │   ├── AudioPlayer.tsx         # Global persistent player bar
-│       │   │   ├── AudioPlayerContext.tsx  # React context for player state
+│       │   │   ├── ui/             # 12 shadcn/ui components
+│       │   │   ├── Navbar.tsx
+│       │   │   ├── SearchResult.tsx
+│       │   │   ├── AudioPlayer.tsx
+│       │   │   ├── AudioPlayerContext.tsx
 │       │   │   ├── DarkModeToggle.tsx
-│       │   │   ├── QueueStatus.tsx         # Includes retry countdown, warm-up banner
-│       │   │   └── SpeakerLabel.tsx
+│       │   │   ├── QueueStatus.tsx
+│       │   │   ├── SetupWizard.tsx
+│       │   │   ├── SpeakerPanel.tsx
+│       │   │   ├── MergeBar.tsx
+│       │   │   ├── NotificationSettings.tsx
+│       │   │   └── ...
 │       │   └── lib/
 │       │       ├── db.ts
 │       │       ├── search.ts
-│       │       └── timestamp.ts            # Path-safe URL builder
+│       │       ├── pipeline.ts
+│       │       ├── timestamp.ts
+│       │       └── types.ts
 │       └── tests/
 │           ├── unit/
 │           └── e2e/
@@ -119,15 +140,15 @@ podlog/
 ### 3.1 Production-like Local Stack (`docker-compose.yml`)
 
 ```yaml
-version: "3.9"
-
 services:
   db:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     environment:
       POSTGRES_DB: podlog
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -136,36 +157,27 @@ services:
       timeout: 5s
       retries: 5
 
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-
   pipeline:
-    build: ./apps/pipeline
+    build:
+      context: ./apps/pipeline
+      dockerfile: Dockerfile.control
     command: >
       sh -c "alembic upgrade head &&
              uvicorn app.main:app --host 0.0.0.0 --port 8000"
     env_file: .env
     environment:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/podlog
-      REDIS_URL: redis://redis:6379/0
     ports:
       - "8000:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - audio_data:/data/audio
       - transcript_data:/data/transcripts
-      - model_cache:/root/.cache/huggingface
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
     healthcheck:
-      # Health endpoint returns 200 only after migrations complete and app is ready
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
       interval: 10s
       timeout: 5s
@@ -173,15 +185,16 @@ services:
       start_period: 30s
 
   worker:
-    build: ./apps/pipeline
-    # Pre-warm runs before the worker starts accepting jobs
+    build:
+      context: ./apps/pipeline
+      dockerfile: Dockerfile.worker
     command: >
-      sh -c "python -m app.tasks.prewarm &&
-             celery -A app.tasks.celery_app worker --loglevel=info --concurrency=${CELERY_CONCURRENCY:-1}"
+      sh -c "python -m app.tasks.prewarm && python -m app.worker"
     env_file: .env
     environment:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/podlog
-      REDIS_URL: redis://redis:6379/0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - audio_data:/data/audio
       - transcript_data:/data/transcripts
@@ -189,32 +202,25 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
       pipeline:
-        condition: service_healthy   # Ensures migrations are done before worker starts
+        condition: service_healthy  # Ensures migrations are done before worker writes to DB
 
-  beat:
-    build: ./apps/pipeline
-    command: celery -A app.tasks.celery_app beat --loglevel=info
-    env_file: .env
-    environment:
-      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/podlog
-      REDIS_URL: redis://redis:6379/0
-    depends_on:
-      pipeline:
-        condition: service_healthy
-
-  flower:
-    build: ./apps/pipeline
-    command: celery -A app.tasks.celery_app flower --port=5555
-    env_file: .env
-    environment:
-      REDIS_URL: redis://redis:6379/0
+  ollama:
+    image: ollama/ollama:latest
     ports:
-      - "5555:5555"
-    depends_on:
-      - redis
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 6g
 
   web:
     build: ./apps/web
@@ -229,22 +235,24 @@ services:
       db:
         condition: service_healthy
       pipeline:
-        condition: service_healthy   # Waits for migrations — prevents schema-not-found errors
+        condition: service_healthy  # Waits for migrations -- prevents schema-not-found errors
 
 volumes:
   postgres_data:
-  redis_data:
   audio_data:
   transcript_data:
   model_cache:
+  ollama_data:
 ```
 
-**Key changes from v1.0:**
-- `pipeline` now has a `healthcheck` that only passes after the app is ready (post-migration).
-- `web` depends on `pipeline` with `service_healthy` (was `service_started`). This closes the race condition where the web app could start before Alembic migrations completed.
-- `worker` depends on `pipeline` with `service_healthy`, ensuring the schema exists before the worker tries to write to the database.
-- `worker` command runs `prewarm.py` before starting Celery, downloading model weights on first run.
-- Migration (`alembic upgrade head`) runs in the `pipeline` startup command, before the FastAPI server starts.
+**5 services:** db, pipeline, worker, ollama, web. No external broker (Redis removed) — the job queue is PostgreSQL-backed. No Celery Beat or Flower.
+
+**Key design points:**
+- `pipeline` uses `Dockerfile.control` (lightweight FastAPI server); `worker` uses `Dockerfile.worker` (includes ML dependencies).
+- `pipeline` healthcheck ensures migrations complete before downstream services start.
+- `worker` runs `prewarm.py` then `worker.py` (which includes both job processing and feed polling).
+- `ollama` provides local LLM inference for the Ask AI feature.
+- `db` uses `pgvector/pgvector:pg15` for vector embedding support.
 
 ### 3.2 Dev Overrides (`docker-compose.override.yml` — gitignored)
 
@@ -282,45 +290,31 @@ services:
       timeout: 5s
       retries: 5
 
-  redis_test:
-    image: redis:7-alpine
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
   mock_rss:
     image: nginx:alpine
     volumes:
       - ./apps/pipeline/tests/fixtures:/usr/share/nginx/html:ro
 
   test:
-    build: ./apps/pipeline
+    build:
+      context: ./apps/pipeline
+      dockerfile: Dockerfile.worker
+      args:
+        INSTALL_DEV: "true"
     command: pytest tests/ -v --cov=app --cov-report=term-missing
     environment:
       DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
-      REDIS_URL: redis://redis_test:6379/0
+      TEST_DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
       MOCK_RSS_URL: http://mock_rss/feed.xml
       HF_TOKEN: ${HF_TOKEN:-}
     depends_on:
       db_test:
         condition: service_healthy
-      redis_test:
-        condition: service_healthy
       mock_rss:
         condition: service_started
-
-  web_test:
-    build: ./apps/web
-    command: npx playwright test
-    environment:
-      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
-      PIPELINE_API_URL: http://pipeline_test:8000
-    depends_on:
-      db_test:
-        condition: service_healthy
 ```
+
+**Note:** `web_test` service is currently disabled pending a pipeline_test service in the test stack (see issue #104).
 
 ---
 
@@ -334,12 +328,13 @@ POSTGRES_PASSWORD=changeme
 HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxx
 
 # ── Pipeline tuning ───────────────────────────────────────
-WHISPER_MODEL=large-v3
+WHISPER_MODEL=large-v3-turbo       # tiny|base|small|medium|large-v3|large-v3-turbo
+WHISPER_COMPUTE_TYPE=int8          # int8 (fast, recommended for CPU) | float32 (accurate)
+WHISPER_BATCH_SIZE=16              # WhisperX batched inference batch size
 DATA_DIR=/data
 ARCHIVE_AUDIO=true
 AUDIO_ARCHIVE_BITRATE=64k
 FEED_POLL_INTERVAL_HOURS=24
-CELERY_CONCURRENCY=1
 
 # ── Retry configuration ───────────────────────────────────
 RETRY_MAX=3                        # Max retries for transient failures
@@ -348,9 +343,11 @@ RETRY_BACKOFF_BASE=30              # Base backoff in seconds (30s → 2m → 10m
 # ── Disk space guard (GAP-06) ─────────────────────────────
 DISK_HEADROOM_BYTES=2147483648     # 2 GB minimum free space before download starts
 
+# ── Ollama (RAG) ─────────────────────────────────────────
+OLLAMA_URL=http://ollama:11434     # Ollama API endpoint for LLM inference
+
 # ── Optional overrides ────────────────────────────────────
-# DATABASE_URL=
-# REDIS_URL=redis://redis:6379/0
+# DATABASE_URL=postgresql://postgres:changeme@db:5432/podlog
 ```
 
 ---
@@ -358,75 +355,99 @@ DISK_HEADROOM_BYTES=2147483648     # 2 GB minimum free space before download sta
 ## 5. Makefile
 
 ```makefile
-.PHONY: up down build logs test test-unit test-e2e migrate shell-db shell-pipeline
+.PHONY: up down build logs test test-unit test-integration test-e2e migrate \
+        shell-db shell-pipeline shell-web web ollama-pull \
+        health-check health-install health-uninstall help
 
-up:             ## Start full stack
+up:               ## Start full stack
 	docker compose up -d
 
-down:           ## Stop all services
+down:             ## Stop all services
 	docker compose down
 
-build:          ## Rebuild all images
+build:            ## Rebuild all images
 	docker compose build
 
-logs:           ## Follow logs for all services
+logs:             ## Follow logs for all services
 	docker compose logs -f
 
-migrate:        ## Run database migrations manually (also runs on pipeline startup)
+migrate:          ## Run database migrations manually (also runs on pipeline startup)
 	docker compose exec pipeline alembic upgrade head
 
-test:           ## Run all tests
+test:             ## Run all tests (unit + e2e)
 	docker compose -f docker-compose.test.yml run --rm test
 	docker compose -f docker-compose.test.yml run --rm web_test
 
-test-unit:      ## Run unit tests only (fast)
+test-unit:        ## Run unit tests only (fast, no Docker required for ML models)
 	docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/ -v
 
-test-e2e:       ## Run E2E tests
+test-integration: ## Run integration tests (requires HF_TOKEN for pyannote)
+	...
+
+test-e2e:         ## Run Playwright end-to-end tests
 	docker compose -f docker-compose.test.yml run --rm web_test
 
-shell-db:       ## Open psql shell
+shell-db:         ## Open psql shell
 	docker compose exec db psql -U postgres podlog
 
-shell-pipeline: ## Open shell in pipeline container
+shell-pipeline:   ## Open shell in pipeline container
 	docker compose exec pipeline bash
 
-flower:         ## Open Flower in browser
-	open http://localhost:5555
+shell-web:        ## Open shell in web container
+	docker compose exec web sh
 
-web:            ## Open web app in browser
+web:              ## Open web app in browser
 	open http://localhost:3000
+
+ollama-pull:      ## Pull default Ollama model (Qwen2.5-3B Q4)
+	...
+
+health-check:     ## Run health check once
+	...
+
+health-install:   ## Install health check cron job (every 15 min)
+	...
+
+health-uninstall: ## Remove health check cron job
+	...
+
+help:             ## Show this help
+	...
 ```
 
 ---
 
 ## 6. Dockerfiles
 
-### `apps/pipeline/Dockerfile`
+### `apps/pipeline/Dockerfile.control`
+
+Lightweight image for the FastAPI API server. Does not include ML dependencies (WhisperX, pyannote).
 
 ```dockerfile
 FROM python:3.11-slim
-
-RUN apt-get update && apt-get install -y \
-    ffmpeg \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
+# curl for healthcheck, ffmpeg for audio processing
+RUN apt-get update && apt-get install -y ffmpeg curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-
-COPY pyproject.toml .
-RUN pip install --no-cache-dir poetry \
-    && poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-interaction
-
+COPY pyproject.toml poetry.lock .
+RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry install --no-dev --no-interaction
 COPY . .
-
-ENV HF_HOME=/root/.cache/huggingface
-
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
-**Note:** `curl` is added as a system dependency to support the Docker healthcheck (`curl -f http://localhost:8000/api/health`).
+### `apps/pipeline/Dockerfile.worker`
+
+Full ML image with WhisperX, pyannote, and all model dependencies. Larger image due to torch and audio ML libs.
+
+```dockerfile
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y ffmpeg curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY pyproject.toml poetry.lock .
+RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry install --no-interaction
+COPY . .
+ENV HF_HOME=/root/.cache/huggingface
+CMD ["python", "-m", "app.worker"]
+```
 
 ### `apps/web/Dockerfile`
 
@@ -532,7 +553,6 @@ make up
 
 # 4. Open the app
 open http://localhost:3000
-open http://localhost:5555   # Flower queue monitor
 
 # On first run:
 # - Migrations run automatically in the pipeline container
@@ -545,7 +565,7 @@ open http://localhost:5555   # Flower queue monitor
 
 ## 10. Open Source Considerations
 
-- All code: **MIT License**
+- All code: **O'Saasy License**
 - Whisper weights: MIT (OpenAI)
 - pyannote models: Non-commercial research license (user must accept independently)
 - Users are responsible for copyright compliance with podcast audio

--- a/prds/PRD-04-host-guest-inference.md
+++ b/prds/PRD-04-host-guest-inference.md
@@ -1,6 +1,6 @@
 # PRD-04: Host & Guest Inference from Episode Metadata
 
-**Project:** PodSearch — Self-hosted Podcast Transcription & Search  
+**Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-04 — Host & Guest Inference  
 **Version:** 1.1  
 **Status:** Draft  


### PR DESCRIPTION
## Summary
- **PRD-01**: Replaced Celery/Redis/Flower/Beat references with PostgreSQL-backed job queue + worker.py. Updated WhisperX, Ollama, architecture diagram, env vars, and roadmap.
- **PRD-02**: Moved semantic search from V2 to implemented.
- **PRD-03**: Rewrote docker-compose (5 services, no Redis), repo structure (actual files), Dockerfiles (control + worker), .env.example, Makefile, and license.
- **PRD-04**: Fixed project name from PodSearch to Podlog.

Every fact was verified against the actual codebase: docker-compose.yml, file tree, .env.example, and source files.

## Test plan
- [x] All changes are documentation only -- no code modified
- [x] Cross-referenced every docker-compose service, file path, env var, and tech stack entry against actual files

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)