### PR TITLE
feat: show processing status and exclude unprocessed episodes from search (#161)

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { AlertTriangle, Info } from "lucide-react";
+import { AlertTriangle, Info, Loader2, XCircle, CheckCircle2 } from "lucide-react";
 import pool from "@/lib/db";
 import type { Segment } from "@/lib/types";
 import { formatTimestamp } from "@/lib/timestamp";
@@ -11,8 +11,34 @@ import EpisodeDescription from "@/components/EpisodeDescription";
 import TranscriptSection from "@/components/TranscriptSection";
 import BackToSearchLink from "@/components/BackToSearchLink";
 import ReprocessButton from "@/components/ReprocessButton";
+import { Badge } from "@/components/ui/badge";
 
 export const dynamic = "force-dynamic";
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "done") return null;
+
+  const isFailed = status === "failed";
+  const label = isFailed ? "Failed" : status.charAt(0).toUpperCase() + status.slice(1);
+
+  return (
+    <Badge
+      variant="outline"
+      className={
+        isFailed
+          ? "text-red-700 border-red-300 dark:text-red-300 dark:border-red-700 gap-1"
+          : "text-blue-700 border-blue-300 dark:text-blue-300 dark:border-blue-700 gap-1"
+      }
+    >
+      {isFailed ? (
+        <XCircle size={12} />
+      ) : (
+        <Loader2 size={12} className="animate-spin" />
+      )}
+      {label}
+    </Badge>
+  );
+}
 
 interface Episode {
   id: string;
@@ -21,6 +47,8 @@ interface Episode {
   published_at: string | null;
   duration_secs: number | null;
   status: string;
+  error_class: string | null;
+  error_message: string | null;
   has_diarization: boolean;
   diarization_error: string | null;
   inference_error: string | null;
@@ -91,6 +119,7 @@ export default async function EpisodePage({ params }: { params: { id: string } }
         )}
         <div className="flex items-center gap-3 mt-2">
           <h1 className="text-xl font-semibold">{episode.title ?? "Untitled Episode"}</h1>
+          <StatusBadge status={episode.status} />
           <ReprocessButton episodeId={episode.id} status={episode.status} />
         </div>
         <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
@@ -153,6 +182,21 @@ export default async function EpisodePage({ params }: { params: { id: string } }
           episodeTitle={episode.title}
           feedTitle={episode.feed_title}
         />
+      )}
+
+      {/* Processing failure banner */}
+      {episode.status === "failed" && (
+        <Card className="border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950">
+          <CardContent className="p-3 flex items-start gap-2">
+            <XCircle size={16} className="text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+            <div className="text-sm text-red-800 dark:text-red-200">
+              <p>Processing failed{episode.error_class ? ` (${episode.error_class})` : ""}</p>
+              {episode.error_message && (
+                <p className="mt-1 text-xs opacity-80">{episode.error_message}</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       )}
 
       {/* Diarization failure banner — PRD-02 §5.3 */}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -57,7 +57,7 @@ function HomePageContent() {
   const flatQuery = useQuery<SearchPage>({
     queryKey: ["search", submittedQuery, feedFilter, page],
     queryFn: async () => {
-      if (!submittedQuery) return { results: [], total: 0, page: 1, pageSize: PAGE_SIZE };
+      if (!submittedQuery) return { results: [], total: 0, page: 1, pageSize: PAGE_SIZE, coverage: { processed: 0, total: 0 } };
       const canSkipCount = page > 1 && cachedFlatTotal.current?.key === flatCacheKey;
       const params = new URLSearchParams({
         q: submittedQuery,
@@ -87,7 +87,7 @@ function HomePageContent() {
     queryKey: ["search-grouped", submittedQuery, feedFilter, page],
     queryFn: async () => {
       if (!submittedQuery)
-        return { feeds: [], totalFeeds: 0, totalEpisodes: 0, totalMentions: 0 };
+        return { feeds: [], totalFeeds: 0, totalEpisodes: 0, totalMentions: 0, coverage: { processed: 0, total: 0 } };
       const canSkipCount = page > 1 && cachedGroupedTotals.current?.key === groupedCacheKey;
       const params = new URLSearchParams({
         q: submittedQuery,
@@ -179,6 +179,13 @@ function HomePageContent() {
                 : viewMode === "flat" && flatQuery.data
                   ? `Page ${page} of ${totalPages} · ${flatQuery.data.total} results`
                   : ""}
+              {(() => {
+                const cov = viewMode === "grouped" ? groupedQuery.data?.coverage : flatQuery.data?.coverage;
+                if (cov && cov.total > 0 && cov.processed < cov.total) {
+                  return ` · Searching ${cov.processed} of ${cov.total} episodes`;
+                }
+                return null;
+              })()}
             </div>
             <div className="flex items-center gap-2">
               <DownloadReportButton

--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -14,6 +14,7 @@ interface Feed {
   image_url: string | null;
   mode: string;
   episode_count: number;
+  processed_count: number;
   last_polled_at: string | null;
 }
 
@@ -25,7 +26,8 @@ async function getFeeds(): Promise<Feed[]> {
       f.image_url,
       f.mode,
       f.last_polled_at,
-      COUNT(e.id)::int AS episode_count
+      COUNT(e.id)::int AS episode_count,
+      COUNT(e.id) FILTER (WHERE e.status = 'done')::int AS processed_count
     FROM feeds f
     LEFT JOIN episodes e ON e.feed_id = f.id
     GROUP BY f.id
@@ -84,7 +86,11 @@ export default async function PodcastsPage() {
                       </Badge>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground">{feed.episode_count} episodes</p>
+                  <p className="text-xs text-muted-foreground">
+                    {feed.processed_count === feed.episode_count
+                      ? `${feed.episode_count} episodes`
+                      : `${feed.processed_count} / ${feed.episode_count} episodes processed`}
+                  </p>
                 </CardContent>
               </Card>
             </Link>

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -28,6 +28,7 @@ export interface GroupedSearchResult {
   totalFeeds: number;
   totalEpisodes: number;
   totalMentions: number;
+  coverage: EpisodeCoverage;
 }
 
 export interface FeedGroup {
@@ -96,11 +97,17 @@ export interface SearchResult {
   feedId: string;
 }
 
+export interface EpisodeCoverage {
+  processed: number;
+  total: number;
+}
+
 export interface SearchPage {
   results: SearchResult[];
   total: number;
   page: number;
   pageSize: number;
+  coverage: EpisodeCoverage;
 }
 
 // ── Speaker turn aggregation CTE ────────────────────────────
@@ -191,6 +198,7 @@ export async function searchSegments(
     LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
       websearch_to_tsquery('english', $1) AS query
     WHERE to_tsvector('english', t.full_text) @@ query
+      AND e.status = 'done'
       AND ($2::uuid IS NULL OR f.id = $2)
     ORDER BY rank DESC
     LIMIT $3`,
@@ -224,6 +232,7 @@ export async function searchSegments(
         LEFT JOIN feeds f ON e.feed_id = f.id
         LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = s.speaker_label
         WHERE s.embedding IS NOT NULL
+          AND e.status = 'done'
           AND ($2::uuid IS NULL OR f.id = $2)
         ORDER BY s.embedding <=> $1::vector
         LIMIT $3`,
@@ -242,12 +251,23 @@ export async function searchSegments(
         LEFT JOIN feeds f ON e.feed_id = f.id,
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
+          AND e.status = 'done'
           AND ($2::uuid IS NULL OR f.id = $2)`,
         [query, feedId]
       );
 
-  const [ftsResult, vecResult, countResult] = await Promise.all([
-    ftsPromise, vecPromise, countPromise,
+  // 4. Episode coverage (processed vs total)
+  const coveragePromise = skipCount
+    ? Promise.resolve(null)
+    : pool.query(
+        `SELECT
+          COUNT(*) FILTER (WHERE status = 'done')::int AS processed,
+          COUNT(*)::int AS total
+        FROM episodes`
+      );
+
+  const [ftsResult, vecResult, countResult, coverageResult] = await Promise.all([
+    ftsPromise, vecPromise, countPromise, coveragePromise,
   ]);
 
   // 4. Build result map keyed by episodeId:bucketedTime for deduplication
@@ -328,7 +348,13 @@ export async function searchSegments(
   const ftsTotal = countResult ? parseInt(countResult.rows[0].count, 10) : -1;
   const total = ftsTotal >= 0 ? Math.max(ftsTotal, sorted.length) : -1;
 
-  return { results, total, page, pageSize };
+  const cov = coverageResult?.rows[0];
+  const coverage: EpisodeCoverage = {
+    processed: cov?.processed ?? 0,
+    total: cov?.total ?? 0,
+  };
+
+  return { results, total, page, pageSize, coverage };
 }
 
 /**
@@ -362,6 +388,7 @@ export async function searchGrouped(
     LEFT JOIN feeds f ON e.feed_id = f.id,
       websearch_to_tsquery('english', $1) AS query
     WHERE to_tsvector('english', t.full_text) @@ query
+      AND e.status = 'done'
       AND ($2::uuid IS NULL OR f.id = $2)
     GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
     ORDER BY best_rank DESC, mention_count DESC
@@ -382,11 +409,21 @@ export async function searchGrouped(
         LEFT JOIN feeds f ON e.feed_id = f.id,
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
+          AND e.status = 'done'
           AND ($2::uuid IS NULL OR f.id = $2)`,
         [query, feedId]
       );
 
-  const [rowsResult, countResult] = await Promise.all([rowsPromise, countPromise]);
+  const coveragePromise = skipCount
+    ? Promise.resolve(null)
+    : pool.query(
+        `SELECT
+          COUNT(*) FILTER (WHERE status = 'done')::int AS processed,
+          COUNT(*)::int AS total
+        FROM episodes`
+      );
+
+  const [rowsResult, countResult, coverageResult] = await Promise.all([rowsPromise, countPromise, coveragePromise]);
 
   // Group episode rows by feed
   const feedMap = new Map<string, FeedGroup>();
@@ -417,12 +454,17 @@ export async function searchGrouped(
   }
 
   const counts = countResult?.rows[0];
+  const cov = coverageResult?.rows[0];
 
   return {
     feeds: Array.from(feedMap.values()),
     totalFeeds: counts?.total_feeds ?? -1,
     totalEpisodes: counts?.total_episodes ?? -1,
     totalMentions: counts?.total_mentions ?? -1,
+    coverage: {
+      processed: cov?.processed ?? 0,
+      total: cov?.total ?? 0,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Excludes unprocessed episodes from search results (only `status = 'done'` episodes are searched)
- Shows episode processing coverage on the search page when not all episodes are ready
- Shows processed/total counts per feed on the podcasts page
- Shows current pipeline status on the episode detail page

## Changes

### Search (`apps/web/src/lib/search.ts`)
- Add `AND e.status = 'done'` to FTS, vector, grouped, and count queries
- Add `EpisodeCoverage` type and query (`processed` vs `total` episode counts)
- Return coverage in both `SearchPage` and `GroupedSearchResult`

### Search page (`apps/web/src/app/page.tsx`)
- Show "Searching X of N episodes" in results summary when `processed < total`
- Hidden when all episodes are fully processed

### Podcasts page (`apps/web/src/app/podcasts/page.tsx`)
- Query now includes `COUNT(...) FILTER (WHERE e.status = 'done')` as `processed_count`
- Shows "X / N episodes processed" when counts differ, "N episodes" when all done

### Episode page (`apps/web/src/app/episodes/[id]/page.tsx`)
- `StatusBadge` component shows current pipeline stage (e.g., "Transcribing", "Diarizing")
- Animated spinner for in-progress states, red X for failed
- Hidden for `done` episodes (transcript is self-explanatory)
- Failure banner with error class and message for failed episodes

## Testing
- 304 pipeline + 81 web tests pass (385 total)
- No changes to test files needed (search tests mock at API level)

Closes #161