### PR TITLE
feat: show full speaker segments in search results (#182)

### DIFF
--- a/apps/web/src/components/EpisodeMentionList.tsx
+++ b/apps/web/src/components/EpisodeMentionList.tsx
@@ -37,6 +37,8 @@ function ContextLine({ seg, dimmed }: { seg: ContextSegment; dimmed: boolean }) 
   );
 }
 
+const SNIPPET_COLLAPSE_THRESHOLD = 500;
+
 function MentionCard({
   mention,
   index,
@@ -57,7 +59,9 @@ function MentionCard({
   query: string;
 }) {
   const { playEpisode } = useAudioPlayer();
+  const [expanded, setExpanded] = useState(false);
   const queryParam = query ? `?q=${encodeURIComponent(query)}` : "";
+  const isLong = mention.snippet.length > SNIPPET_COLLAPSE_THRESHOLD;
 
   function handlePlay() {
     if (!audioLocalPath) return;
@@ -109,9 +113,19 @@ function MentionCard({
               </span>
             )}
             <span
-              className="text-foreground [&_b]:font-semibold [&_b]:bg-yellow-200 [&_b]:dark:bg-yellow-800 [&_b]:px-0.5 [&_b]:rounded-sm"
+              className={`text-foreground [&_b]:font-semibold [&_b]:bg-yellow-200 [&_b]:dark:bg-yellow-800 [&_b]:px-0.5 [&_b]:rounded-sm ${
+                isLong && !expanded ? "line-clamp-4" : ""
+              }`}
               dangerouslySetInnerHTML={{ __html: mention.snippet }}
             />
+            {isLong && (
+              <button
+                onClick={() => setExpanded((e) => !e)}
+                className="text-xs text-primary hover:underline mt-1 block"
+              >
+                {expanded ? "Show less" : "Show more"}
+              </button>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/components/SearchResult.tsx
+++ b/apps/web/src/components/SearchResult.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, ExternalLink, FileText, FlaskConical, Play } from "lucide-react";
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
@@ -8,6 +9,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { SearchResult as SearchResultType } from "@/lib/search";
 import { basename } from "@/lib/utils";
+
+const SNIPPET_COLLAPSE_THRESHOLD = 500;
 
 interface Props {
   result: SearchResultType;
@@ -23,6 +26,8 @@ interface Props {
  */
 export default function SearchResult({ result, query }: Props) {
   const { playEpisode } = useAudioPlayer();
+  const [expanded, setExpanded] = useState(false);
+  const isLong = result.snippet.length > SNIPPET_COLLAPSE_THRESHOLD;
 
   const hasLocalAudio = !!result.audioLocalPath;
   const queryParam = query ? `?q=${encodeURIComponent(query)}` : "";
@@ -113,11 +118,23 @@ export default function SearchResult({ result, query }: Props) {
           </div>
         </div>
 
-        {/* Snippet — rendered HTML from ts_headline (contains <b> tags) */}
-        <p
-          className="text-sm leading-relaxed [&_b]:font-semibold [&_b]:text-foreground text-muted-foreground"
-          dangerouslySetInnerHTML={{ __html: result.snippet }}
-        />
+        {/* Full speaker turn with highlighted matches */}
+        <div className="relative">
+          <p
+            className={`text-sm leading-relaxed [&_b]:font-semibold [&_b]:text-foreground text-muted-foreground ${
+              isLong && !expanded ? "line-clamp-4" : ""
+            }`}
+            dangerouslySetInnerHTML={{ __html: result.snippet }}
+          />
+          {isLong && (
+            <button
+              onClick={() => setExpanded((e) => !e)}
+              className="text-xs text-primary hover:underline mt-1"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -180,7 +180,7 @@ export async function searchSegments(
       t.end_time,
       t.speaker_label,
       COALESCE(sn.display_name, t.speaker_label) AS speaker_display,
-      ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12') AS snippet,
+      ts_headline('english', t.full_text, query, 'MaxFragments=0, HighlightAll=true') AS snippet,
       ts_rank(to_tsvector('english', t.full_text), query) AS rank,
       e.id AS episode_id,
       e.title AS episode_title,
@@ -488,7 +488,7 @@ export async function searchMentions(
       t.full_text,
       CASE WHEN to_tsvector('english', t.full_text) @@ query THEN true ELSE false END AS is_match,
       CASE WHEN to_tsvector('english', t.full_text) @@ query
-        THEN ts_headline('english', t.full_text, query, 'MaxWords=25, MinWords=12')
+        THEN ts_headline('english', t.full_text, query, 'MaxFragments=0, HighlightAll=true')
         ELSE '' END AS snippet,
       CASE WHEN to_tsvector('english', t.full_text) @@ query
         THEN ts_rank(to_tsvector('english', t.full_text), query)


### PR DESCRIPTION
## Summary
- Changed `ts_headline` to return the full speaker turn text with all matches highlighted (`MaxFragments=0, HighlightAll=true`) instead of a short fragment
- Added collapsible expand/collapse for long snippets (>500 chars) in both flat `SearchResult` cards and grouped `MentionCard` views
- Applied consistently across flat search, grouped mentions, and episode mention detail views

## Changes
- `apps/web/src/lib/search.ts` — Updated `ts_headline` options in flat search and mentions queries
- `apps/web/src/components/SearchResult.tsx` — Added `line-clamp-4` collapse with "Show more"/"Show less" toggle
- `apps/web/src/components/EpisodeMentionList.tsx` — Same collapse treatment for mention cards in grouped view

## Testing
- All 81 web tests pass
- TypeScript compilation clean (no new errors)

Closes #182