### PR TITLE
fix: improve Ask page error handling for Ollama failures (#181)

### DIFF
--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -67,12 +67,14 @@ async def _stream_ask(question: str, model: str, feed_ids: list[str] | None):
         yield _sse_event("done", {})
 
     except Exception as exc:
+        error_str = str(exc) or type(exc).__name__
         logger.error(
-            '"action": "ask_error", "question": "%s", "error": "%s"',
+            '"action": "ask_error", "question": "%s", "error": "%s (%s)"',
             question[:100],
-            str(exc),
+            error_str,
+            type(exc).__name__,
         )
-        detail = str(exc).split("\n")[0][:200] if str(exc) else type(exc).__name__
+        detail = error_str.split("\n")[0][:200]
         yield _sse_event("error", {"message": f"Error generating answer: {detail}"})
         yield _sse_event("done", {})
     finally:

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -162,19 +162,24 @@ async def stream_ollama_response(
         "stream": True,
     }
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=120, write=10, pool=10)) as client:
-        async with client.stream("POST", url, json=payload) as resp:
-            if resp.status_code != 200:
-                body = await resp.aread()
-                raise RuntimeError(f"Ollama returned {resp.status_code}: {body.decode()}")
-            async for line in resp.aiter_lines():
-                if not line:
-                    continue
-                data = json.loads(line)
-                if content := data.get("message", {}).get("content"):
-                    yield content
-                if data.get("done"):
-                    return
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=120, write=10, pool=10)) as client:
+            async with client.stream("POST", url, json=payload) as resp:
+                if resp.status_code != 200:
+                    body = await resp.aread()
+                    raise RuntimeError(f"Ollama returned {resp.status_code}: {body.decode()[:500]}")
+                async for line in resp.aiter_lines():
+                    if not line:
+                        continue
+                    data = json.loads(line)
+                    if data.get("error"):
+                        raise RuntimeError(f"Ollama error: {data['error']}")
+                    if content := data.get("message", {}).get("content"):
+                        yield content
+                    if data.get("done"):
+                        return
+    except httpx.HTTPError as exc:
+        raise RuntimeError(f"Ollama connection error: {type(exc).__name__}: {exc}") from exc
 
 
 async def check_model_available(model: str) -> bool:

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -247,7 +247,9 @@ export default function AskPage() {
       } catch (err: unknown) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setStatus("error");
-        setErrorMsg("Connection failed. Is the pipeline running?");
+        setErrorMsg((prev) =>
+          prev || "Connection failed. Is the pipeline running?"
+        );
       }
     },
     [question, model, selectedFeedIds]


### PR DESCRIPTION
## Summary
- Wraps Ollama streaming in `try/except httpx.HTTPError` to produce clear error messages when the connection breaks mid-stream
- Checks for `error` field in Ollama's streaming JSON (e.g. model OOM)
- Pipeline error logs now always include the exception type alongside the message
- Frontend catch block preserves any SSE error message already received instead of overwriting with generic "Connection failed"

## Context
PR #180 fixed the SQL `::vector` cast error and added basic message improvements. This PR addresses the remaining gap: when Ollama itself fails (500, connection reset, timeout), the error string was empty, and the frontend always showed "Connection failed. Is the pipeline running?" even when the pipeline was running fine.

## Testing
- Verified Ollama is healthy and Ask page works end-to-end
- Containers already rebuilt and deployed with these changes

Closes #181