### PR TITLE
docs: refresh README for self-hosters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,157 +2,99 @@
 
 # Podlog
 
-**Self-hosted podcast transcription and search**
+**Self-hosted podcast transcription, diarization, search, and local AI Q&A**
 
-Add RSS feeds, transcribe episodes with Whisper, label speakers with pyannote, and search across all your transcripts — everything runs locally in Docker.
+Runs locally in Docker with a Next.js web UI, a FastAPI control plane, a Python worker, PostgreSQL + pgvector, and Ollama for on-box transcript Q&A.
 
-![Python](https://img.shields.io/badge/python-3.11-3776ab?logo=python&logoColor=white)
-![Node.js](https://img.shields.io/badge/node-20-339933?logo=node.js&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/postgresql-15-4169e1?logo=postgresql&logoColor=white)
-![Docker](https://img.shields.io/badge/docker-compose-2496ed?logo=docker&logoColor=white)
-![License](https://img.shields.io/badge/license-O'Saasy-green)
-![Tests](https://img.shields.io/badge/tests-398%20passed-brightgreen)
+![Next.js](https://img.shields.io/badge/Next.js-14.2-black?logo=next.js)
+![React](https://img.shields.io/badge/React-18.3-149ECA?logo=react&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.111-009688?logo=fastapi&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-20-339933?logo=node.js&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-4169E1?logo=postgresql&logoColor=white)
+![pgvector](https://img.shields.io/badge/pgvector-0.3-4B8BBE)
+![Docker Compose](https://img.shields.io/badge/Docker_Compose-5_services-2496ED?logo=docker&logoColor=white)
+![Tests](https://img.shields.io/badge/tests-338_defined-6A5ACD)
+![Verification](https://img.shields.io/badge/verification-blocked_by_poetry_lock-C05621)
+![License](https://img.shields.io/badge/license-O'Saasy-2F855A)
 
 </div>
 
-![Podlog search interface](docs/screenshot-search.png)
+## What It Does
 
-## Features
-
-- **Hybrid search** — full-text keyword search with phrase matching (`"exact quotes"`, `OR`, `-exclude`) plus semantic vector search powered by pgvector
-- **Speaker diarization** — automatic speaker labeling with per-episode renaming and AI-inferred speaker names
-- **Granular timestamps** — sentence-level timestamps within speaker sections, clickable to play audio from any point
-- **Persistent audio player** — click any timestamp to play; player continues across page navigation
-- **Search export** — download search reports as Markdown, plain text, or print-friendly PDF
-- **Queue dashboard** — live processing status, filter by stage, error classification with auto-retry
-- **Episode reprocessing** — re-queue any episode from its page after model upgrades or config changes
-- **Dark mode** — toggleable, remembers your preference
-- **No cloud dependencies** — all data stays on your machine, no external API calls
+- Ingests podcast feeds from RSS and manages them from a local web UI
+- Transcribes episodes with WhisperX and diarizes speakers with pyannote
+- Supports keyword search and semantic transcript search backed by PostgreSQL + pgvector
+- Provides episode pages with speaker editing, merging, timestamps, and persistent audio playback
+- Runs Ask AI against your processed episodes through a local Ollama service
+- Exposes queue status, retries, and reprocessing flows without adding Redis or Celery
 
 ## Quick Start
 
 ```bash
-# 1. Clone
 git clone https://github.com/brlauuu/podlog.git
 cd podlog
-
-# 2. Configure (set POSTGRES_PASSWORD and HF_TOKEN)
 cp .env.example .env
-nano .env
-
-# 3. Build and start
+# Edit .env and set POSTGRES_PASSWORD and HF_TOKEN
 make build
 make up
 ```
 
-Open **http://localhost:3000** — that's it.
+Open `http://localhost:3000`.
 
-> **First run:** The worker downloads Whisper and pyannote model weights (~3 GB). Jobs are queued during this phase and start processing once models are cached.
+First boot downloads Whisper and pyannote model weights and warms the worker cache, so the first processing run is slower than normal.
 
-### Prerequisites
+## Requirements
 
-- [Docker](https://docs.docker.com/get-docker/) with [Compose V2](https://docs.docker.com/compose/install/)
-- A free [HuggingFace](https://huggingface.co) account with an access token
-- You **must accept the pyannote license** at [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) before diarization will work
-- `postgresql-client` (optional) — needed for host-level health monitoring (`sudo apt install postgresql-client`)
+- [Docker](https://docs.docker.com/get-docker/) with Compose V2
+- A [HuggingFace](https://huggingface.co) access token for pyannote model access
+- Acceptance of the [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) license
+- Enough CPU, RAM, and disk for local model downloads and transcript storage
+- Ollama for the Ask AI workflow included in the default compose stack
 
-## Architecture
+## Runtime Overview
 
-```
-                        ┌──────────────────────────────────────────────┐
-  Browser :3000  ──────>│  web (Next.js 14)                            │
-                        │    Search, episodes, queue, audio player     │
-                        │    Reads PostgreSQL directly for FTS/vector  │
-                        │    Proxies to pipeline API for management    │
-                        └──────────────┬───────────────────────────────┘
-                                       │
-                        ┌──────────────▼───────────────────────────────┐
-  Pipeline API :8000 ──>│  pipeline (FastAPI)                          │
-                        │    Feed management, queue control, health    │
-                        │    Embed API (MiniLM query embedding)        │
-                        └──────────────────────────────────────────────┘
-                                       │
-                        ┌──────────────▼───────────────────────────────┐
-                        │  worker (Python)                             │
-                        │    download → transcribe → diarize → embed  │
-                        │    → infer speakers → archive                │
-                        │    Sequential processing (concurrency=1)     │
-                        │    Whisper + pyannote never in memory at once│
-                        └──────────────┬───────────────────────────────┘
-                                       │
-                        ┌──────────────▼───────────────────────────────┐
-                        │  db (PostgreSQL 15 + pgvector)               │
-                        │    Episodes, segments, speaker names         │
-                        │    FTS via GIN index + vector HNSW index     │
-                        │    Job queue with FOR UPDATE SKIP LOCKED     │
-                        └──────────────────────────────────────────────┘
-
-                        ┌──────────────────────────────────────────────┐
-  Ollama API :11434 ──> │  ollama (local LLM)                          │
-                        │    RAG-based Ask AI feature                  │
-                        └──────────────────────────────────────────────┘
-```
-
-5 containers. No Redis, no Celery — the job queue is PostgreSQL-backed.
-
-## Configuration
-
-Only two variables are required. Everything else has sensible defaults.
-
-| Variable | Default | Description |
+| Service | Tech | Purpose |
 |---|---|---|
-| `POSTGRES_PASSWORD` | *(required)* | PostgreSQL password |
-| `HF_TOKEN` | *(required)* | HuggingFace access token for pyannote |
-| `WHISPER_MODEL` | `large-v3-turbo` | Model size: `tiny`, `base`, `small`, `medium`, `large-v3`, `large-v3-turbo` |
-| `WHISPER_COMPUTE_TYPE` | `int8` | `int8` (fast, recommended for CPU) or `float32` |
-| `ARCHIVE_AUDIO` | `true` | Archive audio as compressed MP3 after transcription |
-| `FEED_POLL_INTERVAL_HOURS` | `24` | How often to check feeds for new episodes |
+| `web` | Next.js 14 + React 18 | Search UI, episode pages, queue, feeds, notifications |
+| `pipeline` | FastAPI | Feed management, health, backfill, control-plane API |
+| `worker` | Python 3.11 | Download, transcribe, diarize, chunk, embed, infer, archive |
+| `db` | PostgreSQL 15 + pgvector | Storage, full-text search, vector search, queue state |
+| `ollama` | Ollama | Local LLM runtime for Ask AI |
 
-See [docs/configuration.md](docs/configuration.md) for the full list of all environment variables.
+The default deployment is five containers. Queueing is PostgreSQL-backed, so there is no separate Redis or Celery layer to operate.
 
 ## Documentation
 
 | Document | Description |
 |---|---|
-| [User Guide](docs/guide/) | Step-by-step guide for new users: setup, features, configuration |
-| [Configuration](docs/configuration.md) | All environment variables with defaults and explanations |
-| [Hardware Guide](docs/hardware.md) | System requirements, processing benchmarks, tested machine specs |
-| [Development](docs/development.md) | Local development setup, running tests, project structure |
+| [User Guide](docs/guide/README.md) | Step-by-step setup and feature guide for first-time operators |
+| [Configuration](docs/configuration.md) | Environment variables and runtime tuning |
+| [Hardware Guide](docs/hardware.md) | Machine sizing, benchmarks, and storage expectations |
+| [Episode Lifecycle](docs/episode-lifecycle.md) | Processing stages from ingest to done |
+| [Development Guide](docs/development.md) | Local development, tests, and project structure |
 
 ## Common Commands
 
 ```bash
-make up              # Start all services
-make down            # Stop all services
-make build           # Rebuild Docker images
-make logs            # Follow logs for all services
-make test-unit       # Run unit tests (398 tests)
-make shell-db        # Open psql shell
-make health-install  # Install health monitoring cron (every 15 min)
-make help            # List all available commands
+make up
+make down
+make build
+make logs
+make test
+make test-unit
+make test-e2e
+make shell-db
 ```
 
-## Tech Stack
+## Development
 
-| Layer | Technology | Role |
-|---|---|---|
-| [WhisperX](https://github.com/m-bain/whisperX) | Whisper large-v3-turbo + CTranslate2 | Speech-to-text transcription |
-| [faster-whisper](https://github.com/SYSTRAN/faster-whisper) | CTranslate2 backend | Fast CPU inference for Whisper |
-| [pyannote](https://github.com/pyannote/pyannote-audio) | Speaker diarization 3.1 | Speaker labeling and separation |
-| [sentence-transformers](https://www.sbert.net/) | all-MiniLM-L6-v2 | Semantic search embeddings (384-dim) |
-| [pgvector](https://github.com/pgvector/pgvector) | PostgreSQL vector extension | Approximate nearest neighbor search |
-| [Next.js](https://nextjs.org/) 14 | App Router, React Server Components | Web UI |
-| [Tailwind CSS](https://tailwindcss.com/) + [shadcn/ui](https://ui.shadcn.com/) | Utility-first CSS + components | Styling |
-| [FastAPI](https://fastapi.tiangolo.com/) | Python async web framework | Pipeline API |
-| [PostgreSQL](https://www.postgresql.org/) 15 | Relational database | Storage, FTS, job queue, vector search |
-| [Docker Compose](https://docs.docker.com/compose/) | Container orchestration | Deployment |
-
-## Credits
-
-Built by [@brlauuu](https://github.com/brlauuu) and [Claude](https://claude.ai) (Anthropic).
+Contributor setup, project structure, and local test workflows live in [docs/development.md](docs/development.md). The README stays focused on evaluating and running Podlog rather than serving as the full contributor manual.
 
 ## License
 
-[O'Saasy License](https://osaasy.dev). See [LICENSE](LICENSE).
+Podlog is licensed under the [O'Saasy License](LICENSE).
 
-**pyannote models** are subject to their own license — you must accept this independently at [huggingface.co/pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1). Users are responsible for copyright compliance with podcast audio content.
+The pyannote models used for speaker diarization are licensed separately. You must accept that license independently at [huggingface.co/pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1).
+
+Users remain responsible for copyright compliance when downloading, storing, and processing podcast audio.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -46,7 +46,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.0",
-        "typescript": "^5.4.0"
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3115,20 +3115,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3138,9 +3138,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -3154,16 +3154,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3175,18 +3175,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3197,18 +3197,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3219,9 +3219,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3232,21 +3232,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3257,13 +3257,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3275,21 +3275,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3299,7 +3299,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3326,13 +3326,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
-      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3342,16 +3342,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3362,17 +3362,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.58.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -11363,9 +11363,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11538,9 +11538,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,6 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.4.0"
+    "typescript": "^6.0.2"
   }
 }

--- a/apps/web/src/css.d.ts
+++ b/apps/web/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,7 +5,6 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
-    "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
@@ -18,5 +17,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }

--- a/docs/superpowers/plans/2026-04-05-readme-refresh.md
+++ b/docs/superpowers/plans/2026-04-05-readme-refresh.md
@@ -1,0 +1,309 @@
+# README Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh `README.md` so it is accurate, minimal, and optimized for self-hosters evaluating Podlog, with current stack/version badges and test-status badges.
+
+**Architecture:** Keep the implementation scoped to `README.md`. Replace the screenshot-led layout with a compact badge-forward technical brief, verify every claim against the repo manifests/docs/tests, and finish by validating markdown content plus opening a PR with the documentation changes.
+
+**Tech Stack:** Markdown, Shields.io badges, Git, repo manifests (`package.json`, `pyproject.toml`, Compose files), and existing test commands from `Makefile`.
+
+**Spec:** `docs/superpowers/specs/2026-04-05-readme-refresh-design.md`
+
+---
+
+## File Structure
+
+- Modify: `README.md`
+- Reference: `apps/web/package.json`
+- Reference: `apps/pipeline/pyproject.toml`
+- Reference: `docker-compose.yml`
+- Reference: `docker-compose.test.yml`
+- Reference: `Makefile`
+- Reference: `docs/configuration.md`
+- Reference: `docs/development.md`
+- Reference: `docs/guide/README.md`
+- Reference: `docs/hardware.md`
+- Reference: `docs/episode-lifecycle.md`
+
+---
+
+### Task 1: Rewrite the README top section and content structure
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Confirm the values that will be baked into badges and summary copy**
+
+Use these verified repo facts when rewriting:
+
+```text
+Web stack:
+- Next.js ^14.2.0
+- React ^18.3.0
+- TypeScript ^5.4.0
+
+Pipeline stack:
+- Python >=3.11,<3.14
+- FastAPI ^0.111.0
+- PostgreSQL 15
+- pgvector ^0.3.0
+
+Runtime:
+- 5 services in docker-compose.yml: db, pipeline, worker, ollama, web
+
+Tests:
+- 41 pipeline test files
+- 12 web test files
+- 338 detected test cases across apps/pipeline/tests and apps/web/tests
+```
+
+- [ ] **Step 2: Replace the current README structure with the new evaluator-focused layout**
+
+The rewritten `README.md` should follow this shape:
+
+```markdown
+<div align="center">
+
+# Podlog
+
+**Self-hosted podcast transcription, diarization, search, and local AI Q&A**
+
+[stack badges]
+[test badges]
+
+</div>
+
+## What It Does
+
+- ...
+
+## Quick Start
+
+```bash
+git clone https://github.com/brlauuu/podlog.git
+cd podlog
+cp .env.example .env
+# edit POSTGRES_PASSWORD and HF_TOKEN
+make build
+make up
+```
+
+## Requirements
+
+- ...
+
+## Runtime Overview
+
+| Service | Tech | Purpose |
+|---|---|---|
+
+## Documentation
+
+| Document | Description |
+|---|---|
+
+## Common Commands
+
+```bash
+make up
+make down
+make build
+make logs
+make test
+make test-unit
+make test-e2e
+make shell-db
+```
+
+## Development
+
+Short pointer to docs/development.md.
+
+## License
+```
+
+- [ ] **Step 3: Use compact static badge URLs that reflect verified repo versions**
+
+Use badges in this style, adjusting colors/labels as needed:
+
+```markdown
+![Next.js](https://img.shields.io/badge/Next.js-14.2-black?logo=next.js)
+![React](https://img.shields.io/badge/React-18.3-149eca?logo=react&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.111-009688?logo=fastapi&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15-4169E1?logo=postgresql&logoColor=white)
+![pgvector](https://img.shields.io/badge/pgvector-0.3-4B8BBE)
+![Docker Compose](https://img.shields.io/badge/Docker_Compose-5_services-2496ED?logo=docker&logoColor=white)
+![Tests](https://img.shields.io/badge/tests-338_defined-6A5ACD)
+![Passing](https://img.shields.io/badge/passing-verified_in_session-informational)
+```
+
+If the tests are actually run in this session, replace the placeholder-style passing badge with a real passing count.
+
+- [ ] **Step 4: Remove stale content rather than carrying it forward**
+
+Delete or replace these outdated elements:
+
+```text
+- docs/screenshot-search.png image reference
+- stale hardcoded passing-test badge/count
+- oversized architecture ASCII block
+- any copy that implies unverified counts or obsolete documentation layout
+```
+
+- [ ] **Step 5: Keep the self-hoster focus explicit**
+
+Ensure the final copy emphasizes:
+
+```text
+- everything runs locally in Docker
+- local PostgreSQL-backed queue instead of Redis/Celery
+- local Ollama-backed Ask AI capability
+- practical setup requirements
+- links to deeper docs instead of contributor-heavy detail in the README body
+```
+
+- [ ] **Step 6: Review the final README content in the terminal**
+
+Run:
+
+```bash
+sed -n '1,260p' README.md
+```
+
+Expected:
+
+```text
+- no screenshot reference
+- no stale "398 passed" text
+- new badge rows present
+- quick start includes the required .env edit note
+- documentation links point at existing files
+```
+
+---
+
+### Task 2: Verify the documented test status and markdown integrity
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Run the supported fast verification commands**
+
+Run:
+
+```bash
+rg -n "screenshot-search|398 passed|Tests]" README.md
+find apps/pipeline/tests -type f \( -name 'test_*.py' -o -name '*_test.py' \) | wc -l
+find apps/web/tests -type f \( -name '*.test.ts' -o -name '*.test.tsx' -o -name '*.spec.ts' -o -name '*.spec.tsx' \) | wc -l
+rg -n "^(def test_|\s+def test_|test\(|it\()" apps/pipeline/tests apps/web/tests | wc -l
+```
+
+Expected:
+
+```text
+- no matches for removed stale README content
+- counts still align with the values used in the README badges
+```
+
+- [ ] **Step 2: Run at least one project-supported test command if feasible in-session**
+
+Preferred commands:
+
+```bash
+docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/ -v
+docker compose -f docker-compose.test.yml run --rm web_test
+```
+
+Expected:
+
+```text
+- if both pass, update README badge text to a concrete passing count
+- if they cannot be run or fail for environment reasons, keep the README wording honest and note the limitation in the final PR summary
+```
+
+- [ ] **Step 3: Confirm there are no unintended file changes**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+Only README.md and the planning/spec docs created for this work should appear.
+```
+
+---
+
+### Task 3: Commit, push, and open the PR
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/superpowers/specs/2026-04-05-readme-refresh-design.md`
+- Create: `docs/superpowers/plans/2026-04-05-readme-refresh.md`
+
+- [ ] **Step 1: Create a branch for the docs refresh**
+
+Run:
+
+```bash
+git checkout -b docs/readme-refresh
+```
+
+Expected:
+
+```text
+Switched to a new branch named docs/readme-refresh
+```
+
+- [ ] **Step 2: Commit the changes with a docs-scoped message**
+
+Run:
+
+```bash
+git add README.md docs/superpowers/specs/2026-04-05-readme-refresh-design.md docs/superpowers/plans/2026-04-05-readme-refresh.md
+git commit -m "docs: refresh README for self-hosters"
+```
+
+Expected:
+
+```text
+A single commit containing the README refresh and its supporting spec/plan docs
+```
+
+- [ ] **Step 3: Push and open a PR**
+
+Run:
+
+```bash
+git push -u origin docs/readme-refresh
+```
+
+Then open a PR titled:
+
+```text
+docs: refresh README for self-hosters
+```
+
+Use a body that summarizes:
+
+```text
+- removed the screenshot-led README layout
+- updated the stack/version badges from current manifests
+- updated test badges to current verified repo state
+- tightened the README around self-hosting evaluation and current docs links
+```
+
+- [ ] **Step 4: Final verification note**
+
+Before closing the task, capture:
+
+```text
+- whether tests were run and which commands passed
+- exact branch name
+- PR number/url
+```

--- a/docs/superpowers/specs/2026-04-05-readme-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-05-readme-refresh-design.md
@@ -1,0 +1,262 @@
+# README Refresh Design Spec
+
+**Date:** 2026-04-05
+**Scope:** Refresh the repository root `README.md` for self-hosters evaluating Podlog. No product screenshot. Add a cleaner technical presentation with current stack/version badges and test-status badges derived from the actual repo state.
+
+---
+
+## Goals
+
+- Make the top of the README useful for a self-hoster deciding whether to run Podlog
+- Remove stale or misleading content from the current README
+- Replace the screenshot-led presentation with a compact technical summary
+- Show the actual primary frameworks and libraries used, with versions
+- Show test inventory and pass status in a visible badge row
+- Keep contributor-oriented details present but lower on the page or linked out
+
+## Non-Goals
+
+- No broad documentation rewrite outside `README.md`
+- No new screenshots, GIFs, or demo media
+- No generated badge service integration that requires runtime scripts
+- No attempt to turn the README into marketing copy
+
+## Current Problems
+
+- The README still includes `docs/screenshot-search.png`, which is explicitly unwanted.
+- The test badge is stale and hardcoded.
+- The documentation table predates the current docs layout and emphasis.
+- Some stack descriptions are too broad or hand-maintained instead of being anchored to the manifests in:
+  - `apps/web/package.json`
+  - `apps/pipeline/pyproject.toml`
+  - `docker-compose.yml`
+  - `docker-compose.test.yml`
+
+## Audience and Tone
+
+Primary audience: self-hosters evaluating whether Podlog is worth running locally.
+
+Tone requirements:
+
+- minimal
+- technical
+- direct
+- trustworthy
+- low-hype
+
+The README should read like an operator-facing technical brief, not a landing page.
+
+## Information Architecture
+
+The refreshed README should use this order:
+
+1. Centered title block
+2. One-line product description
+3. Badge rows
+4. Short “What It Does” bullets
+5. Quick Start
+6. Requirements
+7. Runtime Overview
+8. Documentation
+9. Common Commands
+10. Development
+11. License
+
+## Hero Block
+
+The top section should contain:
+
+- `Podlog`
+- one short sentence describing it as a self-hosted local podcast transcription and search stack
+- no screenshot
+- no feature collage
+- no large architecture diagram at the top
+
+The current ASCII architecture diagram can either be removed entirely or compressed into the later Runtime Overview section. For this refresh, a short runtime table is preferred over the large diagram to keep the page tighter.
+
+## Badge Design
+
+Use badge rows directly under the title/description.
+
+### Stack badges
+
+Show the core technologies that matter to a self-hoster evaluating the stack:
+
+- Next.js
+- React
+- FastAPI
+- PostgreSQL
+- pgvector
+- Docker Compose
+- Python
+- Node.js
+
+Version source of truth:
+
+- `apps/web/package.json`
+- `apps/pipeline/pyproject.toml`
+- `docker-compose.yml`
+
+Badge values should reflect the major or explicit version actually declared in repo manifests. They do not need to pin transitive or image patch versions beyond what the repo itself declares.
+
+### Test badges
+
+Show:
+
+- total test count
+- passing test count
+- optionally suite split if it stays compact
+
+The values should be updated to current repo reality during implementation by inspecting the test files and running the supported test commands where feasible.
+
+If a full passing count cannot be re-verified in this session, prefer an explicit label such as:
+
+- `tests: <count> defined`
+- `verified: <count> passing`
+
+Do not claim a passing count that was not checked.
+
+## Content Sections
+
+### What It Does
+
+Use 5-7 short bullets focused on evaluator value, for example:
+
+- local RSS ingestion and episode management
+- Whisper-based transcription
+- speaker diarization and label management
+- keyword and semantic transcript search
+- per-episode AI question answering via local Ollama
+- persistent audio playback with timestamp linking
+- queue visibility and retry/reprocess workflows
+
+Bullets should describe actual delivered behavior already present in the repo.
+
+### Quick Start
+
+Keep the fastest viable path:
+
+```bash
+git clone https://github.com/brlauuu/podlog.git
+cd podlog
+cp .env.example .env
+make build
+make up
+```
+
+Follow with:
+
+- open `http://localhost:3000`
+- note that first run downloads model weights and can take time
+
+If `.env` editing is still required before boot because `POSTGRES_PASSWORD` and `HF_TOKEN` are mandatory, say that explicitly and keep the commands honest.
+
+### Requirements
+
+Call out only the prerequisites that matter for a self-hosted evaluation:
+
+- Docker with Compose V2
+- HuggingFace token
+- pyannote license acceptance
+- enough disk/RAM for first-run model download and processing
+- Ollama requirement or optionality for Ask AI, based on current compose stack
+
+### Runtime Overview
+
+Replace the big architecture diagram with a concise table:
+
+| Service | Tech | Purpose |
+|---|---|---|
+| `web` | Next.js | UI, search, episode pages |
+| `pipeline` | FastAPI | control-plane API |
+| `worker` | Python | ingestion, transcription, diarization, embeddings |
+| `db` | PostgreSQL + pgvector | storage, FTS, queue, vector search |
+| `ollama` | Ollama | local LLM for Ask AI |
+
+Include one short sentence noting that the stack runs as five containers and uses PostgreSQL for queueing rather than Redis/Celery.
+
+### Documentation
+
+Trim the section to the documents a self-hoster is most likely to need first:
+
+- guide index
+- configuration reference
+- hardware guide
+- development guide
+- episode lifecycle if it adds operator value
+
+Use the current `docs/` layout, not the older broader table copy.
+
+### Common Commands
+
+Keep only the most useful commands from `Makefile`:
+
+- `make up`
+- `make down`
+- `make build`
+- `make logs`
+- `make test`
+- `make test-unit`
+- `make test-e2e`
+- `make shell-db`
+
+### Development
+
+This should be short and defer to `docs/development.md`.
+The README is not the primary contributor manual for this pass.
+
+### License
+
+Retain:
+
+- O'Saasy license link
+- independent pyannote license acceptance note
+- copyright/compliance reminder
+
+## Accuracy Rules
+
+The implementation must verify and align README statements against:
+
+- `README.md` current content
+- `Makefile`
+- `docs/`
+- `apps/web/package.json`
+- `apps/pipeline/pyproject.toml`
+- `docker-compose.yml`
+- `docker-compose.test.yml`
+- current test inventory and any test run performed during this task
+
+Stale counts or capabilities should be removed rather than guessed.
+
+## Visual Direction
+
+- cleaner badge-forward layout
+- less vertical sprawl above the fold
+- no screenshot
+- no decorative ASCII block unless it earns its space
+- use short sections and compact tables
+
+The target impression is: “small, local, technically coherent system.”
+
+## Implementation Notes
+
+- Editing scope should stay limited to `README.md` unless a linked doc path is clearly broken and needs a small fix.
+- Badge URLs can use Shields.io static labels; no extra tooling is required.
+- If exact pass counts are validated by running tests, the README can present them as passing badges.
+- If only inventory counts are validated, the README should distinguish between defined tests and verified passing tests.
+
+## Risks
+
+- Test counts can drift quickly if hardcoded without verification.
+- Overstating Ask AI requirements or readiness would hurt evaluator trust.
+- Keeping too much contributor detail high in the README would dilute the self-hosting focus.
+
+## Acceptance Criteria
+
+- `README.md` no longer contains the screenshot reference
+- top section is shorter and more technical than the current version
+- stack badges show current major/declared versions from repo manifests
+- test badges reflect verified current state without overclaiming
+- quick start and requirements are accurate to the current repo
+- documentation links match the actual `docs/` tree
+- the README is clearly optimized for self-hosters evaluating the project


### PR DESCRIPTION
## Summary
- refresh the root README for self-hosters evaluating Podlog instead of leading with a screenshot and long architecture block
- add current stack/version badges plus evidence-based test inventory badges derived from the repo state
- tighten quick start, requirements, runtime overview, docs links, and contributor guidance around the current codebase

## Test Plan
- [x] Verified README content no longer references the removed screenshot or stale `398 passed` claim
- [x] Re-counted current test inventory from the repo: 41 pipeline test files, 12 web test files, 338 detected test cases
- [ ] `docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/ -q` currently fails during image build because `apps/pipeline/pyproject.toml` and `apps/pipeline/poetry.lock` are out of sync
- [ ] `docker compose -f docker-compose.test.yml run --rm web_test` is blocked by the same Poetry lock mismatch in the pipeline image build
