### PR TITLE
docs: clarify audit workflows and findings lifecycle (#225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See [docs/configuration.md](docs/configuration.md) for the full list of all envi
 | [Configuration](docs/configuration.md) | All environment variables with defaults and explanations |
 | [Hardware Guide](docs/hardware.md) | System requirements, processing benchmarks, tested machine specs |
 | [Development](docs/development.md) | Local development setup, running tests, architecture notes, and Codex/Claude audit workflows |
+| [Audit Workflows](docs/development.md#audit-workflows) | How Codex (`nightly-audit`) and Claude (`/codebase-audit`) audits are run, what they produce, and safety constraints |
 
 ## Common Commands
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -285,3 +285,14 @@ claude -p "/codebase-audit" \
 - Audits should be non-destructive and analysis-first.
 - No commit/push as part of a standard audit run.
 - No automatic issue creation unless explicitly requested.
+
+### Findings Lifecycle (How Audits Improve the Repo)
+
+In this project, audit output is used as an input to normal issue/PR development:
+
+1. Run an audit (Codex or Claude path).
+2. Review findings and create or update focused GitHub issues (often labeled `codebase-audit`).
+3. Implement fixes in regular branches/PRs with tests and validation.
+4. Merge fixes and close the related audit issues.
+
+This keeps audits visible to contributors while preserving normal review and merge controls.


### PR DESCRIPTION
## Summary
- keep audit-workflow documentation centered in docs/development.md (single discoverable source)
- add an explicit findings-lifecycle section explaining how audit findings flow into issues and PR fixes
- add a direct README documentation link to the audit workflows section for contributor discoverability

## Why
Issue #225 asks for clear documentation that the repo uses two audit paths and that findings are used to improve the codebase. This update emphasizes the practical lifecycle: audit output to focused issues to PR fixes to issue closure.

## Files changed
- README.md
- docs/development.md

Closes #225.