### PR TITLE
[codex] Fix PIPELINE_API vs PIPELINE_API_URL inconsistency

### DIFF
--- a/apps/web/src/app/api/pipeline/embed/route.ts
+++ b/apps/web/src/app/api/pipeline/embed/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const PIPELINE_API = process.env.PIPELINE_API ?? "http://pipeline:8000";
+import { PIPELINE_API } from "@/lib/pipeline";
 
 export async function POST(req: NextRequest) {
   try {

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,6 +1,5 @@
 import pool from "@/lib/db";
-
-const PIPELINE_API = process.env.PIPELINE_API ?? "http://pipeline:8000";
+import { PIPELINE_API } from "@/lib/pipeline";
 
 /**
  * Get embedding for a search query from the pipeline's embed API.


### PR DESCRIPTION
## Summary
- remove direct `process.env.PIPELINE_API` usage from web search embedding calls
- remove direct `process.env.PIPELINE_API` usage from the pipeline embed proxy route
- use the shared `PIPELINE_API` constant from `@/lib/pipeline` in both places, which reads `PIPELINE_API_URL`

## Why
Docker Compose config sets `PIPELINE_API_URL`, so code paths reading `PIPELINE_API` can silently fall back to the hardcoded default instead of the configured endpoint.

## Validation
- `npm run typecheck` (apps/web) passes
- grep check confirms no remaining `process.env.PIPELINE_API` usage in these paths

Closes #238
