### PR TITLE
docs: fix rag, lifecycle, and health-check config accuracy (#235)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ OLLAMA_URL=http://ollama:11434  # Ollama API endpoint for LLM inference
 # -- Health monitoring (host cron — see scripts/healthcheck.py) --
 # TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID above are used first;
 # if unset, the script falls back to UI-configured values from the DB.
+# HEALTH_CHECK_NOTIFICATIONS_ENABLED=true
 # HEALTH_CHECK_PIPELINE_URL=http://localhost:8000
 # HEALTH_CHECK_WEB_URL=http://localhost:3000
 # HEALTH_CHECK_DB_HOST=localhost

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ The host-level health check script (`scripts/healthcheck.py`) uses these setting
 
 | Variable | Default | Description |
 |---|---|---|
+| `HEALTH_CHECK_NOTIFICATIONS_ENABLED` | `true` | Enable/disable health-check Telegram notifications. Priority: `.env` value overrides DB/UI value. |
 | `HEALTH_CHECK_PIPELINE_URL` | `http://localhost:8000` | Pipeline API URL as seen from the host. |
 | `HEALTH_CHECK_WEB_URL` | `http://localhost:3000` | Web app URL as seen from the host. |
 | `HEALTH_CHECK_DB_HOST` | `localhost` | PostgreSQL host for `pg_isready` and zombie job queries. |

--- a/docs/episode-lifecycle.md
+++ b/docs/episode-lifecycle.md
@@ -24,7 +24,7 @@ pending → download → transcribe → diarize → embed → infer → archive 
 |-------|-------|-------------|
 | `audio_local_path` | episodes | Path to raw downloaded audio file |
 
-**Failure mode:** Retries transient errors (5xx, network) up to `retry_max`. Fails immediately on `DISK_FULL`, `HTTP_ACCESS` (403/404).
+**Failure mode:** Retries transient errors (`TRANSIENT_NETWORK`, `HTTP_ACCESS`) up to `retry_max` with exponential backoff. Fails immediately on `DISK_FULL`.
 
 ---
 

--- a/docs/guide/12-rag-search.md
+++ b/docs/guide/12-rag-search.md
@@ -24,7 +24,7 @@ The system retrieves relevant transcript chunks via semantic search (pgvector), 
 - **Fully local** — powered by [Ollama](https://ollama.ai) running in a Docker container
 - **No external API calls** — your data never leaves your machine
 - **Streaming responses** — answers appear word-by-word via server-sent events
-- **Model selection** — configurable via `OLLAMA_MODEL` env var (default: see `.env.example`)
+- **Model selection** — chosen in the Ask page model selector and sent per request (default: `qwen2.5:3b`)
 - **Additional RAM:** ~2 GB when the LLM is active (auto-unloaded when idle)
 
 ## Prerequisites
@@ -32,13 +32,14 @@ The system retrieves relevant transcript chunks via semantic search (pgvector), 
 The Ask AI feature requires:
 - The Ollama service running (included in `docker-compose.yml`)
 - At least one episode fully processed through the embed stage (segments need vector embeddings)
-- A pulled Ollama model (`make ollama-pull` or the worker pulls it automatically)
+- A pulled Ollama model (for example: `make ollama-pull`)
 
 ## Troubleshooting
 
 - **"Ollama not available"** — Check that the ollama container is running: `docker compose ps ollama`
 - **Slow first response** — The model loads into memory on first query; subsequent queries are faster
-- **Poor answer quality** — Try a larger model via `OLLAMA_MODEL` in `.env`, or ensure more episodes are processed so the retrieval pool is larger
+- **Model not available** — Pull the model first (`make ollama-pull`) or select one that already exists in Ollama
+- **Poor answer quality** — Try a larger model in the Ask page model selector, or ensure more episodes are processed so the retrieval pool is larger
 
 ---
 


### PR DESCRIPTION
## Summary
- update Ask AI guide to remove stale OLLAMA_MODEL env-var guidance
- document actual model selection path (Ask page selector, request-level model)
- remove incorrect claim that the worker auto-pulls Ollama models
- correct episode lifecycle download failure-mode text to match retry logic (HTTP_ACCESS is auto-retry)
- document HEALTH_CHECK_NOTIFICATIONS_ENABLED in both docs/configuration.md and .env.example

## Validation
- verified references in code:
  - apps/pipeline/app/services/rag.py (DEFAULT_MODEL = qwen2.5:3b)
  - apps/web/src/app/ask/page.tsx (UI model selector)
  - apps/pipeline/app/tasks/download.py (HTTP_ACCESS goes through transient retry handler)
  - scripts/healthcheck.py + apps/pipeline/app/config.py (HEALTH_CHECK_NOTIFICATIONS_ENABLED support)
- grep checks confirm stale claims removed and new env var is documented

Closes #235.