### PR TITLE
fix: add torchaudio as explicit dependency

### DIFF
--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -36,6 +36,7 @@ optional = true
 # WhisperX (CTranslate2 backend + wav2vec2 alignment)
 whisperx = "^3.8.0"
 torch = "^2.2.0"
+torchaudio = "^2.2.0"
 
 # pyannote diarization (>=4.0 required by whisperx)
 pyannote-audio = ">=3.1.0"


### PR DESCRIPTION
## Summary
- Added `torchaudio = "^2.2.0"` to `pyproject.toml` ML dependencies group
- Was imported directly in `pyannote.py` but only installed transitively via pyannote-audio
- Lock file already has torchaudio 2.8.0 -- no regeneration needed

## Test plan
- [x] torchaudio 2.8.0 in poetry.lock satisfies `^2.2.0`
- [x] No code changes, only dependency declaration

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)