### PR TITLE
docs: fix test counts and add missing Ollama service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add RSS feeds, transcribe episodes with Whisper, label speakers with pyannote, a
 ![PostgreSQL](https://img.shields.io/badge/postgresql-15-4169e1?logo=postgresql&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-compose-2496ed?logo=docker&logoColor=white)
 ![License](https://img.shields.io/badge/license-O'Saasy-green)
-![Tests](https://img.shields.io/badge/tests-155%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-321%20passed-brightgreen)
 
 </div>
 
@@ -86,6 +86,11 @@ Open **http://localhost:3000** — that's it.
                         │    FTS via GIN index + vector HNSW index     │
                         │    Job queue with FOR UPDATE SKIP LOCKED     │
                         └──────────────────────────────────────────────┘
+
+                        ┌──────────────────────────────────────────────┐
+  Ollama API :11434 ──> │  ollama (local LLM)                          │
+                        │    RAG-based Ask AI feature                  │
+                        └──────────────────────────────────────────────┘
 ```
 
 5 containers. No Redis, no Celery — the job queue is PostgreSQL-backed.
@@ -121,7 +126,7 @@ make up              # Start all services
 make down            # Stop all services
 make build           # Rebuild Docker images
 make logs            # Follow logs for all services
-make test-unit       # Run unit tests (155 tests, ~2 seconds)
+make test-unit       # Run unit tests (321 tests)
 make shell-db        # Open psql shell
 make health-install  # Install health monitoring cron (every 15 min)
 make help            # List all available commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 ```
 podlog/
-├── docker-compose.yml              # 5 services: db, pipeline, worker, web
+├── docker-compose.yml              # 5 services: db, pipeline, worker, ollama, web
 ├── .env.example                    # All config vars documented
 ├── Makefile                        # make up / down / build / test / etc.
 ├── apps/
@@ -91,7 +91,7 @@ docker compose exec pipeline alembic upgrade head
 
 ## Running Tests
 
-### Unit Tests (91 tests, ~1 second)
+### Unit Tests (321 tests — 240 pipeline + 81 web)
 
 ```bash
 cd apps/pipeline

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -72,6 +72,7 @@ Podlog starts 5 containers:
 | **pipeline** | 8000 | FastAPI control plane — feed management, health |
 | **worker** | — | Processes episodes: download, transcribe, diarize, archive |
 | **db** | 5432 | PostgreSQL 15 with pgvector for FTS + semantic search |
+| **ollama** | 11434 | Local LLM inference for RAG-based Ask AI feature |
 
 No Redis, no Celery — the job queue is PostgreSQL-backed.
 


### PR DESCRIPTION
## Summary
- Updated test count badges/references from stale values (155, 91) to actual 321 (240 pipeline + 81 web)
- Added Ollama service to README architecture diagram, installation guide service table, and development.md service list

## Test plan
- [x] Documentation only -- no code changes
- [x] Test counts verified by running both suites

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)