### PR TITLE
feat(episode): add markdown and pdf export options (#248)

### DIFF
--- a/apps/web/src/components/TranscriptExportButton.tsx
+++ b/apps/web/src/components/TranscriptExportButton.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Download } from "lucide-react";
+import { Download, FileText, Printer, Type } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { Segment } from "@/lib/types";
 import { formatTimestamp } from "@/lib/timestamp";
 
@@ -81,28 +88,154 @@ function buildExportText(props: Props): string {
   return lines.join("\n");
 }
 
+function buildExportMarkdown(props: Props): string {
+  const lines: string[] = [];
+  lines.push("# Transcript Export");
+  lines.push("");
+  if (props.feedTitle) lines.push(`**Podcast:** ${props.feedTitle}`);
+  lines.push(`**Episode:** ${props.episodeTitle}`);
+  if (props.publishedAt) lines.push(`**Published:** ${new Date(props.publishedAt).toLocaleDateString()}`);
+  if (props.durationSecs) lines.push(`**Duration:** ${formatDuration(props.durationSecs)}`);
+  if (props.audioUrl) lines.push(`**Audio URL:** ${props.audioUrl}`);
+  if (props.guid) lines.push(`**Episode GUID:** ${props.guid}`);
+  lines.push("");
+  if (props.description) {
+    lines.push("## Description");
+    lines.push("");
+    lines.push(props.description);
+    lines.push("");
+  }
+  lines.push("## Transcript");
+  lines.push("");
+
+  for (const seg of props.segments) {
+    const ts = formatTimestamp(seg.start_time, { padHours: true });
+    const speaker = seg.display_name || seg.speaker_label;
+    if (speaker) {
+      lines.push(`- \`${ts}\` **${speaker}:** ${seg.text}`);
+    } else {
+      lines.push(`- \`${ts}\` ${seg.text}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function openPrintView(props: Props) {
+  const title = props.episodeTitle || "Transcript Export";
+  const rows = props.segments
+    .map((seg) => {
+      const ts = formatTimestamp(seg.start_time, { padHours: true });
+      const speaker = seg.display_name || seg.speaker_label;
+      return `<p><span class="ts">[${escapeHtml(ts)}]</span> ${speaker ? `<strong>${escapeHtml(speaker)}:</strong> ` : ""}${escapeHtml(seg.text)}</p>`;
+    })
+    .join("\n");
+
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${escapeHtml(title)} - Transcript Export</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 24px; color: #111827; }
+      h1, h2 { margin: 0 0 12px; }
+      .meta { margin-bottom: 16px; font-size: 14px; color: #4b5563; }
+      .meta div { margin: 2px 0; }
+      .ts { color: #2563eb; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      p { margin: 0 0 10px; line-height: 1.45; }
+      @media print { body { margin: 0.5in; } }
+    </style>
+  </head>
+  <body>
+    <h1>${escapeHtml(title)}</h1>
+    <div class="meta">
+      ${props.feedTitle ? `<div><strong>Podcast:</strong> ${escapeHtml(props.feedTitle)}</div>` : ""}
+      ${props.publishedAt ? `<div><strong>Published:</strong> ${escapeHtml(new Date(props.publishedAt).toLocaleDateString())}</div>` : ""}
+      ${props.durationSecs ? `<div><strong>Duration:</strong> ${escapeHtml(formatDuration(props.durationSecs))}</div>` : ""}
+    </div>
+    <h2>Transcript</h2>
+    ${rows}
+  </body>
+</html>`;
+
+  const w = window.open("", "_blank");
+  if (!w) return;
+  w.document.open();
+  w.document.write(html);
+  w.document.close();
+  w.focus();
+  w.print();
+}
+
 export default function TranscriptExportButton(props: Props) {
-  function handleExport() {
+  function handleExport(format: "markdown" | "text" | "print") {
+    const safe = sanitizeFilename(props.episodeTitle);
+
+    if (format === "markdown") {
+      const content = buildExportMarkdown(props);
+      downloadFile(content, `${safe}_transcript.md`, "text/markdown;charset=utf-8");
+      return;
+    }
+
+    if (format === "print") {
+      openPrintView(props);
+      return;
+    }
+
     const text = buildExportText(props);
-    const blob = new Blob([text], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${sanitizeFilename(props.episodeTitle)}_transcript.txt`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadFile(text, `${safe}_transcript.txt`, "text/plain;charset=utf-8");
   }
 
   return (
-    <button
-      onClick={handleExport}
-      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground border border-input rounded-md px-3 py-1.5 transition-colors"
-      title="Export transcript as .txt"
-    >
-      <Download size={14} />
-      Export
-    </button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5" title="Export transcript">
+          <Download size={14} />
+          Export
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem onClick={() => handleExport("markdown")} className="gap-2">
+          <FileText size={14} />
+          <div>
+            <div className="text-sm">Markdown (.md)</div>
+            <div className="text-[11px] text-muted-foreground">Structured transcript + metadata</div>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("text")} className="gap-2">
+          <Type size={14} />
+          <div>
+            <div className="text-sm">Plain Text (.txt)</div>
+            <div className="text-[11px] text-muted-foreground">Simple format, no markup</div>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("print")} className="gap-2">
+          <Printer size={14} />
+          <div>
+            <div className="text-sm">Print / PDF</div>
+            <div className="text-[11px] text-muted-foreground">Open printable transcript view</div>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/tests/unit/transcript-export-button.test.tsx
+++ b/apps/web/tests/unit/transcript-export-button.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TranscriptExportButton from "@/components/TranscriptExportButton";
+
+const baseProps = {
+  episodeTitle: "Example Episode",
+  feedTitle: "Example Podcast",
+  publishedAt: "2026-01-02T00:00:00.000Z",
+  durationSecs: 1800,
+  description: "Episode description",
+  feedUrl: "https://example.com/feed.xml",
+  feedWebsiteUrl: "https://example.com",
+  feedDescription: "Feed description",
+  audioUrl: "https://cdn.example.com/audio.mp3",
+  guid: "guid-1",
+  segments: [
+    {
+      id: 1,
+      start_time: 12,
+      end_time: 15,
+      speaker_label: "SPEAKER_00",
+      display_name: "Host",
+      inferred: false,
+      confirmed_by_user: true,
+      text: "Hello world",
+    },
+  ],
+};
+
+describe("TranscriptExportButton", () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalAnchorClick = HTMLAnchorElement.prototype.click;
+  const createObjectURL = jest.fn(() => "blob:mock");
+  const revokeObjectURL = jest.fn();
+  const anchorClick = jest.fn();
+  const openSpy = jest.spyOn(window, "open");
+  const appendSpy = jest.spyOn(document.body, "appendChild");
+  const removeSpy = jest.spyOn(document.body, "removeChild");
+
+  beforeEach(() => {
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+    HTMLAnchorElement.prototype.click = anchorClick;
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+    anchorClick.mockClear();
+    openSpy.mockReset();
+    appendSpy.mockClear();
+    removeSpy.mockClear();
+  });
+
+  afterAll(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    HTMLAnchorElement.prototype.click = originalAnchorClick;
+    openSpy.mockRestore();
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it("exports markdown as .md", async () => {
+    const user = userEvent.setup();
+    render(<TranscriptExportButton {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Markdown (.md)"));
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("exports plain text as .txt", async () => {
+    const user = userEvent.setup();
+    render(<TranscriptExportButton {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Plain Text (.txt)"));
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("opens print window for pdf export path", async () => {
+    const user = userEvent.setup();
+    const print = jest.fn();
+    const focus = jest.fn();
+    const docOpen = jest.fn();
+    const docWrite = jest.fn();
+    const docClose = jest.fn();
+    openSpy.mockReturnValue({
+      document: {
+        open: docOpen,
+        write: docWrite,
+        close: docClose,
+      },
+      focus,
+      print,
+    } as unknown as Window);
+
+    render(<TranscriptExportButton {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Print / PDF"));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith("", "_blank");
+      expect(docOpen).toHaveBeenCalled();
+      expect(docWrite).toHaveBeenCalled();
+      expect(docClose).toHaveBeenCalled();
+      expect(focus).toHaveBeenCalled();
+      expect(print).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend episode transcript export from single txt action to a dropdown with:
  - Markdown (.md)
  - Plain Text (.txt)
  - Print / PDF (print-friendly popup view)
- keep existing metadata-rich txt export behavior
- add markdown generator for episode transcript + metadata
- add unit tests for all export paths (markdown, text, print/pdf)

## Validation
- npx jest tests/unit/transcript-export-button.test.tsx --no-cache
- npx jest tests/unit/episode-page-navigation.test.tsx --no-cache
- npm run typecheck (apps/web)

Closes #248.