### PR TITLE
fix: allow retrying stuck/orphaned episodes (#170)

### DIFF
--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -1,7 +1,7 @@
 """
 Queue management API — control-plane endpoints only.
 
-POST  /api/queue/{episode_id}/retry      Retry a failed job
+POST  /api/queue/{episode_id}/retry      Retry a failed/stuck/done job
 
 Queue read (GET /api/queue) is served directly by the Next.js web app
 via PostgreSQL queries (no proxy needed).
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Episode
+from app.models import Episode, Job
 from app.tasks.ingest import ingest_episode
 
 logger = logging.getLogger(__name__)
@@ -21,6 +21,9 @@ router = APIRouter()
 # Error classes that cannot be auto-retried -- user must resolve the root cause first
 NON_RETRYABLE = {"DISK_FULL", "OOM"}
 
+# Terminal or known-idle statuses that are always safe to retry
+_RETRYABLE_STATUSES = {"done", "failed", "pending"}
+
 
 @router.post("/queue/{episode_id}/retry", status_code=202)
 def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
@@ -28,22 +31,22 @@ def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
     if not episode:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    if episode.status in ("done", "failed"):
-        # Allow reprocessing of completed or failed episodes
-        if episode.error_class in NON_RETRYABLE:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
-            )
-    elif episode.error_class is not None:
-        # Stalled job with an error — allow retry
-        if episode.error_class in NON_RETRYABLE:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
-            )
-    else:
-        raise HTTPException(status_code=409, detail="Episode is still being processed")
+    if episode.error_class in NON_RETRYABLE:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot retry -- resolve the underlying issue first ({episode.error_class})",
+        )
+
+    if episode.status not in _RETRYABLE_STATUSES:
+        # Intermediate status (downloading, transcribing, etc.) — only allow if
+        # there's no active queue entry (i.e. the episode is stuck/orphaned)
+        has_active_job = (
+            db.query(Job)
+            .filter(Job.episode_id == episode_id, Job.status.in_(["pending", "picked"]))
+            .first()
+        ) is not None
+        if has_active_job:
+            raise HTTPException(status_code=409, detail="Episode is still being processed")
 
     # Reset state and re-enqueue
     episode.status = "pending"

--- a/apps/pipeline/tests/unit/test_queue_api.py
+++ b/apps/pipeline/tests/unit/test_queue_api.py
@@ -2,6 +2,7 @@
 from unittest.mock import MagicMock, patch
 
 from app.api.queue import NON_RETRYABLE, retry_job
+from app.models import Episode, Job
 
 
 def _make_episode(status, **kwargs):
@@ -32,12 +33,23 @@ class TestNonRetryable:
 class TestRetryJob:
     """Tests for the retry endpoint guard logic (issue #46)."""
 
-    def _call_retry(self, episode):
+    def _call_retry(self, episode, has_active_job=False):
         """Call retry_job with a mocked DB that returns the given episode."""
         from fastapi import HTTPException
 
         db = MagicMock()
-        db.query.return_value.filter.return_value.first.return_value = episode
+
+        # db.query(Episode).filter(...).first() returns the episode
+        # db.query(Job).filter(...).first() returns None (no active job) or a mock
+        def query_side_effect(model):
+            chain = MagicMock()
+            if model is Episode:
+                chain.filter.return_value.first.return_value = episode
+            elif model is Job:
+                chain.filter.return_value.first.return_value = MagicMock() if has_active_job else None
+            return chain
+
+        db.query.side_effect = query_side_effect
         try:
             with patch("app.api.queue.ingest_episode"):
                 return retry_job("ep-1", db=db)
@@ -62,9 +74,9 @@ class TestRetryJob:
         assert result["queued"] is True
 
     def test_retry_active_episode_without_error_rejected(self):
-        """Active jobs without an error should not be retryable."""
+        """Active jobs with a queue entry should not be retryable."""
         ep = _make_episode("diarizing", error_class=None)
-        result = self._call_retry(ep)
+        result = self._call_retry(ep, has_active_job=True)
         assert result.status_code == 409
 
     def test_retry_non_retryable_error_rejected(self):
@@ -78,3 +90,15 @@ class TestRetryJob:
         ep = _make_episode("done", error_class="DISK_FULL")
         result = self._call_retry(ep)
         assert result.status_code == 422
+
+    def test_retry_stuck_episode_no_queue_entry_succeeds(self):
+        """Stuck episodes (intermediate status, no queue entry) should be retryable."""
+        ep = _make_episode("archiving")
+        result = self._call_retry(ep, has_active_job=False)
+        assert result["queued"] is True
+
+    def test_retry_active_episode_with_queue_entry_rejected(self):
+        """Episodes with an active queue entry should not be retryable."""
+        ep = _make_episode("transcribing")
+        result = self._call_retry(ep, has_active_job=True)
+        assert result.status_code == 409

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -178,17 +178,18 @@ function EpisodeRow({
 }) {
   const [expanded, setExpanded] = useState(false);
   const isFailed = job.status === "failed";
+  const isStuck = job.status === "stuck";
   const canRetry =
-    isFailed &&
+    (isFailed || isStuck) &&
     !NON_RETRYABLE.has(job.error_class ?? "");
 
   return (
     <>
       <tr
         className={`border-b border-border hover:bg-muted/50 ${
-          isFailed ? "bg-destructive/5 cursor-pointer" : ""
+          isFailed ? "bg-destructive/5 cursor-pointer" : isStuck ? "bg-purple-500/5 cursor-pointer" : ""
         }`}
-        onClick={isFailed ? () => setExpanded(!expanded) : undefined}
+        onClick={isFailed || isStuck ? () => setExpanded(!expanded) : undefined}
       >
         <td className="px-3 py-2 text-sm">
           <Link


### PR DESCRIPTION
## Summary
- Retry endpoint now checks the job_queue table for intermediate-status episodes
- If no pending/picked job exists, the episode is treated as stuck and retryable
- Queue UI: stuck jobs now show the Retry button and are expandable (purple highlight)
- Currently 10 episodes stuck in "archiving" status can now be retried from the UI

## Changes
- `apps/pipeline/app/api/queue.py` — check Job table for active entries before rejecting intermediate-status episodes
- `apps/pipeline/tests/unit/test_queue_api.py` — updated mocks for Job query, added stuck/active queue entry tests
- `apps/web/src/components/QueueStatus.tsx` — enable retry + expand for stuck jobs

## Testing
- 10/10 queue API unit tests pass
- TypeScript compiles cleanly

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)