### PR TITLE
docs: fix stale documentation across CLAUDE.md, README, PRDs, and guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Podlog is a self-hosted podcast transcription and search app. It downloads episodes from RSS feeds, transcribes them with Whisper, labels speakers with pyannote, and provides a web UI to search across all transcripts. Single user, local only, runs entirely in Docker.
 
-**Phase:** Core pipeline is operational. Episodes are being ingested, transcribed, diarized, chunked, and archived. 302 pipeline + 81 web tests pass. 10 Alembic migrations applied. Web UI serves search, queue dashboard, feed management, and an Ask AI feature.
+**Phase:** Core pipeline is operational. Episodes are being ingested, transcribed, diarized, chunked, and archived. 317 pipeline + 81 web tests pass. 10 Alembic migrations applied. Web UI serves search, queue dashboard, feed management, and an Ask AI feature.
 
 ## Documentation
 
@@ -15,6 +15,7 @@ Detailed specifications live in `prds/`:
 | `prds/PRD-01-ingestion-pipeline.md` | Pipeline: RSS ingestion, Whisper, pyannote, task queue, error handling, retry logic |
 | `prds/PRD-02-search-web-app.md` | Web app: search UI, audio player, queue dashboard, dark mode, speaker renaming |
 | `prds/PRD-03-infrastructure.md` | Docker Compose, repo structure, Dockerfiles, CI/CD, Makefile, env vars |
+| `prds/PRD-04-host-guest-inference.md` | Host/guest speaker name inference via NER |
 | `prds/RISKS-AND-GAPS.md` | Active risks, known gaps, hardware requirements, resolved items |
 
 When making decisions, reference PRD sections (e.g. "per PRD-01 §5.4") rather than re-deriving. The PRDs are the source of truth for requirements.
@@ -27,6 +28,9 @@ podlog/
 ├── docker-compose.test.yml         # Test stack with db_test, mock_rss, test runner
 ├── .env.example                    # All config vars documented
 ├── Makefile                        # make up / down / build / test / etc.
+├── README.md
+├── VERSION
+├── LICENSE
 ├── apps/
 │   ├── pipeline/                   # Python 3.11 — FastAPI + DB-backed job queue
 │   │   ├── app/
@@ -34,17 +38,19 @@ podlog/
 │   │   │   ├── config.py           # pydantic-settings, all env vars
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments, speaker_names)
 │   │   │   ├── database.py         # Engine + session factory
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, notifications)
-│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive)
-│   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, notifications)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications)
+│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive, cleanup, prewarm)
+│   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, notifications, digest, events)
 │   │   │   └── worker.py           # Background job worker
 │   │   ├── alembic/                # Database migrations (10 applied)
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 14 (App Router)
-│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds, /ask, /search, /notifications
-│       ├── src/app/api/            # API routes: search, feeds, queue, audio, speaker rename, wizard, notifications
+│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds, /ask, /notifications
+│       ├── src/app/api/            # API routes: search, feeds, queue, audio, ask, speaker rename, wizard, notifications, pipeline proxy
 │       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, SetupWizard, etc.
-│       └── src/lib/                # db.ts (pg pool), search.ts (FTS query), timestamp.ts, pipeline.ts
+│       └── src/lib/                # db.ts, search.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts
+├── docs/                           # User-facing documentation and guides
+├── scripts/                        # Operational scripts (nightly audit, health check)
 └── prds/                           # Specifications and risk register
 ```
 
@@ -54,10 +60,10 @@ podlog/
 |---|---|---|
 | Pipeline API | FastAPI (Python 3.11) | Internal API consumed by web app |
 | Task queue | PostgreSQL-backed job queue | Sequential processing (concurrency=1) to avoid OOM |
-| Transcription | `openai/whisper-large-v3` via `transformers` | Explicit unload before diarization — mandatory |
+| Transcription | WhisperX (CTranslate2 backend), default `large-v3-turbo` | Explicit unload before diarization — mandatory |
 | Diarization | `pyannote/speaker-diarization-3.1` | Requires HF_TOKEN; graceful failure path |
 | LLM inference | Ollama (local) | RAG-based Ask AI feature; default model configurable via `OLLAMA_MODEL` |
-| Database | PostgreSQL 15 | FTS via `to_tsvector` + GIN index |
+| Database | PostgreSQL 15 (pgvector/pgvector:pg15) | FTS via `to_tsvector` + GIN index, vector HNSW index |
 | ORM | SQLAlchemy 2.0 + Alembic | Migrations auto-run on pipeline startup |
 | Web app | Next.js 14 (App Router) | `output: 'standalone'` for Docker |
 | Styling | Tailwind CSS + shadcn/ui | Dark mode via `class` strategy; 12 shadcn/ui components installed |
@@ -102,7 +108,7 @@ Services: web (:3000), pipeline API (:8000), ollama (:11434).
 - Full pipeline: ingest, download, transcribe, diarize, chunk, embed, infer, archive
 - All FastAPI endpoints (feeds, episodes, queue, health, ask, notifications, backfill)
 - All Next.js pages, API routes, and components (search, ask, queue, feeds, episodes, notifications)
-- 302 pipeline tests + 81 web tests passing
+- 317 pipeline tests + 81 web tests passing
 - 10 Alembic migrations applied
 - 12 shadcn/ui components installed
 - Setup wizard for first-run onboarding
@@ -111,5 +117,5 @@ Services: web (:3000), pipeline API (:8000), ollama (:11434).
 - Notification settings
 
 **Not yet done:**
-- Integration and e2e test bodies (stubs exist, some skipped)
+- Some integration and e2e test bodies still stubbed or skipped
 - Full end-to-end pipeline smoke test in CI

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add RSS feeds, transcribe episodes with Whisper, label speakers with pyannote, a
 ![PostgreSQL](https://img.shields.io/badge/postgresql-15-4169e1?logo=postgresql&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-compose-2496ed?logo=docker&logoColor=white)
 ![License](https://img.shields.io/badge/license-O'Saasy-green)
-![Tests](https://img.shields.io/badge/tests-383%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-398%20passed-brightgreen)
 
 </div>
 
@@ -126,7 +126,7 @@ make up              # Start all services
 make down            # Stop all services
 make build           # Rebuild Docker images
 make logs            # Follow logs for all services
-make test-unit       # Run unit tests (383 tests)
+make test-unit       # Run unit tests (398 tests)
 make shell-db        # Open psql shell
 make health-install  # Install health monitoring cron (every 15 min)
 make help            # List all available commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,15 +16,15 @@ podlog/
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments)
 │   │   │   ├── database.py         # Engine + session factory
 │   │   │   ├── job_queue.py        # DB-backed job queue (FOR UPDATE SKIP LOCKED)
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, embed)
-│   │   │   ├── tasks/              # Pipeline tasks (download, transcribe, diarize, embed, infer, archive)
-│   │   │   └── services/           # Business logic (whisper, pyannote, alignment, embed)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications)
+│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive, cleanup, prewarm)
+│   │   │   └── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, notifications, digest, events)
 │   │   ├── alembic/                # Database migrations
 │   │   └── tests/                  # Unit, integration, e2e tests
 │   └── web/                        # Next.js 14 (App Router)
-│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds
+│       ├── src/app/                # Pages: /, /podcasts, /episodes/[id], /queue, /feeds, /ask, /notifications
 │       ├── src/components/         # React components
-│       └── src/lib/                # Utilities (db, search, timestamp, types)
+│       └── src/lib/                # Utilities (db, search, timestamp, pipeline, types, utils, speakerColors, validateMergeRequest)
 ├── docs/                           # User-facing documentation
 └── prds/                           # Internal design specs and risk register
 ```
@@ -91,7 +91,7 @@ docker compose exec pipeline alembic upgrade head
 
 ## Running Tests
 
-### Unit Tests (383 tests — 302 pipeline + 81 web)
+### Unit Tests (398 tests — 317 pipeline + 81 web)
 
 ```bash
 cd apps/pipeline
@@ -199,9 +199,9 @@ claude -p "/codebase-audit" \
 
 ### Output
 
-- **Report:** `docs/audit/YYYY-MM-DD-audit.md` — committed and pushed to main
-- **Issues:** CRITICAL and WARNING findings auto-create GitHub issues with label `codebase-audit`
-- **Status:** Check the `> Status:` line at the top of the report to see if it completed (`COMPLETE 7/7`) or was interrupted (`IN PROGRESS N/7`)
+- **Reports:** `docs/audit/YYYY-MM-DD/claude/` — one file per check section plus a `summary.md`
+- **No auto-commit or issue creation** — reports are left as local files for manual review
+- **Status:** Check the `> Status:` line in `summary.md` to see if it completed (`COMPLETE 7/7`) or was interrupted (`IN PROGRESS N/7`)
 
 ### What it checks
 

--- a/docs/episode-lifecycle.md
+++ b/docs/episode-lifecycle.md
@@ -209,18 +209,18 @@ Everything from FTS, plus:
 ---
 
 ### RAG Search ("Ask" Page)
-**Status:** Not yet implemented (#114, #115, #116, #117)
+**Status:** Working
 
 Everything from Hybrid Search, plus:
 
 | Requirement | Source | Notes |
 |-------------|--------|-------|
-| `chunks` table | **#114 — NEW** | Merged speaker-turn text (~400 tokens) with embeddings |
-| `chunks.embedding` | **#114 — NEW** | 384-dim vector on the merged chunk (better quality than per-segment) |
-| HNSW index on `chunks.embedding` | **#114 — NEW** | For fast retrieval |
-| Ollama service | **#115 — NEW** | Local LLM for answer generation |
-| RAG endpoint (`POST /api/ask`) | **#116 — NEW** | Retrieval + prompt + streaming |
-| Ask page UI | **#117 — NEW** | Frontend for streaming answers with citations |
+| `chunks` table | Chunk task | Merged speaker-turn text (~400 tokens) with embeddings |
+| `chunks.embedding` | Chunk task | 384-dim vector on the merged chunk (better quality than per-segment) |
+| HNSW index on `chunks.embedding` | Migration | For fast retrieval |
+| Ollama service | docker-compose.yml | Local LLM for answer generation |
+| RAG endpoint (`POST /api/ask`) | Pipeline API | Retrieval + prompt + streaming |
+| Ask page UI | `/ask` page | Frontend for streaming answers with citations |
 
 **Minimum viable:** Chunks table populated + Ollama running + RAG endpoint + Ask page.
 
@@ -237,8 +237,8 @@ A fully processed episode ready for all current and planned features:
 | Diarized | `has_diarization = true` | Speaker labels assigned (non-fatal if false) |
 | Embedded | All segments have `embedding IS NOT NULL` | 100% coverage |
 | Speaker names | `speaker_names` rows exist | At least host identified (non-fatal if missing) |
-| Chunked | `chunks` rows exist for episode | **Not yet implemented (#114)** |
-| Chunk embeddings | All chunks have `embedding IS NOT NULL` | **Not yet implemented (#114)** |
+| Chunked | `chunks` rows exist for episode | Produced by chunk task |
+| Chunk embeddings | All chunks have `embedding IS NOT NULL` | Produced by chunk task |
 | Archived | `status = 'done'` AND `processed_at IS NOT NULL` | Episode fully processed |
 | Transcript file | `transcript_path IS NOT NULL` | Flat `.txt` file written |
 

--- a/docs/guide/12-rag-search.md
+++ b/docs/guide/12-rag-search.md
@@ -1,28 +1,44 @@
-# RAG Search (Coming Soon)
+# Ask AI (RAG Search)
 
-A future feature that will let you ask natural language questions and get answers drawn from your transcript library.
+Ask natural language questions and get answers drawn from your transcript library, powered by a local LLM.
 
-## What It Will Do
+## How It Works
 
-Instead of searching for keywords, you'll be able to ask questions like:
+Instead of searching for keywords, you can ask questions like:
 
 - "What arguments were made about carbon pricing across all episodes?"
 - "Did anyone discuss the impact of remote work on team culture?"
 - "Summarize what guests have said about AI regulation"
 
-The system will retrieve relevant transcript excerpts, feed them to a local LLM, and return a citation-backed answer with clickable timestamps linking to the source audio.
+The system retrieves relevant transcript chunks via semantic search (pgvector), feeds them to a local LLM as context, and streams back a citation-backed answer with clickable timestamps linking to the source audio.
 
-## How It Will Work
+## Using Ask AI
 
-- **Fully local** — powered by [Ollama](https://ollama.ai) running on your machine
-- **No external API calls** — your data never leaves your computer
-- **Streaming responses** — answers appear word-by-word instead of waiting 20-30 seconds for a full response
-- **Model selection** — choose between faster (Qwen2.5-1.5B) and higher quality (Qwen2.5-3B) models
+1. Navigate to the **Ask** page from the navbar
+2. Type your question in the input box
+3. The answer streams in word-by-word with source citations
+4. Click any citation timestamp to jump to that point in the audio
+
+## Architecture
+
+- **Fully local** — powered by [Ollama](https://ollama.ai) running in a Docker container
+- **No external API calls** — your data never leaves your machine
+- **Streaming responses** — answers appear word-by-word via server-sent events
+- **Model selection** — configurable via `OLLAMA_MODEL` env var (default: see `.env.example`)
 - **Additional RAM:** ~2 GB when the LLM is active (auto-unloaded when idle)
 
-## Status
+## Prerequisites
 
-This feature is being planned in [issue #90](https://github.com/brlauuu/podlog/issues/90). The embedding pipeline (a prerequisite) is already in place — all transcript segments are embedded with all-MiniLM-L6-v2 vectors stored in pgvector.
+The Ask AI feature requires:
+- The Ollama service running (included in `docker-compose.yml`)
+- At least one episode fully processed through the embed stage (segments need vector embeddings)
+- A pulled Ollama model (`make ollama-pull` or the worker pulls it automatically)
+
+## Troubleshooting
+
+- **"Ollama not available"** — Check that the ollama container is running: `docker compose ps ollama`
+- **Slow first response** — The model loads into memory on first query; subsequent queries are faster
+- **Poor answer quality** — Try a larger model via `OLLAMA_MODEL` in `.env`, or ensure more episodes are processed so the retrieval pool is larger
 
 ---
 

--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -147,7 +147,7 @@ The flat file is always written on successful transcription, regardless of diari
 
 - Task runner: **PostgreSQL-backed job queue** (no external broker). Jobs are stored in the `episodes` table with status tracking.
 - Jobs are processed sequentially by default (one worker, concurrency=1) to avoid memory exhaustion on CPU-only machines running Whisper.
-- Job states: `PENDING` → `DOWNLOADING` → `TRANSCRIBING` → `DIARIZING` → `ARCHIVING` → `DONE` / `FAILED`.
+- Job states: `PENDING` → `DOWNLOADING` → `TRANSCRIBING` → `DIARIZING` → `EMBEDDING` → `CHUNKING` → `INFERRING` → `ARCHIVING` → `DONE` / `FAILED`.
 - **Error classification:** All failures are tagged with an `error_class` field stored in the database and surfaced in the queue UI:
 
 | `error_class`        | Meaning                               | Auto-retry?              |

--- a/prds/RISKS-AND-GAPS.md
+++ b/prds/RISKS-AND-GAPS.md
@@ -117,10 +117,10 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 **Component:** PRD-01 — Worker  
 **Description:** Whisper large-v3 requires ~3.5 GB RAM. On machines with 8 GB total, OS overhead + Docker + PostgreSQL + the worker can push total usage to the limit. If the OS kills the worker process mid-transcription, the episode stays in `TRANSCRIBING` state indefinitely (zombie job).  
 **Mitigation:**
-1. Per PRD-01 §5.9, `OOM` is an error class — if Celery catches the OOM exception, it marks the job `FAILED` with `error_class=OOM`.
+1. Per PRD-01 §5.9, `OOM` is an error class — if the worker catches the OOM exception, it marks the job `FAILED` with `error_class=OOM`.
 2. Document the hardware recommendations (above) prominently in the README.
 3. Recommend `WHISPER_MODEL=medium` or `small` for machines with <16 GB RAM.
-4. Known gap: if the OS kills the process with SIGKILL (rather than Python raising an exception), Celery cannot catch it. The job stalls. Add a periodic "zombie job" cleanup task in V1 that marks jobs stuck in non-terminal states for >2 hours as failed.
+4. Known gap: if the OS kills the process with SIGKILL (rather than Python raising an exception), the worker cannot catch it. The job stalls. A periodic zombie job cleanup task marks jobs stuck in non-terminal states for >2 hours as failed.
 
 **Status:** Fully mitigated in v1.3. Zombie job cleanup task implemented (see GAP-01 resolved).
 
@@ -188,16 +188,9 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 
 ---
 
-### RISK-07: Celery Beat Single Point of Failure
+### ~~RISK-07: Celery Beat Single Point of Failure~~ → Resolved in v1.3
 
-**Severity:** Low  
-**Component:** PRD-01 — Scheduler  
-**Description:** Celery Beat runs as a separate container and stores its schedule state in-memory (or in a local file). If the beat container restarts, it may re-enqueue tasks that already ran, or miss scheduled runs during downtime. For a 24-hour feed poll this is low-impact (a missed poll is caught on the next cycle), but it is worth documenting.  
-**Mitigation:**
-1. Use Celery Beat's database scheduler (`django-celery-beat` or the SQLAlchemy equivalent) to persist the schedule state to PostgreSQL in V1. This makes beat restarts safe.
-2. For MVP, the in-memory scheduler is acceptable given the 24-hour interval and single-user context.
-
-**Status:** Accepted for MVP. Database scheduler is a V1 candidate.
+*Moved to Part 4: Resolved Items.*
 
 ---
 
@@ -215,12 +208,9 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 
 ---
 
-### GAP-03: No Episode Re-Processing in MVP
+### ~~GAP-03: No Episode Re-Processing in MVP~~ → Resolved in v1.3
 
-**Component:** PRD-01  
-**Description:** If a user wants to re-transcribe an episode (e.g. after changing `WHISPER_MODEL`), there is no mechanism in MVP. The episode is already marked `done` and is idempotency-blocked from re-ingestion.  
-**Proposed fix:** Add a `POST /api/episodes/{id}/reprocess` endpoint that resets the episode's status to `pending`, clears segments, and re-enqueues the task. This is already listed in the V1 roadmap (PRD-01 §11).  
-**Target phase:** V1
+*Moved to Part 4: Resolved Items.*
 
 ---
 
@@ -259,8 +249,8 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 | GAP-N/A | Pagination count missing | Companion `COUNT(*)` query added to search API route | v1.1 |
 | GAP-02 | No RSS feed validation on add | `validate_and_parse_feed()` in `rss.py` fetches + parses before persisting; 422 on failure | v1.2 |
 | GAP-06 | No disk space pre-check before download | `shutil.disk_usage()` check against `DISK_HEADROOM_BYTES` (default 2 GB) before download | v1.2 |
-| GAP-N/A | `redis_test` service missing from test compose | Added `redis_test` service with healthcheck to `docker-compose.test.yml` | v1.2 |
 | GAP-N/A | `updated_at` missing from episodes table | Added `updated_at` to episodes model (prerequisite for GAP-01 zombie detection) | v1.2 |
-| GAP-N/A | `beat` container startup ordering | Changed `beat` dependency from `- worker` to `pipeline: service_healthy` | v1.2 |
 | GAP-N/A | Next.js standalone output missing | Added `output: 'standalone'` to `next.config.ts` (required for Docker build) | v1.2 |
-| GAP-01 | Zombie job cleanup | Periodic Celery Beat task every 30 min — queries episodes stuck in non-terminal status for >2 h and marks them `failed` with `error_class=SYSTEM_ERROR` (`app/tasks/cleanup.py`) | v1.3 |
+| GAP-01 | Zombie job cleanup | Periodic task every 30 min — queries episodes stuck in non-terminal status for >2 h and marks them `failed` with `error_class=SYSTEM_ERROR` (`app/tasks/cleanup.py`) | v1.3 |
+| GAP-03 | No episode re-processing | Episode reprocessing implemented — resets status to `pending`, clears segments, re-enqueues through the pipeline | v1.3 |
+| RISK-07 | Celery Beat single point of failure | No longer applicable — Celery/Redis replaced by PostgreSQL-backed job queue with polling loop in `worker.py` | v1.3 |


### PR DESCRIPTION
## Summary

- Update test counts (302->317 pipeline, 383->398 total) across README, CLAUDE.md, and development.md
- Add PRD-04 to CLAUDE.md docs table; expand repo structure tree with missing files/dirs
- Fix transcription stack (WhisperX, not transformers) and DB image (pgvector/pgvector:pg15)
- Rewrite RAG guide from "Coming Soon" to document the working Ask AI feature
- Resolve stale RISKS-AND-GAPS entries (Celery Beat, episode reprocessing)
- Add missing pipeline job states (EMBEDDING, CHUNKING, INFERRING) to PRD-01
- Update audit output docs to reflect local-only report format

Closes #192

## Test plan

- [ ] Verify no broken markdown links in changed files
- [ ] Spot-check that updated counts/paths match the actual codebase
- [ ] Confirm CLAUDE.md repo structure tree matches `ls` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)