### PR TITLE
feat: simplify footer, add about page, move system status to help menu

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -1,0 +1,115 @@
+import { ExternalLink } from "lucide-react";
+
+const TECH_STACK = [
+  { name: "WhisperX", url: "https://github.com/m-bain/whisperX" },
+  { name: "faster-whisper", url: "https://github.com/SYSTRAN/faster-whisper" },
+  { name: "pyannote", url: "https://github.com/pyannote/pyannote-audio" },
+  { name: "Next.js", url: "https://nextjs.org" },
+  { name: "PostgreSQL", url: "https://www.postgresql.org" },
+  { name: "Tailwind CSS", url: "https://tailwindcss.com" },
+  { name: "shadcn/ui", url: "https://ui.shadcn.com" },
+];
+
+const CREDITS = [
+  { name: "@brlauuu", url: "https://brlauuu.github.io" },
+  { name: "Claude (Anthropic)", url: "https://www.anthropic.com" },
+  { name: "Codex (OpenAI)", url: "https://openai.com" },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-8 py-4">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">About Podlog</h1>
+        <p className="text-muted-foreground">
+          Podlog is a self-hosted podcast transcription and search application.
+          It downloads episodes from RSS feeds, transcribes them locally using
+          Whisper, identifies speakers with pyannote, and provides full-text and
+          semantic search across all your transcripts.
+        </p>
+        <p className="text-muted-foreground">
+          Everything runs on your hardware. No audio leaves your machine, no
+          transcripts are sent to external services, and no telemetry is
+          collected.
+        </p>
+      </div>
+
+      {/* Blog placeholder */}
+      <div className="rounded-lg border border-border p-4 space-y-1">
+        <p className="text-sm font-medium">Read more</p>
+        <p className="text-sm text-muted-foreground">
+          A blog post covering the motivation behind Podlog is coming soon.
+        </p>
+      </div>
+
+      {/* Credits */}
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Credits</h2>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+          {CREDITS.map((credit) => (
+            <a
+              key={credit.name}
+              href={credit.url}
+              className="text-muted-foreground underline hover:text-foreground"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {credit.name}
+            </a>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <ExternalLink size={13} />
+          <a
+            href="https://github.com/brlauuu/podlog"
+            className="underline hover:text-foreground"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            brlauuu/podlog
+          </a>
+          {" · "}
+          <a
+            href="https://osaasy.dev"
+            className="underline hover:text-foreground"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            O&apos;Saasy License
+          </a>
+        </div>
+      </div>
+
+      {/* Built with */}
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Built with</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {TECH_STACK.map((tech, i) => (
+            <span key={tech.name}>
+              <a
+                href={tech.url}
+                className="underline hover:text-foreground"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {tech.name}
+              </a>
+              {i < TECH_STACK.length - 1 ? " · " : ""}
+            </span>
+          ))}
+        </p>
+      </div>
+
+      {/* Privacy */}
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Privacy</h2>
+        <p className="text-sm text-muted-foreground">
+          All data stays on your machine. Audio files, transcripts, and
+          embeddings are stored locally. No external APIs are called during
+          transcription or search. The only outbound requests are RSS feed
+          fetches to download episode metadata and audio.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,140 +1,36 @@
-"use client";
-
-import { useQuery } from "@tanstack/react-query";
-import { ExternalLink } from "lucide-react";
+import Link from "next/link";
 
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
 
-interface ServiceStatus {
-  name: string;
-  status: string;
-}
-
-interface HealthData {
-  status: string;
-  services?: ServiceStatus[];
-}
-
-const TECH_STACK = [
-  { name: "WhisperX", url: "https://github.com/m-bain/whisperX" },
-  { name: "faster-whisper", url: "https://github.com/SYSTRAN/faster-whisper" },
-  { name: "pyannote", url: "https://github.com/pyannote/pyannote-audio" },
-  { name: "Next.js", url: "https://nextjs.org" },
-  { name: "PostgreSQL", url: "https://www.postgresql.org" },
-  { name: "Tailwind CSS", url: "https://tailwindcss.com" },
-  { name: "shadcn/ui", url: "https://ui.shadcn.com" },
-];
-
-function StatusDot({ status }: { status: string }) {
-  const color =
-    status === "OK"
-      ? "bg-green-500"
-      : status === "WARMING_UP"
-        ? "bg-amber-500"
-        : "bg-red-500";
-
-  return (
-    <span className={`inline-block w-2 h-2 rounded-full ${color} shrink-0`} />
-  );
-}
-
 export default function Footer() {
-  const health = useQuery<HealthData>({
-    queryKey: ["pipeline-health"],
-    queryFn: async () => {
-      const resp = await fetch("/api/pipeline/health", { cache: "no-store" });
-      if (!resp.ok) return { status: "DEGRADED", services: [] };
-      return resp.json();
-    },
-    refetchInterval: 30_000,
-    staleTime: 10_000,
-  });
-
-  const services = health.data?.services ?? [];
-
   return (
-    <footer className="border-t border-border bg-background text-sm text-muted-foreground mt-auto">
-      <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
-        {/* Top row: branding + system status */}
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-          <div className="space-y-1">
-            <p className="font-semibold text-foreground text-base">Podlog</p>
-            <p>Self-hosted podcast transcription and search</p>
-          </div>
-          <div className="space-y-1.5 text-xs">
-            <p className="font-medium text-foreground">System status</p>
-            {services.length > 0 ? (
-              <div className="space-y-1">
-                {services.map((svc) => (
-                  <div key={svc.name} className="flex items-center gap-2">
-                    <StatusDot status={svc.status} />
-                    <span>{svc.name}</span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="flex items-center gap-2">
-                <StatusDot status="DEGRADED" />
-                <span>Checking...</span>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Info grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-xs">
-          {/* Credits */}
-          <div className="space-y-2">
-            <p className="font-medium text-foreground">Credits</p>
-            <p>
-              Built by{" "}
-              <a href="https://brlauuu.github.io" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
-                @brlauuu
-              </a>
-              {" "}and{" "}
-              <a href="https://www.anthropic.com" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
-                Claude (Anthropic)
-              </a>
-            </p>
-            <div className="flex items-center gap-1.5">
-              <ExternalLink size={13} />
-              <a href="https://github.com/brlauuu/podlog" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
-                brlauuu/podlog
-              </a>
-              {" · "}
-              <a href="https://osaasy.dev" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
-                O&apos;Saasy License
-              </a>
-            </div>
-          </div>
-
-          {/* Tech stack with links */}
-          <div className="space-y-2">
-            <p className="font-medium text-foreground">Built with</p>
-            <p className="leading-relaxed">
-              {TECH_STACK.map((tech, i) => (
-                <span key={tech.name}>
-                  <a href={tech.url} className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
-                    {tech.name}
-                  </a>
-                  {i < TECH_STACK.length - 1 ? " · " : ""}
-                </span>
-              ))}
-            </p>
-          </div>
-
-          {/* Privacy */}
-          <div className="space-y-2">
-            <p className="font-medium text-foreground">Privacy</p>
-            <p>All data stays on your machine. No external telemetry.</p>
-          </div>
-        </div>
-
-        {/* Bottom row */}
-        <div className="flex items-center justify-between pt-2 border-t border-border text-xs">
-          <p>&copy; 2026 <a href="https://brlauuu.github.io" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">brlauuu</a>. O&apos;Saasy License.</p>
-          <p>v{APP_VERSION}</p>
-        </div>
+    <footer className="border-t border-border bg-background text-xs text-muted-foreground mt-auto">
+      <div className="max-w-5xl mx-auto px-4 py-4 flex flex-col items-center gap-1">
+        <p>
+          &copy; 2026{" "}
+          <a
+            href="https://brlauuu.github.io"
+            className="underline hover:text-foreground"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            brlauuu
+          </a>
+          .{" "}
+          <a
+            href="https://osaasy.dev"
+            className="underline hover:text-foreground"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            O&apos;Saasy License
+          </a>
+          {" · "}
+          <Link href="/about" className="underline hover:text-foreground">
+            About
+          </Link>
+        </p>
+        <p>v{APP_VERSION}</p>
       </div>
     </footer>
   );

--- a/apps/web/src/components/HelpMenu.tsx
+++ b/apps/web/src/components/HelpMenu.tsx
@@ -1,16 +1,54 @@
 "use client";
 
 import { HelpCircle, Wand2, BookOpen } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useWizard } from "@/components/WizardProvider";
 
+interface ServiceStatus {
+  name: string;
+  status: string;
+}
+
+interface HealthData {
+  status: string;
+  services?: ServiceStatus[];
+}
+
+function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "OK"
+      ? "bg-green-500"
+      : status === "WARMING_UP"
+        ? "bg-amber-500"
+        : "bg-red-500";
+
+  return (
+    <span className={`inline-block w-2 h-2 rounded-full ${color} shrink-0`} />
+  );
+}
+
 export default function HelpMenu() {
   const { setOpen } = useWizard();
+
+  const health = useQuery<HealthData>({
+    queryKey: ["pipeline-health"],
+    queryFn: async () => {
+      const resp = await fetch("/api/pipeline/health", { cache: "no-store" });
+      if (!resp.ok) return { status: "DEGRADED", services: [] };
+      return resp.json();
+    },
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+
+  const services = health.data?.services ?? [];
 
   return (
     <DropdownMenu>
@@ -22,7 +60,7 @@ export default function HelpMenu() {
           <HelpCircle className="h-4 w-4" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
+      <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem onClick={() => setOpen(true)} className="cursor-pointer gap-2">
           <Wand2 className="h-4 w-4" />
           Setup Wizard
@@ -37,6 +75,25 @@ export default function HelpMenu() {
             User Guide
           </a>
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <div className="px-2 py-1.5 space-y-1.5">
+          <p className="text-xs font-medium text-foreground">System status</p>
+          {services.length > 0 ? (
+            <div className="space-y-1">
+              {services.map((svc) => (
+                <div key={svc.name} className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <StatusDot status={svc.status} />
+                  <span>{svc.name}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <StatusDot status="DEGRADED" />
+              <span>Checking...</span>
+            </div>
+          )}
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/tests/unit/footer-links.test.tsx
+++ b/apps/web/tests/unit/footer-links.test.tsx
@@ -1,19 +1,15 @@
 /**
- * Unit test for Footer component — verifies brlauuu links point to
- * the personal blog (GitHub Pages) per issue #25.
+ * Unit test for Footer component — verifies links point to the correct URLs.
  */
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-// Mock TanStack React Query so Footer renders without a QueryClient
-jest.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: undefined, isLoading: true }),
-}));
-
-// Mock lucide-react icons
-jest.mock("lucide-react", () => ({
-  ExternalLink: () => <svg data-testid="external-link-icon" />,
-}));
+// Mock next/link to render a plain anchor
+jest.mock("next/link", () => {
+  return ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  );
+});
 
 import Footer from "@/components/Footer";
 
@@ -24,21 +20,18 @@ describe("Footer brlauuu links", () => {
     render(<Footer />);
   });
 
-  test("@brlauuu credits link points to GitHub Pages blog", () => {
-    const link = screen.getByRole("link", { name: "@brlauuu" });
-    expect(link).toHaveAttribute("href", BLOG_URL);
-  });
-
   test("copyright brlauuu link points to GitHub Pages blog", () => {
     const copyrightLink = screen.getByRole("link", { name: "brlauuu" });
     expect(copyrightLink).toHaveAttribute("href", BLOG_URL);
   });
 
-  test("brlauuu/podlog repo link still points to GitHub", () => {
-    const repoLink = screen.getByRole("link", { name: "brlauuu/podlog" });
-    expect(repoLink).toHaveAttribute(
-      "href",
-      "https://github.com/brlauuu/podlog"
-    );
+  test("O'Saasy License link points to osaasy.dev", () => {
+    const licenseLink = screen.getByRole("link", { name: "O'Saasy License" });
+    expect(licenseLink).toHaveAttribute("href", "https://osaasy.dev");
+  });
+
+  test("About link points to /about", () => {
+    const aboutLink = screen.getByRole("link", { name: "About" });
+    expect(aboutLink).toHaveAttribute("href", "/about");
   });
 });

--- a/apps/web/tests/unit/help-menu.test.tsx
+++ b/apps/web/tests/unit/help-menu.test.tsx
@@ -12,6 +12,11 @@ jest.mock("@/components/WizardProvider", () => ({
   useWizard: () => ({ open: false, setOpen: mockSetOpen, markCompleted: jest.fn() }),
 }));
 
+// Mock TanStack React Query for the health check
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: true }),
+}));
+
 beforeEach(() => {
   mockSetOpen.mockReset();
 });
@@ -29,6 +34,7 @@ describe("HelpMenu", () => {
     await waitFor(() => {
       expect(screen.getByText("Setup Wizard")).toBeInTheDocument();
       expect(screen.getByText("User Guide")).toBeInTheDocument();
+      expect(screen.getByText("System status")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace detailed footer with minimal centered layout: copyright, O'Saasy License link, About link, and version
- Create `/about` page with credits (including Codex/OpenAI), tech stack links, privacy statement, and blog post placeholder
- Move system status indicators from footer into the Help "?" dropdown in the navbar
- Created follow-up issue #211 to add the actual blog post link once written

## Test plan
- [x] All 92 web tests pass (footer + help menu tests updated)
- [ ] Verify footer shows copyright, license, about link, and version centered
- [ ] Verify `/about` page renders with credits, tech stack, privacy
- [ ] Verify Help "?" dropdown shows system status below User Guide
- [ ] Verify system status dots update correctly (green/amber/red)

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)