### PR TITLE
chore: remove unused soundfile dependency

### DIFF
--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -40,7 +40,6 @@ torchaudio = "^2.2.0"
 
 # pyannote diarization (>=4.0 required by whisperx)
 pyannote-audio = ">=3.1.0"
-soundfile = ">=0.12.0"  # Audio backend for pyannote (fallback when torchcodec unavailable)
 
 # spaCy NER for host/guest inference (PRD-04)
 spacy = "^3.7"


### PR DESCRIPTION
## Summary
- Removed `soundfile` from pyproject.toml ML dependencies — zero imports in codebase, pyannote.py uses `torchaudio.load()` exclusively
- **spacy is NOT unused** — it's imported in `services/inference.py:91` for host/guest NER. The audit finding was incorrect.

## Test plan
- [x] Verified no `soundfile` or `sf.` imports exist in any Python file
- [x] Verified `torchaudio` is the audio loading backend in pyannote.py
- [x] Verified spacy is actually used in inference.py

Partially closes #146 (soundfile removed; spacy correctly retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)