### PR TITLE
docs: refresh stale search paths and test count references (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add RSS feeds, transcribe episodes with Whisper, label speakers with pyannote, a
 ![PostgreSQL](https://img.shields.io/badge/postgresql-15-4169e1?logo=postgresql&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-compose-2496ed?logo=docker&logoColor=white)
 ![License](https://img.shields.io/badge/license-O'Saasy-green)
-![Tests](https://img.shields.io/badge/tests-398%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-passing-brightgreen)
 
 </div>
 
@@ -126,7 +126,7 @@ make up              # Start all services
 make down            # Stop all services
 make build           # Rebuild Docker images
 make logs            # Follow logs for all services
-make test-unit       # Run unit tests (398 tests)
+make test-unit       # Run unit tests
 make shell-db        # Open psql shell
 make health-install  # Install health monitoring cron (every 15 min)
 make help            # List all available commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,7 +91,7 @@ docker compose exec pipeline alembic upgrade head
 
 ## Running Tests
 
-### Unit Tests (398 tests — 317 pipeline + 81 web)
+### Unit Tests
 
 ```bash
 cd apps/pipeline

--- a/docs/guide/02-first-run.md
+++ b/docs/guide/02-first-run.md
@@ -50,7 +50,7 @@ After adding a feed, go to `/queue` to watch the episode move through the pipeli
 
 For more detail on each stage and error handling, see [Queue Dashboard](08-queue.md).
 
-Once the episode reaches **Done**, go to `/` and search for something from the episode — you should see results with clickable timestamps.
+Once the episode reaches **Done**, go to `/search` and search for something from the episode — you should see results with clickable timestamps.
 
 ---
 

--- a/docs/guide/04-search.md
+++ b/docs/guide/04-search.md
@@ -4,7 +4,7 @@ Podlog provides hybrid search combining full-text keyword matching with semantic
 
 ## Full-Text Search
 
-Type keywords into the search bar on the home page (`/`). Podlog supports these operators:
+Type keywords into the search bar on the search page (`/search`). Podlog supports these operators:
 
 | Operator | Example | Matches |
 |---|---|---|


### PR DESCRIPTION
## Summary
- update README test badge from a hardcoded passing-count badge to a stable passing badge
- remove hardcoded unit-test count text from README make test-unit command list
- remove stale hardcoded unit-test count from docs/development.md
- update guide docs to reference /search (not /) as the search page path

## Validation
- verified stale strings are removed from the four touched docs
- verified /search references exist in docs/guide/02-first-run.md and docs/guide/04-search.md

Closes #234.