### PR TITLE
fix: resolve remaining #104 review findings (notifications + test stack)

### DIFF
--- a/apps/pipeline/app/tasks/archive.py
+++ b/apps/pipeline/app/tasks/archive.py
@@ -15,7 +15,7 @@ from app.database import SessionLocal
 from app.models import Episode, Segment, SpeakerName
 from app.services.events import bus
 from app.services.notifications import EpisodeDoneEvent, compute_avg_processing_stats, estimate_queue_status
-from app.tasks.helpers import update_episode
+from app.tasks.helpers import mark_failed, update_episode
 
 logger = logging.getLogger(__name__)
 
@@ -38,14 +38,10 @@ def archive_episode(episode_id: str) -> str:
                 archived_path = _compress_audio(raw_path, episode_id)
             except OSError as exc:
                 if "No space left on device" in str(exc) or getattr(exc, "errno", None) == 28:
-                    update_episode(
+                    mark_failed(
                         db, episode_id,
-                        status="failed",
                         error_class="DISK_FULL",
                         error_message="Disk full during archival. Free space and retry.",
-                    )
-                    logger.error(
-                        '"action": "archive_disk_full", "episode_id": "%s"', episode_id
                     )
                     return episode_id
                 raise
@@ -65,13 +61,11 @@ def archive_episode(episode_id: str) -> str:
         name_map = {sn.speaker_label: sn for sn in speaker_names}
 
         if not segments:
-            update_episode(
+            mark_failed(
                 db, episode_id,
-                status="failed",
                 error_class="SYSTEM_ERROR",
                 error_message="No transcript segments found at archival -- cannot mark done.",
             )
-            logger.error('"action": "archive_no_segments", "episode_id": "%s"', episode_id)
             return episode_id
 
         transcript_path = _write_transcript(episode, segments, name_map)

--- a/apps/pipeline/app/tasks/cleanup.py
+++ b/apps/pipeline/app/tasks/cleanup.py
@@ -22,6 +22,7 @@ def cleanup_zombie_jobs() -> dict:
     from app.config import settings
     from app.database import SessionLocal
     from app.models import Episode, Job
+    from app.tasks.helpers import mark_failed
 
     db = SessionLocal()
     try:
@@ -70,11 +71,12 @@ def cleanup_zombie_jobs() -> dict:
                     "Re-enqueue to retry."
                 )
 
-                # Mark the episode as failed
-                episode.status = "failed"
-                episode.error_class = "SYSTEM_ERROR"
-                episode.error_message = job.error
-                episode.updated_at = now
+                # Mark the episode as failed (emits notification)
+                mark_failed(
+                    db, str(episode.id),
+                    error_class="SYSTEM_ERROR",
+                    error_message=job.error,
+                )
 
                 failed_episode_ids.append(episode.id)
                 failed_job_ids.append(job.id)

--- a/apps/pipeline/app/tasks/helpers.py
+++ b/apps/pipeline/app/tasks/helpers.py
@@ -33,9 +33,12 @@ def mark_failed(db, episode_id: str, error_class: str, error_message: str) -> No
         episode_id, error_class, error_message,
     )
 
-    # Emit failure notification only on terminal failure (retries exhausted)
+    # Emit failure notification on terminal failure:
+    # - retries exhausted, OR
+    # - non-retryable error class (DISK_FULL, OOM, SYSTEM_ERROR from zombies)
+    _NON_RETRYABLE = {"DISK_FULL", "OOM", "SYSTEM_ERROR"}
     episode = db.query(Episode).filter(Episode.id == episode_id).first()
-    if episode and episode.retry_count >= episode.retry_max:
+    if episode and (error_class in _NON_RETRYABLE or episode.retry_count >= episode.retry_max):
         remaining, estimated = estimate_queue_status(db)
         avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         bus.emit(EpisodeFailedEvent(

--- a/apps/pipeline/tests/unit/test_cleanup.py
+++ b/apps/pipeline/tests/unit/test_cleanup.py
@@ -55,14 +55,16 @@ class TestCleanupZombieJobs:
         db.query.return_value.filter.return_value.first.return_value = episode
 
         with patch("app.database.SessionLocal", return_value=db), \
-             patch("app.config.settings", _make_settings()):
+             patch("app.config.settings", _make_settings()), \
+             patch("app.tasks.helpers.mark_failed") as mock_mark_failed:
             result = cleanup_zombie_jobs()
 
         assert result["marked_failed"] == 1
         assert job.status == "failed"
         assert "Zombie" in job.error
-        assert episode.status == "failed"
-        assert episode.error_class == "SYSTEM_ERROR"
+        mock_mark_failed.assert_called_once()
+        call_kwargs = mock_mark_failed.call_args
+        assert call_kwargs[1]["error_class"] == "SYSTEM_ERROR"
 
     def test_does_not_mark_picked_job_within_timeout(self):
         """A job running within expected time is NOT a zombie."""
@@ -104,7 +106,8 @@ class TestCleanupZombieJobs:
         db.query.return_value.filter.return_value.first.return_value = episode
 
         with patch("app.database.SessionLocal", return_value=db), \
-             patch("app.config.settings", _make_settings(min_timeout_minutes=60)):
+             patch("app.config.settings", _make_settings(min_timeout_minutes=60)), \
+             patch("app.tasks.helpers.mark_failed"):
             result = cleanup_zombie_jobs()
 
         assert result["marked_failed"] == 1

--- a/apps/pipeline/tests/unit/test_task_archive.py
+++ b/apps/pipeline/tests/unit/test_task_archive.py
@@ -81,9 +81,10 @@ class TestArchiveEpisode:
         mock_update.assert_any_call(db, "ep1", status="archiving")
         mock_bus.emit.assert_called_once()
 
+    @patch("app.tasks.archive.mark_failed")
     @patch("app.tasks.archive.update_episode")
     @patch("app.tasks.archive.SessionLocal")
-    def test_no_segments_fails(self, mock_session_cls, mock_update):
+    def test_no_segments_fails(self, mock_session_cls, mock_update, mock_mark_failed):
         ep = _make_episode()
         db = MagicMock()
         db.query.return_value.filter.return_value.first.return_value = ep
@@ -102,13 +103,15 @@ class TestArchiveEpisode:
             result = archive_episode("ep1")
 
         assert result == "ep1"
-        # Should be marked failed due to no segments
-        calls = [str(c) for c in mock_update.call_args_list]
-        assert any("failed" in c for c in calls)
+        mock_mark_failed.assert_called_once_with(
+            db, "ep1", error_class="SYSTEM_ERROR",
+            error_message="No transcript segments found at archival -- cannot mark done.",
+        )
 
+    @patch("app.tasks.archive.mark_failed")
     @patch("app.tasks.archive.update_episode")
     @patch("app.tasks.archive.SessionLocal")
-    def test_disk_full_during_compress(self, mock_session_cls, mock_update):
+    def test_disk_full_during_compress(self, mock_session_cls, mock_update, mock_mark_failed):
         ep = _make_episode()
         db = MagicMock()
         db.query.return_value.filter.return_value.first.return_value = ep
@@ -127,8 +130,10 @@ class TestArchiveEpisode:
             result = archive_episode("ep1")
 
         assert result == "ep1"
-        calls = [str(c) for c in mock_update.call_args_list]
-        assert any("DISK_FULL" in c for c in calls)
+        mock_mark_failed.assert_called_once_with(
+            db, "ep1", error_class="DISK_FULL",
+            error_message="Disk full during archival. Free space and retry.",
+        )
 
     @patch("app.tasks.archive.SessionLocal")
     def test_missing_episode_raises(self, mock_session_cls):

--- a/apps/web/Dockerfile.test
+++ b/apps/web/Dockerfile.test
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/playwright:v1.45.0-jammy
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+RUN npx playwright install --with-deps chromium
+
+# Build the Next.js app so we can run it in production mode
+RUN npm run build
+
+# Start the server and run tests
+CMD sh -c "node .next/standalone/server.js & sleep 2 && npx playwright test"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -36,15 +36,36 @@ services:
       mock_rss:
         condition: service_started
 
-  # web_test: disabled until a pipeline_test service is added to the test stack.
-  # The Playwright tests require a running pipeline API which is not yet available
-  # in the test composition. See issue #104 finding #2.
-  # web_test:
-  #   build: ./apps/web
-  #   command: npx playwright test
-  #   environment:
-  #     DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
-  #     PIPELINE_API_URL: http://pipeline_test:8000
-  #   depends_on:
-  #     db_test:
-  #       condition: service_healthy
+  pipeline_test:
+    build:
+      context: ./apps/pipeline
+      dockerfile: Dockerfile.worker
+      args:
+        INSTALL_DEV: "true"
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      HF_TOKEN: ${HF_TOKEN:-}
+      OLLAMA_BASE_URL: http://localhost:11434
+    depends_on:
+      db_test:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/api/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  web_test:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile.test
+    environment:
+      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      PIPELINE_API_URL: http://pipeline_test:8000
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+    depends_on:
+      db_test:
+        condition: service_healthy
+      pipeline_test:
+        condition: service_healthy


### PR DESCRIPTION
## Summary
- Fixes the two remaining findings from the repository review (#104)
- All 6 findings from the original review are now addressed

## Changes

### Finding 4: Terminal failures now emit notifications
- `apps/pipeline/app/tasks/archive.py` — use `mark_failed()` for disk-full and no-segments failures instead of direct `update_episode(status="failed")`
- `apps/pipeline/app/tasks/cleanup.py` — use `mark_failed()` for zombie job detection instead of direct episode status assignment
- `apps/pipeline/app/tasks/helpers.py` — `mark_failed()` now also emits notifications for non-retryable error classes (`DISK_FULL`, `OOM`, `SYSTEM_ERROR`) regardless of retry count

### Finding 2: E2E test stack
- `docker-compose.test.yml` — add `pipeline_test` service (FastAPI against test DB) and uncomment `web_test` (Playwright)
- `apps/web/Dockerfile.test` — new test Dockerfile with Playwright + Chromium

## Testing
- 304 pipeline unit tests pass
- Archive and cleanup tests updated to verify `mark_failed()` is called with correct error classes

Closes #104