### PR TITLE
fix: wizard UX bugs — X button, Get Started nav, test mode color

### DIFF
--- a/apps/web/src/components/SetupWizard.tsx
+++ b/apps/web/src/components/SetupWizard.tsx
@@ -33,12 +33,13 @@ export default function SetupWizard() {
     if (dontShow) markCompleted(true);
     close();
     if (feedAdded) router.push("/queue");
+    else router.push("/");
   }
 
   if (!open) return null;
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) handleSkip(); }}>
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) close(); }}>
       <DialogContent className="max-w-xl" onPointerDownOutside={(e) => e.preventDefault()}>
         {step === 1 && (
           <WizardHealthCheck

--- a/apps/web/src/components/WizardAddFeed.tsx
+++ b/apps/web/src/components/WizardAddFeed.tsx
@@ -196,7 +196,7 @@ export default function WizardAddFeed({ onNext, onBack, onSkip }: Props) {
               onClick={() => setMode("test")}
               className={`flex-1 flex items-center gap-1.5 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
                 mode === "test"
-                  ? "bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200 ring-1 ring-violet-300 dark:ring-violet-700"
+                  ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 ring-1 ring-blue-300 dark:ring-blue-700"
                   : "bg-muted text-muted-foreground hover:bg-accent"
               }`}
             >


### PR DESCRIPTION
## Summary
- X button now dismisses wizard without permanently suppressing it (was calling `markCompleted(true)`)
- "Get Started" navigates to `/` when feed was skipped (was a no-op, missing `else` branch)
- Test mode card uses blue highlight per spec (was violet)

## Test plan
- [x] Wizard tests: 15/15 pass
- [x] Full web suite: 81/81 pass

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)