### PR TITLE
feat: add drag-and-drop audio file upload (#151)

### DIFF
--- a/apps/pipeline/app/api/episodes.py
+++ b/apps/pipeline/app/api/episodes.py
@@ -2,23 +2,30 @@
 Episode API — control-plane endpoints only.
 
 POST  /api/episodes/ingest   Manually ingest a single audio URL
+POST  /api/episodes/upload   Upload a local audio file for processing
 
 Read-only episode data is served directly by the Next.js web app
 via PostgreSQL queries (no proxy needed).
 """
 import logging
+import shutil
+from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.database import get_db
 from app.models import Episode
 from app.tasks.ingest import ingest_episode
+from app import job_queue
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+ALLOWED_EXTENSIONS = {".mp3", ".m4a", ".wav", ".ogg", ".flac", ".opus", ".aac", ".wma", ".webm"}
 
 
 class IngestEpisodeRequest(BaseModel):
@@ -46,3 +53,70 @@ def ingest_manual(body: IngestEpisodeRequest, db: Session = Depends(get_db)) -> 
     ingest_episode(episode.id)
     logger.info('"action": "manual_ingest", "episode_id": "%s"', episode.id)
     return {"episode_id": episode.id}
+
+
+@router.post("/episodes/upload", status_code=202)
+def upload_audio(
+    file: UploadFile = File(...),
+    title: str = Form(""),
+    description: str = Form(""),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Upload a local audio file for processing through the pipeline."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    suffix = Path(file.filename).suffix.lower()
+    if suffix not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type '{suffix}'. Allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))}",
+        )
+
+    # Disk space check
+    try:
+        usage = shutil.disk_usage(settings.data_dir)
+        if usage.free < settings.disk_headroom_bytes:
+            raise HTTPException(status_code=507, detail="Insufficient disk space for upload")
+    except OSError:
+        pass  # Non-fatal — proceed with upload
+
+    # Use filename (without extension) as default title
+    default_title = Path(file.filename).stem.replace("_", " ").replace("-", " ")
+    episode_title = title.strip() or default_title
+    episode_description = description.strip() or None
+
+    episode = Episode(
+        guid=f"upload:{file.filename}:{episode_title}",
+        audio_url=f"local://{file.filename}",
+        title=episode_title,
+        description=episode_description,
+        status="pending",
+    )
+    db.add(episode)
+    db.flush()
+    db.refresh(episode)
+
+    # Save file to raw audio directory
+    raw_dir = Path(settings.audio_raw_dir)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    dest = raw_dir / f"{episode.id}{suffix}"
+
+    try:
+        with open(dest, "wb") as fh:
+            shutil.copyfileobj(file.file, fh)
+    except OSError as exc:
+        db.rollback()
+        raise HTTPException(status_code=507, detail=f"Failed to save file: {exc}")
+
+    episode.audio_local_path = str(dest)
+    db.commit()
+
+    # Skip download — file is already local, go straight to transcribe
+    job_queue.enqueue(db, str(episode.id), "transcribe")
+
+    logger.info(
+        '"action": "upload_ingest", "episode_id": "%s", "filename": "%s"',
+        episode.id, file.filename,
+    )
+    return {"episode_id": str(episode.id)}

--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -6273,4 +6273,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "536c31793170031112fae071c353dfe236e56b658a5bc7f4cf34e50b0c1bf960"
+content-hash = "0a60d1cc030686fe877d68131c473511ed0655b853ca11f7f3e37c448210537b"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -28,6 +28,7 @@ feedparser = "^6.0.11"
 
 # Audio processing
 ffmpeg-python = "^0.2.0"
+python-multipart = "^0.0.22"
 
 [tool.poetry.group.ml]
 optional = true

--- a/apps/web/src/app/api/episodes/upload/route.ts
+++ b/apps/web/src/app/api/episodes/upload/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PIPELINE_API } from "@/lib/pipeline";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+
+  const resp = await fetch(`${PIPELINE_API}/api/episodes/upload`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const data = await resp.json();
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import SearchResult from "@/components/SearchResult";
 import FeedGroupCard from "@/components/FeedGroupCard";
 import DownloadReportButton from "@/components/DownloadReportButton";
+import AudioUpload from "@/components/AudioUpload";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import type { SearchPage, GroupedSearchResult } from "@/lib/search";
@@ -168,6 +169,13 @@ function HomePageContent() {
           />
         </div>
       </form>
+
+      {!submittedQuery && (
+        <div className="max-w-md mx-auto">
+          <h2 className="text-sm font-medium mb-2">Upload audio</h2>
+          <AudioUpload />
+        </div>
+      )}
 
       {submittedQuery && (
         <div className="space-y-4">

--- a/apps/web/src/components/AudioUpload.tsx
+++ b/apps/web/src/components/AudioUpload.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { Upload, X, FileAudio, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+const ALLOWED_TYPES = new Set([
+  "audio/mpeg", "audio/mp4", "audio/wav", "audio/ogg", "audio/flac",
+  "audio/opus", "audio/aac", "audio/x-m4a", "audio/webm", "audio/x-wav",
+]);
+
+const ALLOWED_EXTENSIONS = new Set([
+  ".mp3", ".m4a", ".wav", ".ogg", ".flac", ".opus", ".aac", ".wma", ".webm",
+]);
+
+function isValidAudio(file: File): boolean {
+  if (ALLOWED_TYPES.has(file.type)) return true;
+  const ext = "." + file.name.split(".").pop()?.toLowerCase();
+  return ALLOWED_EXTENSIONS.has(ext);
+}
+
+function defaultTitle(filename: string): string {
+  const stem = filename.replace(/\.[^.]+$/, "");
+  return stem.replace(/[_-]/g, " ");
+}
+
+interface AudioUploadProps {
+  onUploaded?: (episodeId: string) => void;
+}
+
+export default function AudioUpload({ onUploaded }: AudioUploadProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback((f: File) => {
+    setError(null);
+    setSuccess(null);
+    if (!isValidAudio(f)) {
+      setError(`Unsupported file type. Allowed: ${Array.from(ALLOWED_EXTENSIONS).join(", ")}`);
+      return;
+    }
+    setFile(f);
+    setTitle(defaultTitle(f.name));
+    setDescription("");
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const f = e.dataTransfer.files[0];
+      if (f) handleFile(f);
+    },
+    [handleFile]
+  );
+
+  const handleSubmit = async () => {
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("title", title.trim());
+    formData.append("description", description.trim());
+
+    try {
+      const resp = await fetch("/api/episodes/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await resp.json();
+
+      if (!resp.ok) {
+        setError(data.detail || "Upload failed");
+        return;
+      }
+
+      setSuccess("Upload successful — episode queued for processing");
+      setFile(null);
+      setTitle("");
+      setDescription("");
+      onUploaded?.(data.episode_id);
+    } catch {
+      setError("Upload failed — check your connection");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const clear = () => {
+    setFile(null);
+    setTitle("");
+    setDescription("");
+    setError(null);
+    setSuccess(null);
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-4">
+        {/* Drop zone */}
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => inputRef.current?.click()}
+          className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+            dragOver
+              ? "border-primary bg-primary/5"
+              : "border-border hover:border-primary/50"
+          }`}
+        >
+          <input
+            ref={inputRef}
+            type="file"
+            accept="audio/*"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = "";
+            }}
+          />
+          <Upload size={24} className="mx-auto mb-2 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            Drop an audio file here, or click to browse
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            MP3, M4A, WAV, OGG, FLAC, OPUS, AAC, WebM
+          </p>
+        </div>
+
+        {/* Selected file + metadata form */}
+        {file && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <FileAudio size={16} className="text-muted-foreground shrink-0" />
+              <span className="truncate">{file.name}</span>
+              <span className="text-muted-foreground shrink-0">
+                ({(file.size / 1024 / 1024).toFixed(1)} MB)
+              </span>
+              <button onClick={clear} className="ml-auto text-muted-foreground hover:text-foreground">
+                <X size={16} />
+              </button>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium mb-1">Title</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Episode title"
+                className="w-full px-3 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium mb-1">Description (optional)</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Notes about this audio file..."
+                rows={3}
+                className="w-full px-3 py-2 border border-input rounded-md bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+              />
+            </div>
+
+            <Button onClick={handleSubmit} disabled={uploading} className="w-full">
+              {uploading ? (
+                <>
+                  <Loader2 size={16} className="mr-2 animate-spin" />
+                  Uploading...
+                </>
+              ) : (
+                "Upload and process"
+              )}
+            </Button>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+        {success && (
+          <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds drag-and-drop audio file upload to Podlog, allowing users to process local audio files without an RSS feed
- Uploaded files go through the same pipeline as RSS episodes (transcribe, diarize, chunk, embed, infer, archive)

## Changes

### Pipeline (`apps/pipeline/`)
- **`app/api/episodes.py`** — new `POST /episodes/upload` endpoint accepting multipart file + title + description. Validates file type, checks disk space, saves to `/data/audio/raw/`, creates episode record, skips download and enqueues transcribe directly
- **`pyproject.toml` / `poetry.lock`** — add `python-multipart` dependency (required for FastAPI file uploads)

### Web (`apps/web/`)
- **`src/components/AudioUpload.tsx`** — new component with drag-and-drop zone, file type validation, editable title (defaults to cleaned-up filename), optional description textarea, upload progress, and error/success feedback
- **`src/app/api/episodes/upload/route.ts`** — proxy route forwarding multipart uploads to the pipeline API
- **`src/app/page.tsx`** — shows upload UI on the home page when no search is active

## Design decisions
- **File types**: mp3, m4a, wav, ogg, flac, opus, aac, wma, webm
- **Title**: Defaults to filename (with underscores/dashes replaced by spaces), user can edit
- **Description**: Optional free-text field
- **Feed grouping**: Feedless/manual episodes (existing `LEFT JOIN` + "Manual episode" fallback)
- **Pipeline path**: Skips download task entirely (file is already local), goes straight to transcribe

## Testing
- 304 pipeline + 81 web tests pass (385 total)

Closes #151