### PR TITLE
[codex] Fix episode nav placement and help dropdown opacity

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -192,6 +192,34 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
         )}
       </div>
 
+      {/* Episode navigation */}
+      {(prev || next) && (
+        <div className="flex items-center justify-between gap-4">
+          {prev ? (
+            <Link
+              href={`/episodes/${prev.id}`}
+              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0"
+            >
+              <ChevronLeft size={16} className="shrink-0" />
+              <span className="truncate">{prev.title ?? "Previous episode"}</span>
+            </Link>
+          ) : (
+            <span />
+          )}
+          {next ? (
+            <Link
+              href={`/episodes/${next.id}`}
+              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0 text-right"
+            >
+              <span className="truncate">{next.title ?? "Next episode"}</span>
+              <ChevronRight size={16} className="shrink-0" />
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      )}
+
       {/* Podcast context card */}
       {episode.feed_id && (
         <Card>
@@ -295,37 +323,6 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
         audioUrl={episode.audio_url}
         guid={episode.guid}
       />
-
-      {/* Episode navigation */}
-      {(prev || next) && (
-        <>
-          <Separator />
-          <div className="flex items-center justify-between gap-4">
-            {prev ? (
-              <Link
-                href={`/episodes/${prev.id}`}
-                className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0"
-              >
-                <ChevronLeft size={16} className="shrink-0" />
-                <span className="truncate">{prev.title ?? "Previous episode"}</span>
-              </Link>
-            ) : (
-              <span />
-            )}
-            {next ? (
-              <Link
-                href={`/episodes/${next.id}`}
-                className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0 text-right"
-              >
-                <span className="truncate">{next.title ?? "Next episode"}</span>
-                <ChevronRight size={16} className="shrink-0" />
-              </Link>
-            ) : (
-              <span />
-            )}
-          </div>
-        </>
-      )}
 
       {episode.status === "done" && (
         <EpisodeChat

--- a/apps/web/src/components/HelpMenu.tsx
+++ b/apps/web/src/components/HelpMenu.tsx
@@ -60,7 +60,7 @@ export default function HelpMenu() {
           <HelpCircle className="h-4 w-4" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-52">
+      <DropdownMenuContent align="end" className="w-52 bg-background">
         <DropdownMenuItem onClick={() => setOpen(true)} className="cursor-pointer gap-2">
           <Wand2 className="h-4 w-4" />
           Setup Wizard

--- a/apps/web/tests/unit/episode-page-navigation.test.tsx
+++ b/apps/web/tests/unit/episode-page-navigation.test.tsx
@@ -112,4 +112,19 @@ describe("Episode page navigation", () => {
       "/episodes/ep-next"
     );
   });
+
+  it("renders episode navigation above transcript content", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-prev", title: "Previous episode" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: "Next episode" }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const prevLink = screen.getByRole("link", { name: /previous episode/i });
+    const transcript = screen.getByTestId("transcript-section");
+
+    expect(prevLink.compareDocumentPosition(transcript) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });

--- a/apps/web/tests/unit/help-menu.test.tsx
+++ b/apps/web/tests/unit/help-menu.test.tsx
@@ -38,6 +38,14 @@ describe("HelpMenu", () => {
     });
   });
 
+  it("uses an opaque dropdown surface for readability", async () => {
+    const user = userEvent.setup();
+    render(<HelpMenu />);
+    await user.click(screen.getByRole("button", { name: /help/i }));
+    const menu = await screen.findByRole("menu");
+    expect(menu.className).toContain("bg-background");
+  });
+
   it("opens wizard when Setup Wizard is clicked", async () => {
     const user = userEvent.setup();
     render(<HelpMenu />);


### PR DESCRIPTION
## Summary
- move episode previous/next navigation controls to the top section of the episode page (above transcript content)
- remove the duplicate bottom navigation block
- make help dropdown content explicitly opaque with `bg-background` for improved readability
- add/extend unit tests for both behaviors

## Why
- #246 requests episode navigation at the top of the episode page
- #244 reports help dropdown readability issues due to excessive transparency

## Validation
- `npx jest tests/unit/episode-page-navigation.test.tsx tests/unit/help-menu.test.tsx --no-cache`
- `npm run typecheck` (in `apps/web`)

Closes #244
Closes #246
