### PR TITLE
[codex] Fix PRD staleness in PRD-02 and PRD-04

### DIFF
--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-02 — Search Web Application  
-**Version:** 1.4
-**Status:** Draft
+**Version:** 1.5
+**Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.5 — Marked document status as Active and removed stale non-goal note claiming semantic/vector search was out of scope.
 - v1.4 — Added Ask AI (RAG) documentation (§5.10): retrieval pipeline, key parameters (TOP_K, SIMILARITY_THRESHOLD), model options, source filtering, speaker attribution, citation rendering, error handling.
 - v1.3 — Queue dashboard (§5.6) redesigned: replaced kanban/grouping modes with a Summary + Table hybrid layout. Worker warm-up banner removed (brief warm-up does not warrant persistent UI). Retry countdown timer removed; retry count shown as N/M instead. Stage progress bar added (horizontal bar showing per-stage episode counts). Search/filter input added (debounced, filters by episode title or podcast name). Done episodes collapsed by default in an expandable section. Responsiveness: Podcast and Retries columns hidden on screens narrower than 640 px. ASCII diagram in §9.3 updated to match new layout.
 - v1.2 — Renamed project from PodSearch to Podlog. localStorage key changed to `podlog-theme`. Added `/feeds` page separate from `/podcasts` for feed management. Added `QueryProvider` wrapper in root layout for React Query. Web API routes proxy to pipeline API for feed management, queue retries, and health checks. Database name changed to `podlog`.
@@ -34,7 +35,6 @@ Once podcast transcripts are stored in the database (PRD-01), users need a simpl
 
 ### Non-Goals (V1)
 - User accounts or authentication (deferred to V2)
-- Semantic / vector search (implemented — see search.ts grouped search)
 - Mobile app (web-only, but responsive)
 - Public deployment (local only in V1)
 - Search result grouping by episode (deferred to V1)

--- a/prds/PRD-04-host-guest-inference.md
+++ b/prds/PRD-04-host-guest-inference.md
@@ -122,7 +122,7 @@ DOWNLOADING → TRANSCRIBING → DIARIZING → INFERRING → ARCHIVING → DONE
 The flat `.txt` file written after processing (per PRD-01 §5.7) uses inferred display names where available:
 
 ```
-# PodSearch Transcript
+# Podlog Transcript
 # Episode: Ep. 712: Andrew Huberman on Sleep
 # Host: Tim Ferriss (inferred)
 # Guests: Andrew Huberman (inferred)


### PR DESCRIPTION
## Summary
- update `prds/PRD-02-search-web-app.md` status metadata from Draft to Active
- bump PRD-02 version to `1.5` and add a changelog note for this documentation correction
- remove the contradictory PRD-02 non-goal bullet that claimed semantic/vector search was out of scope while marked as implemented
- replace stale `PodSearch` string in the PRD-04 transcript example with `Podlog`

## Why
Fixes stale PRD metadata and naming references reported in issue #236.

## Validation
- `rg` checks confirm:
  - PRD-02 now shows `Status: Active`
  - no remaining `PodSearch Transcript` string in PRD-04
  - contradictory PRD-02 non-goal bullet removed

Closes #236
