### PR TITLE
fix: ask page SQL error from vector cast syntax

### DIFF
--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -72,7 +72,8 @@ async def _stream_ask(question: str, model: str, feed_ids: list[str] | None):
             question[:100],
             str(exc),
         )
-        yield _sse_event("error", {"message": f"Error generating answer: {type(exc).__name__}"})
+        detail = str(exc).split("\n")[0][:200] if str(exc) else type(exc).__name__
+        yield _sse_event("error", {"message": f"Error generating answer: {detail}"})
         yield _sse_event("done", {})
     finally:
         db.close()

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -78,12 +78,12 @@ def retrieve_chunks(
             c.start_time,
             c.end_time,
             c.text,
-            1 - (c.embedding <=> :embedding::vector) AS similarity
+            1 - (c.embedding <=> CAST(:embedding AS vector)) AS similarity
         FROM chunks c
         JOIN episodes e ON c.episode_id = e.id
         WHERE c.embedding IS NOT NULL
             {feed_filter}
-        ORDER BY c.embedding <=> :embedding::vector
+        ORDER BY c.embedding <=> CAST(:embedding AS vector)
         LIMIT :top_k
     """)
 


### PR DESCRIPTION
## Summary
- Fixed `ProgrammingError` when using Ask page: `::vector` PostgreSQL cast syntax conflicts with SQLAlchemy `text()` parameter binding (`:embedding::vector` parsed as two params `:embedding` and `:vector`)
- Changed to `CAST(:embedding AS vector)` which SQLAlchemy handles correctly
- Improved SSE error messages to include actual error detail instead of just the exception class name

## Changes
- `apps/pipeline/app/services/rag.py` — use CAST() instead of :: for vector type cast
- `apps/pipeline/app/api/ask.py` — include first line of error message in SSE error events

## Testing
- 12/12 RAG unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)