### PR TITLE
chore: bump @tanstack/react-query floor to ^5.96.2 (#220)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/typography": "^0.5.19",
-    "@tanstack/react-query": "^5.40.0",
+    "@tanstack/react-query": "^5.96.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "isomorphic-dompurify": "^3.3.0",


### PR DESCRIPTION
## Summary
- Bump `@tanstack/react-query` minimum from `^5.40.0` to `^5.96.2` (latest 5.x)
- No functional change — npm was already resolving to 5.96.2
- Documents the tested minimum version

## Testing
- 95/95 Jest tests pass

Closes #220