### PR TITLE
[codex] Fix wizard accessibility and API compliance gaps

### DIFF
--- a/apps/web/src/app/api/feeds/preview/route.ts
+++ b/apps/web/src/app/api/feeds/preview/route.ts
@@ -3,12 +3,7 @@ import { PIPELINE_API } from "@/lib/pipeline";
 
 // Issue #84: proxy feed preview requests to the pipeline API.
 // No DB writes — pipeline fetches the RSS URL and returns feed metadata + episode list.
-export async function GET(req: NextRequest) {
-  const url = req.nextUrl.searchParams.get("url");
-  if (!url) {
-    return NextResponse.json({ error: "url query parameter is required" }, { status: 400 });
-  }
-
+async function proxyPreview(url: string) {
   try {
     const resp = await fetch(
       `${PIPELINE_API}/api/feeds/preview?url=${encodeURIComponent(url)}`,
@@ -24,5 +19,27 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     console.error("Feed preview error:", err);
     return NextResponse.json({ error: "Failed to fetch feed preview" }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get("url");
+  if (!url) {
+    return NextResponse.json({ error: "url query parameter is required" }, { status: 400 });
+  }
+
+  return proxyPreview(url);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const url = typeof body?.url === "string" ? body.url.trim() : "";
+    if (!url) {
+      return NextResponse.json({ error: "url is required" }, { status: 400 });
+    }
+    return proxyPreview(url);
+  } catch {
+    return NextResponse.json({ error: "url is required" }, { status: 400 });
   }
 }

--- a/apps/web/src/app/api/wizard/status/route.ts
+++ b/apps/web/src/app/api/wizard/status/route.ts
@@ -19,16 +19,23 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
-  const { completed } = await req.json();
+  try {
+    const { completed } = await req.json();
 
-  if (completed) {
-    await pool.query(
-      "INSERT INTO system_state (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2",
-      [KEY, "1"]
+    if (completed) {
+      await pool.query(
+        "INSERT INTO system_state (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2",
+        [KEY, "1"]
+      );
+    } else {
+      await pool.query("DELETE FROM system_state WHERE key = $1", [KEY]);
+    }
+
+    return NextResponse.json({ completed: !!completed });
+  } catch {
+    return NextResponse.json(
+      { completed: false, error: "Failed to update wizard status" },
+      { status: 503 }
     );
-  } else {
-    await pool.query("DELETE FROM system_state WHERE key = $1", [KEY]);
   }
-
-  return NextResponse.json({ completed: !!completed });
 }

--- a/apps/web/src/components/SetupWizard.tsx
+++ b/apps/web/src/components/SetupWizard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { useWizard } from "@/components/WizardProvider";
 import WizardHealthCheck from "@/components/WizardHealthCheck";
 import WizardAddFeed from "@/components/WizardAddFeed";
@@ -45,7 +45,14 @@ export default function SetupWizard() {
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) close(); }}>
-      <DialogContent className="max-w-xl" onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogContent
+        className="max-w-[calc(100vw-2rem)] w-[calc(100vw-2rem)] h-[calc(100vh-2rem)] overflow-y-auto"
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
+        <DialogTitle className="sr-only">Setup Wizard</DialogTitle>
+        <DialogDescription className="sr-only">
+          First-run onboarding for health checks, feed setup, and next steps.
+        </DialogDescription>
         {step === 1 && (
           <WizardHealthCheck
             onNext={() => setStep(2)}

--- a/apps/web/src/components/WizardAddFeed.tsx
+++ b/apps/web/src/components/WizardAddFeed.tsx
@@ -60,7 +60,11 @@ export default function WizardAddFeed({ onNext, onBack, onSkip }: Props) {
     if (mode === "selective" && !previewStep) {
       setPreviewLoading(true);
       try {
-        const resp = await fetch(`/api/feeds/preview?url=${encodeURIComponent(url.trim())}`);
+        const resp = await fetch("/api/feeds/preview", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url: url.trim() }),
+        });
         if (!resp.ok) {
           const err = await resp.json().catch(() => ({}));
           throw new Error(err.detail ?? "Couldn't fetch episodes — check the URL and try again");

--- a/apps/web/src/components/WizardComplete.tsx
+++ b/apps/web/src/components/WizardComplete.tsx
@@ -62,17 +62,17 @@ export default function WizardComplete({ feedAdded, onFinish, onDontShowChange }
               onClick={onFinish}
               className={`flex items-center gap-3 p-2.5 rounded-md transition-colors ${
                 link.highlight
-                  ? "border-2 border-primary bg-primary/5"
+                  ? "border-2 border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30"
                   : "border border-border hover:bg-accent/40"
               }`}
             >
               <div className="min-w-0 flex-1">
-                <p className={`text-sm font-semibold ${link.highlight ? "text-primary" : ""}`}>
+                <p className={`text-sm font-semibold ${link.highlight ? "text-blue-700 dark:text-blue-300" : ""}`}>
                   {link.title}
                 </p>
                 <p className="text-xs text-muted-foreground">{link.description}</p>
               </div>
-              <ChevronRight className={`h-4 w-4 shrink-0 ${link.highlight ? "text-primary" : "text-muted-foreground"}`} />
+              <ChevronRight className={`h-4 w-4 shrink-0 ${link.highlight ? "text-blue-700 dark:text-blue-300" : "text-muted-foreground"}`} />
             </Link>
           ))}
         </div>

--- a/apps/web/tests/unit/feeds-preview-route.test.ts
+++ b/apps/web/tests/unit/feeds-preview-route.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/feeds/preview/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({
+  PIPELINE_API: "http://pipeline:8000",
+}));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("POST /api/feeds/preview", () => {
+  it("returns 400 when url is missing", async () => {
+    const req = new NextRequest("http://localhost/api/feeds/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const resp = await POST(req);
+    const data = await resp.json();
+
+    expect(resp.status).toBe(400);
+    expect(data).toEqual({ error: "url is required" });
+  });
+
+  it("proxies preview request to pipeline API", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify({ title: "Test Feed", episodes: [] }),
+    });
+
+    const req = new NextRequest("http://localhost/api/feeds/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+
+    const resp = await POST(req);
+    const data = await resp.json();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/preview?url=https%3A%2F%2Fexample.com%2Ffeed.xml"
+    );
+    expect(resp.status).toBe(200);
+    expect(data).toEqual({ title: "Test Feed", episodes: [] });
+  });
+});

--- a/apps/web/tests/unit/setup-wizard.test.tsx
+++ b/apps/web/tests/unit/setup-wizard.test.tsx
@@ -213,6 +213,17 @@ describe("WizardAddFeed", () => {
     // Click Next to fetch preview
     fireEvent.click(screen.getByRole("button", { name: /next/i }));
 
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feeds/preview",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+        })
+      );
+    });
+
     // Episode picker should appear
     await waitFor(() => {
       expect(screen.getByText("Episode 1")).toBeInTheDocument();
@@ -297,7 +308,9 @@ describe("WizardComplete", () => {
 
   it("highlights 'Add Your First Feed' link when feed was skipped", () => {
     render(<WizardComplete feedAdded={false} onFinish={() => {}} onDontShowChange={() => {}} />);
-    expect(screen.getByText(/Add Your First Feed/i)).toBeInTheDocument();
+    const cta = screen.getByText(/Add Your First Feed/i).closest("a");
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveClass("border-blue-500");
   });
 
   it("shows 'Don't show this wizard' checkbox", () => {
@@ -378,6 +391,19 @@ describe("SetupWizard", () => {
     // Step 1 is current, steps 2 and 3 are disabled (not yet visited)
     expect(dots[1]).toBeDisabled();
     expect(dots[2]).toBeDisabled();
+  });
+
+  it("renders accessible dialog title/description and fullscreen sizing", async () => {
+    mockUseWizard.mockReturnValue({ open: true, setOpen: jest.fn(), markCompleted: jest.fn() });
+    render(<SetupWizard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Setup Wizard")).toBeInTheDocument();
+      expect(screen.getByText("First-run onboarding for health checks, feed setup, and next steps.")).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("h-[calc(100vh-2rem)]");
   });
 
   it("calls markCompleted(false) on finish when checkbox unchecked", async () => {

--- a/apps/web/tests/unit/wizard-status-route.test.ts
+++ b/apps/web/tests/unit/wizard-status-route.test.ts
@@ -74,4 +74,22 @@ describe("PUT /api/wizard/status", () => {
       ["wizard_completed"]
     );
   });
+
+  it("returns 503 when DB write fails", async () => {
+    mockQuery.mockRejectedValue(new Error("db down"));
+    const req = new NextRequest("http://localhost/api/wizard/status", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ completed: true }),
+    });
+
+    const resp = await PUT(req);
+    const data = await resp.json();
+
+    expect(resp.status).toBe(503);
+    expect(data).toEqual({
+      completed: false,
+      error: "Failed to update wizard status",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `DialogTitle` + `DialogDescription` to `SetupWizard` to satisfy Radix dialog accessibility requirements
- update wizard dialog sizing to a full-screen style overlay panel (`w/h` constrained to viewport)
- switch selective preview fetch in `WizardAddFeed` to `POST /api/feeds/preview` with JSON body
- add `POST` support to `/api/feeds/preview` route while keeping existing `GET` behavior for current callers
- add error handling to `PUT /api/wizard/status` and return a structured `503` response when DB writes fail
- make skipped-flow CTA border explicitly blue in `WizardComplete` per spec wording
- add/extend unit tests for the above behavior

## Notes
- I intentionally left Screen 2 "Skip" behavior unchanged (`Skip -> Screen 3`), because the first-run wizard spec says this should advance to Screen 3 rather than dismiss.

## Validation
- `npx jest tests/unit/setup-wizard.test.tsx tests/unit/wizard-status-route.test.ts tests/unit/feeds-preview-route.test.ts --no-cache`
- `npm run typecheck` (in `apps/web`)

Refs #239
