### PR TITLE
feat: ask page improvements and error fix (#168, #174)

### DIFF
--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -35,6 +35,7 @@ class AskRequest(BaseModel):
     question: str
     model: str | None = None
     feed_id: str | None = None
+    feed_ids: list[str] | None = None
 
 
 def _sse_event(event: str, data: dict | str) -> str:
@@ -42,11 +43,11 @@ def _sse_event(event: str, data: dict | str) -> str:
     return f"event: {event}\ndata: {payload}\n\n"
 
 
-async def _stream_ask(question: str, model: str, feed_id: str | None):
+async def _stream_ask(question: str, model: str, feed_ids: list[str] | None):
     db = SessionLocal()
     try:
         # 1. Retrieve relevant chunks
-        chunks = retrieve_chunks(db, question, feed_id=feed_id)
+        chunks = retrieve_chunks(db, question, feed_ids=feed_ids)
 
         if not chunks:
             yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
@@ -90,8 +91,13 @@ async def ask_endpoint(req: AskRequest):
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
 
+    # Support both feed_ids (multi-select) and legacy feed_id (single)
+    feed_ids = req.feed_ids
+    if not feed_ids and req.feed_id:
+        feed_ids = [req.feed_id]
+
     return StreamingResponse(
-        _stream_ask(req.question, model, req.feed_id),
+        _stream_ask(req.question, model, feed_ids),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -46,16 +46,28 @@ def retrieve_chunks(
     db: Session,
     question: str,
     top_k: int = TOP_K,
-    feed_id: str | None = None,
+    feed_ids: list[str] | None = None,
 ) -> list[ChunkResult]:
     """Retrieve top-K chunks by cosine similarity to the question embedding."""
     embedding = embed_query(question)
     embedding_str = f"[{','.join(str(x) for x in embedding)}]"
 
-    feed_filter = "AND e.feed_id = :feed_id" if feed_id else ""
+    feed_filter = ""
     params: dict = {"embedding": embedding_str, "top_k": top_k, "threshold": SIMILARITY_THRESHOLD}
-    if feed_id:
-        params["feed_id"] = feed_id
+    if feed_ids:
+        # Build feed filter supporting both feed IDs and "uploads" (feed_id IS NULL)
+        has_uploads = "__uploads__" in feed_ids
+        real_ids = [fid for fid in feed_ids if fid != "__uploads__"]
+        conditions = []
+        if real_ids:
+            placeholders = ", ".join(f":fid_{i}" for i in range(len(real_ids)))
+            conditions.append(f"e.feed_id IN ({placeholders})")
+            for i, fid in enumerate(real_ids):
+                params[f"fid_{i}"] = fid
+        if has_uploads:
+            conditions.append("e.feed_id IS NULL")
+        if conditions:
+            feed_filter = f"AND ({' OR '.join(conditions)})"
 
     query = text(f"""
         SELECT

--- a/apps/web/src/app/api/ask/coverage/route.ts
+++ b/apps/web/src/app/api/ask/coverage/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import pool from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const result = await pool.query(`
+    SELECT
+      COUNT(*) FILTER (WHERE status = 'done') AS processed,
+      COUNT(*) AS total,
+      EXISTS(SELECT 1 FROM episodes WHERE feed_id IS NULL) AS has_manual_uploads
+    FROM episodes
+  `);
+
+  const row = result.rows[0];
+  return NextResponse.json({
+    processed: Number(row.processed),
+    total: Number(row.total),
+    has_manual_uploads: row.has_manual_uploads,
+  });
+}

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import { MessageSquare, Send, Play, Loader2 } from "lucide-react";
+import { MessageSquare, Send, Play, Loader2, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
@@ -20,6 +20,11 @@ interface Source {
 interface Feed {
   id: string;
   title: string | null;
+}
+
+interface CoverageStats {
+  processed: number;
+  total: number;
 }
 
 type StreamStatus = "idle" | "connecting" | "streaming" | "done" | "error";
@@ -116,20 +121,44 @@ export default function AskPage() {
   const [errorMsg, setErrorMsg] = useState("");
   const [model, setModel] = useState(getStoredModel);
   const [feeds, setFeeds] = useState<Feed[]>([]);
-  const [feedFilter, setFeedFilter] = useState("");
+  const [selectedFeedIds, setSelectedFeedIds] = useState<Set<string>>(new Set());
+  const [feedDropdownOpen, setFeedDropdownOpen] = useState(false);
+  const [hasManualUploads, setHasManualUploads] = useState(false);
+  const [coverage, setCoverage] = useState<CoverageStats | null>(null);
   const answerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const feedDropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     localStorage.setItem("podlog-ask-model", model);
   }, [model]);
 
-  // Fetch feeds for filter dropdown
+  // Close feed dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (feedDropdownRef.current && !feedDropdownRef.current.contains(e.target as Node)) {
+        setFeedDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  // Fetch feeds and coverage stats
   useEffect(() => {
     fetch("/api/feeds")
       .then((r) => r.json())
       .then((data) => {
         if (Array.isArray(data)) setFeeds(data);
+      })
+      .catch(() => {});
+
+    // Check for manual uploads (episodes with no feed_id)
+    fetch("/api/ask/coverage")
+      .then((r) => r.json())
+      .then((data) => {
+        setCoverage({ processed: data.processed, total: data.total });
+        setHasManualUploads(data.has_manual_uploads ?? false);
       })
       .catch(() => {});
   }, []);
@@ -157,8 +186,8 @@ export default function AskPage() {
       abortRef.current = controller;
 
       try {
-        const body: Record<string, string> = { question: q, model };
-        if (feedFilter) body.feed_id = feedFilter;
+        const body: Record<string, unknown> = { question: q, model };
+        if (selectedFeedIds.size > 0) body.feed_ids = Array.from(selectedFeedIds);
 
         const resp = await fetch("/api/pipeline/ask", {
           method: "POST",
@@ -203,7 +232,7 @@ export default function AskPage() {
                   setErrorMsg(data.message || "Unknown error");
                   setStatus("error");
                 } else if (currentEvent === "done") {
-                  setStatus("done");
+                  setStatus((s) => (s === "error" ? "error" : "done"));
                 }
               } catch {
                 // skip malformed JSON
@@ -221,7 +250,7 @@ export default function AskPage() {
         setErrorMsg("Connection failed. Is the pipeline running?");
       }
     },
-    [question, model, feedFilter]
+    [question, model, selectedFeedIds]
   );
 
   function handlePlaySource(source: Source) {
@@ -244,7 +273,7 @@ export default function AskPage() {
         </p>
       </div>
 
-      {/* Controls row: model + feed filter */}
+      {/* Controls row: model + feed filter + coverage */}
       <div className="flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
           <label
@@ -261,34 +290,89 @@ export default function AskPage() {
           >
             {MODEL_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
-                {opt.label} ({opt.hint})
+                {opt.label} &middot; {opt.value} ({opt.hint})
               </option>
             ))}
           </select>
         </div>
 
-        {feeds.length > 0 && (
-          <div className="flex items-center gap-2">
-            <label
-              htmlFor="feed-filter"
-              className="text-sm text-muted-foreground"
+        {(feeds.length > 0 || hasManualUploads) && (
+          <div className="relative" ref={feedDropdownRef}>
+            <button
+              type="button"
+              onClick={() => setFeedDropdownOpen((o) => !o)}
+              className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
             >
-              Podcast:
-            </label>
-            <select
-              id="feed-filter"
-              value={feedFilter}
-              onChange={(e) => setFeedFilter(e.target.value)}
-              className="text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground"
-            >
-              <option value="">All podcasts</option>
-              {feeds.map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.title || "Untitled"}
-                </option>
-              ))}
-            </select>
+              <span className="text-muted-foreground">Source:</span>
+              {selectedFeedIds.size === 0
+                ? "All"
+                : `${selectedFeedIds.size} selected`}
+              <ChevronDown size={14} className="text-muted-foreground" />
+            </button>
+            {feedDropdownOpen && (
+              <div className="absolute top-full left-0 mt-1 z-50 bg-background border border-border rounded-md shadow-lg py-1 min-w-[220px] max-h-64 overflow-y-auto">
+                <button
+                  type="button"
+                  onClick={() => setSelectedFeedIds(new Set())}
+                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors ${
+                    selectedFeedIds.size === 0 ? "font-medium" : ""
+                  }`}
+                >
+                  All sources
+                </button>
+                <div className="border-t border-border my-1" />
+                {feeds.map((f) => (
+                  <label
+                    key={f.id}
+                    className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedFeedIds.has(f.id)}
+                      onChange={() => {
+                        setSelectedFeedIds((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(f.id)) next.delete(f.id);
+                          else next.add(f.id);
+                          return next;
+                        });
+                      }}
+                      className="rounded"
+                    />
+                    <span className="truncate">{f.title || "Untitled"}</span>
+                  </label>
+                ))}
+                {hasManualUploads && (
+                  <>
+                    <div className="border-t border-border my-1" />
+                    <label className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selectedFeedIds.has("__uploads__")}
+                        onChange={() => {
+                          setSelectedFeedIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has("__uploads__")) next.delete("__uploads__");
+                            else next.add("__uploads__");
+                            return next;
+                          });
+                        }}
+                        className="rounded"
+                      />
+                      <span>Manual uploads</span>
+                    </label>
+                  </>
+                )}
+              </div>
+            )}
           </div>
+        )}
+
+        {coverage && (
+          <span className="text-xs text-muted-foreground">
+            Searching across {coverage.processed} processed episode{coverage.processed !== 1 ? "s" : ""}
+            {coverage.total > coverage.processed && ` (${coverage.total - coverage.processed} still processing)`}
+          </span>
         )}
       </div>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 6g
+          memory: 10g
 
   web:
     build: ./apps/web


### PR DESCRIPTION
## Summary
- Fix silent error clearing bug (#174): `done` SSE event no longer overwrites `error` status
- Show model identifier alongside performance label (e.g. "Default - qwen2.5:3b")
- Add episode coverage stats on Ask page
- Multi-feed selection with checkbox dropdown (supports feeds + manual uploads)
- Bump Ollama container memory from 6GB to 10GB (models couldn't load with 6GB)
- Downloaded and verified all 3 Ollama models (qwen2.5:1.5b, qwen2.5:3b, phi3:mini)

## Changes
- `apps/pipeline/app/api/ask.py` — accept `feed_ids` list, backwards-compatible with `feed_id`
- `apps/pipeline/app/services/rag.py` — `retrieve_chunks()` supports multi-feed filtering with `__uploads__` sentinel
- `apps/web/src/app/ask/page.tsx` — error fix, model display, multi-select, coverage stats
- `apps/web/src/app/api/ask/coverage/route.ts` — new endpoint for episode coverage counts
- `docker-compose.yml` — Ollama memory limit 6g -> 10g

## Testing
- 12/12 RAG unit tests pass
- TypeScript compiles cleanly
- All 3 Ollama models verified working

Closes #168
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)