### PR TITLE
fix: allow reprocessing of done episodes (#171)

### DIFF
--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -28,19 +28,29 @@ def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
     if not episode:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    if episode.status != "failed" and episode.error_class is None:
-        raise HTTPException(status_code=409, detail="Job has no error to retry")
-
-    if episode.error_class in NON_RETRYABLE:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
-        )
+    if episode.status in ("done", "failed"):
+        # Allow reprocessing of completed or failed episodes
+        if episode.error_class in NON_RETRYABLE:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
+            )
+    elif episode.error_class is not None:
+        # Stalled job with an error — allow retry
+        if episode.error_class in NON_RETRYABLE:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
+            )
+    else:
+        raise HTTPException(status_code=409, detail="Episode is still being processed")
 
     # Reset state and re-enqueue
     episode.status = "pending"
     episode.error_message = None
     episode.error_class = None
+    episode.diarization_error = None
+    episode.has_diarization = False
     db.commit()
 
     ingest_episode(episode.id)

--- a/apps/pipeline/tests/unit/test_queue_api.py
+++ b/apps/pipeline/tests/unit/test_queue_api.py
@@ -55,6 +55,12 @@ class TestRetryJob:
         result = self._call_retry(ep)
         assert result["queued"] is True
 
+    def test_retry_done_episode_succeeds(self):
+        """Done episodes (e.g. with diarization failure) should be reprocessable."""
+        ep = _make_episode("done")
+        result = self._call_retry(ep)
+        assert result["queued"] is True
+
     def test_retry_active_episode_without_error_rejected(self):
         """Active jobs without an error should not be retryable."""
         ep = _make_episode("diarizing", error_class=None)
@@ -64,5 +70,11 @@ class TestRetryJob:
     def test_retry_non_retryable_error_rejected(self):
         """Jobs with DISK_FULL or OOM should not be retryable."""
         ep = _make_episode("failed", error_class="DISK_FULL")
+        result = self._call_retry(ep)
+        assert result.status_code == 422
+
+    def test_retry_done_non_retryable_rejected(self):
+        """Done episodes with non-retryable error class should still be rejected."""
+        ep = _make_episode("done", error_class="DISK_FULL")
         result = self._call_retry(ep)
         assert result.status_code == 422


### PR DESCRIPTION
## Summary
- Relaxed retry endpoint guard to allow reprocessing of `done` and `failed` episodes (not just `failed` with error_class)
- Reset `diarization_error` and `has_diarization` on retry so diarization runs fresh
- Added tests for done-episode reprocess and done+non-retryable rejection

## Changes
- `apps/pipeline/app/api/queue.py` — restructured guard logic: done/failed episodes are retryable, in-progress without error are rejected, non-retryable errors still blocked
- `apps/pipeline/tests/unit/test_queue_api.py` — added `test_retry_done_episode_succeeds` and `test_retry_done_non_retryable_rejected`

## Testing
- 8/8 queue API unit tests pass
- Covers: failed retry, stalled retry, done retry, active rejection, non-retryable rejection

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)