### PR TITLE
feat(web): monochrome action system + centralized action color

### DIFF
--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -480,7 +480,7 @@ export default function AskPage() {
                   <div className="flex items-center gap-2 min-w-0">
                     <Link
                       href={episodeTimestampHref(source.episode_id, source.start_time)}
-                      className="font-medium truncate hover:underline text-primary"
+                      className="font-medium truncate hover:underline text-link"
                     >
                       {source.episode_title}
                     </Link>

--- a/apps/web/src/app/feeds/page.tsx
+++ b/apps/web/src/app/feeds/page.tsx
@@ -227,7 +227,7 @@ export default function FeedsPage() {
                     onClick={() => setAddMode("test")}
                     className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                       addMode === "test"
-                        ? "bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200 ring-1 ring-violet-300 dark:ring-violet-700"
+                        ? "bg-action text-action-foreground"
                         : "bg-muted text-muted-foreground hover:bg-accent"
                     }`}
                   >
@@ -239,7 +239,7 @@ export default function FeedsPage() {
                     onClick={() => setAddMode("selective")}
                     className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                       addMode === "selective"
-                        ? "bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-200 ring-1 ring-sky-300 dark:ring-sky-700"
+                        ? "bg-action text-action-foreground"
                         : "bg-muted text-muted-foreground hover:bg-accent"
                     }`}
                   >
@@ -251,7 +251,7 @@ export default function FeedsPage() {
                     onClick={() => setAddMode("full")}
                     className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                       addMode === "full"
-                        ? "bg-primary text-primary-foreground"
+                        ? "bg-action text-action-foreground"
                         : "bg-muted text-muted-foreground hover:bg-accent"
                     }`}
                   >
@@ -286,7 +286,7 @@ export default function FeedsPage() {
                   <button
                     type="button"
                     onClick={toggleAll}
-                    className="text-xs text-primary underline"
+                    className="text-xs text-link underline"
                   >
                     {selectedGuids.size === preview.episodes.length ? "Deselect all" : "Select all"}
                   </button>
@@ -362,7 +362,7 @@ export default function FeedsPage() {
           <p className="text-muted-foreground">No feeds yet.</p>
           <button
             onClick={() => setShowAddModal(true)}
-            className="mt-2 text-sm text-primary underline"
+            className="mt-2 text-sm text-link underline"
           >
             Add your first RSS feed
           </button>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -14,6 +14,9 @@
 
   --color-primary: hsl(var(--primary));
   --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-action: hsl(var(--action));
+  --color-action-foreground: hsl(var(--action-foreground));
+  --color-link: hsl(var(--link));
 
   --color-secondary: hsl(var(--secondary));
   --color-secondary-foreground: hsl(var(--secondary-foreground));
@@ -91,8 +94,11 @@
     --foreground: 0 0% 20%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 20%;
-    --primary: 210 79% 56%;
+    --primary: 0 0% 20%;
     --primary-foreground: 0 0% 100%;
+    --action: 0 0% 20%;
+    --action-foreground: 0 0% 100%;
+    --link: 210 79% 56%;
     --secondary: 0 0% 96%;
     --secondary-foreground: 0 0% 20%;
     --muted: 0 0% 96%;
@@ -103,7 +109,7 @@
     --destructive-foreground: 0 0% 100%;
     --border: 0 0% 90%;
     --input: 0 0% 90%;
-    --ring: 210 79% 56%;
+    --ring: 0 0% 35%;
     --radius: 0.5rem;
   }
 
@@ -113,8 +119,11 @@
     --foreground: 0 0% 83%;
     --card: 0 0% 10%;
     --card-foreground: 0 0% 83%;
-    --primary: 210 79% 65%;
+    --primary: 0 0% 83%;
     --primary-foreground: 0 0% 10%;
+    --action: 0 0% 83%;
+    --action-foreground: 0 0% 10%;
+    --link: 210 79% 65%;
     --secondary: 0 0% 17%;
     --secondary-foreground: 0 0% 83%;
     --muted: 0 0% 17%;
@@ -125,7 +134,7 @@
     --destructive-foreground: 0 0% 83%;
     --border: 0 0% 17%;
     --input: 0 0% 17%;
-    --ring: 210 79% 65%;
+    --ring: 0 0% 65%;
   }
 }
 

--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -114,7 +114,7 @@ export default async function SourcesPage() {
       {feeds.length === 0 && uploads.total === 0 && (
         <div className="text-center py-12 space-y-3">
           <p className="text-muted-foreground">No sources yet.</p>
-          <Link href="/feeds" className="text-sm text-primary underline">
+          <Link href="/feeds" className="text-sm text-link underline">
             Add your first RSS feed
           </Link>
           <p className="text-xs text-muted-foreground">or upload an audio file below</p>

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -268,7 +268,7 @@ function SearchPageContent() {
             {[0, 1, 2, 3, 4, 5, 6].map((i) => (
               <span
                 key={i}
-                className="w-1 h-6 origin-center rounded-full bg-primary animate-[eqBar_1.4s_ease-in-out_infinite]"
+                className="w-1 h-6 origin-center rounded-full bg-foreground animate-[eqBar_1.4s_ease-in-out_infinite]"
                 style={{ animationDelay: `${i * 0.1}s` }}
               />
             ))}
@@ -317,7 +317,7 @@ function SearchPageContent() {
                   }}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
                     viewMode === "grouped"
-                      ? "bg-primary text-primary-foreground"
+                      ? "bg-action text-action-foreground"
                       : "hover:bg-accent/30"
                   }`}
                   title="Grouped view"
@@ -332,7 +332,7 @@ function SearchPageContent() {
                   }}
                   className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
                     viewMode === "flat"
-                      ? "bg-primary text-primary-foreground"
+                      ? "bg-action text-action-foreground"
                       : "hover:bg-accent/30"
                   }`}
                   title="Flat view"

--- a/apps/web/src/components/EpisodeChat.tsx
+++ b/apps/web/src/components/EpisodeChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import { MessageSquare, Send, X, Loader2 } from "lucide-react";
+import { BrainCircuit, Send, X, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { renderAnswerWithCitations, type Source, type OnCitationClick } from "@/lib/citations";
 
@@ -140,10 +140,10 @@ export default function EpisodeChat({ episodeId, episodeTitle }: EpisodeChatProp
     return (
       <button
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-primary px-4 py-3 text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-action px-4 py-3 text-action-foreground shadow-lg hover:bg-action/90 transition-colors"
         aria-label="Ask about this episode"
       >
-        <MessageSquare size={18} />
+        <BrainCircuit size={18} />
         <span className="text-sm font-medium">Ask</span>
       </button>
     );
@@ -155,7 +155,7 @@ export default function EpisodeChat({ episodeId, episodeTitle }: EpisodeChatProp
       {/* Header */}
       <div className="flex items-center justify-between gap-2 px-4 py-3 border-b shrink-0">
         <div className="flex items-center gap-2 min-w-0">
-          <MessageSquare size={16} className="text-primary shrink-0" />
+          <BrainCircuit size={16} className="text-link shrink-0" />
           <span className="text-sm font-medium truncate">{episodeTitle}</span>
         </div>
         <button
@@ -259,7 +259,7 @@ function MessageBubble({ message, episodeId, isStreaming }: { message: Message; 
                   key={s.chunk_id}
                   type="button"
                   onClick={() => scrollToTime(Math.floor(s.start_time))}
-                  className="block w-full text-left text-xs text-primary hover:underline truncate"
+                  className="block w-full text-left text-xs text-link hover:underline truncate"
                 >
                   {s.timestamp} {s.speaker_label ? `(${s.speaker_label})` : ""} — {s.text.slice(0, 80)}...
                 </button>

--- a/apps/web/src/components/EpisodeDescription.tsx
+++ b/apps/web/src/components/EpisodeDescription.tsx
@@ -148,7 +148,7 @@ export default function EpisodeDescription({
       <div
         ref={containerRef}
         onClick={handleClick}
-        className={`prose prose-sm dark:prose-invert max-w-none prose-a:text-primary prose-a:underline ${
+        className={`prose prose-sm dark:prose-invert max-w-none prose-a:text-link prose-a:underline ${
           !expanded && isLong ? "line-clamp-3" : ""
         }`}
         dangerouslySetInnerHTML={{ __html: sanitizedHtml }}

--- a/apps/web/src/components/EpisodeMentionList.tsx
+++ b/apps/web/src/components/EpisodeMentionList.tsx
@@ -121,7 +121,7 @@ function MentionCard({
             {isLong && (
               <button
                 onClick={() => setExpanded((e) => !e)}
-                className="text-xs text-primary hover:underline mt-1 block"
+                className="text-xs text-link hover:underline mt-1 block"
               >
                 {expanded ? "Show less" : "Show more"}
               </button>
@@ -198,7 +198,7 @@ export default function EpisodeMentionList({
       {!showAll && hiddenCount > 0 && (
         <button
           onClick={() => setShowAll(true)}
-          className="text-sm text-primary hover:underline w-full text-center py-1"
+          className="text-sm text-link hover:underline w-full text-center py-1"
         >
           Show {hiddenCount} more mention{hiddenCount !== 1 ? "s" : ""}
         </button>

--- a/apps/web/src/components/NotificationSettingsSections.tsx
+++ b/apps/web/src/components/NotificationSettingsSections.tsx
@@ -220,6 +220,8 @@ function FieldGroup({
 
 const inputClass =
   "w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring";
+const actionButtonClass =
+  "px-5 py-2 rounded-md bg-action text-action-foreground text-sm font-medium hover:bg-action/90 disabled:opacity-50";
 
 const EMAIL_RE = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
 
@@ -364,7 +366,7 @@ export function TelegramTab({
 
       <div className="flex gap-3 mt-6">
         <button
-          className="px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-500 disabled:opacity-50"
+          className={actionButtonClass}
           onClick={onSave}
           disabled={saving}
         >
@@ -499,7 +501,7 @@ export function EmailTab({
 
       <div className="flex gap-3 mt-6">
         <button
-          className="px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-500 disabled:opacity-50"
+          className={actionButtonClass}
           onClick={onSave}
           disabled={saving}
         >
@@ -564,7 +566,7 @@ export function GeneralTab({
 
       <div className="flex gap-3 mt-6">
         <button
-          className="px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-500 disabled:opacity-50"
+          className={actionButtonClass}
           onClick={onSave}
           disabled={saving}
         >
@@ -757,7 +759,7 @@ export function FireworksTab({
 
       <div className="flex gap-3 mt-6">
         <button
-          className="px-5 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-500 disabled:opacity-50"
+          className={actionButtonClass}
           onClick={onSave}
           disabled={saving}
         >

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -129,7 +129,7 @@ function EpisodeRow({
         <td className="px-3 py-2 text-sm">
           <Link
             href={`/episodes/${job.episode_id}`}
-            className="hover:text-primary hover:underline transition-colors"
+            className="hover:text-link hover:underline transition-colors"
             onClick={(e) => e.stopPropagation()}
           >
             {job.title ?? "Untitled"}
@@ -188,7 +188,7 @@ function EpisodeRow({
               )}
               {canRetry && (
                 <button
-                  className="mt-2 px-3 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90"
+                  className="mt-2 px-3 py-1 text-xs bg-action text-action-foreground rounded hover:bg-action/90"
                   onClick={(e) => {
                     e.stopPropagation();
                     onRetry(job.episode_id);
@@ -306,7 +306,7 @@ export default function QueueStatus() {
         <div className="text-center py-12 text-muted-foreground">
           <p>No episodes in the queue.</p>
           <p className="text-sm mt-1">
-            <Link href="/feeds" className="text-primary hover:underline">
+            <Link href="/feeds" className="text-link hover:underline">
               Add a feed
             </Link>{" "}
             to get started.
@@ -321,7 +321,7 @@ export default function QueueStatus() {
             Filtering by <b>{stageFilter}</b>
           </span>
           <button
-            className="text-xs text-primary hover:underline"
+            className="text-xs text-link hover:underline"
             onClick={() => setStageFilter(null)}
           >
             Clear filter

--- a/apps/web/src/components/SearchResult.tsx
+++ b/apps/web/src/components/SearchResult.tsx
@@ -129,7 +129,7 @@ export default function SearchResult({ result, query }: Props) {
           {isLong && (
             <button
               onClick={() => setExpanded((e) => !e)}
-              className="text-xs text-primary hover:underline mt-1"
+              className="text-xs text-link hover:underline mt-1"
             >
               {expanded ? "Show less" : "Show more"}
             </button>

--- a/apps/web/src/components/WizardAddFeed.tsx
+++ b/apps/web/src/components/WizardAddFeed.tsx
@@ -203,7 +203,7 @@ export default function WizardAddFeed({ onNext, onBack, onSkip }: Props) {
               onClick={() => setMode("test")}
               className={`flex-1 flex items-center gap-1.5 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
                 mode === "test"
-                  ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 ring-1 ring-blue-300 dark:ring-blue-700"
+                  ? "bg-action text-action-foreground"
                   : "bg-muted text-muted-foreground hover:bg-accent"
               }`}
             >
@@ -218,7 +218,7 @@ export default function WizardAddFeed({ onNext, onBack, onSkip }: Props) {
               onClick={() => setMode("selective")}
               className={`flex-1 flex items-center gap-1.5 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
                 mode === "selective"
-                  ? "bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-200 ring-1 ring-sky-300 dark:ring-sky-700"
+                  ? "bg-action text-action-foreground"
                   : "bg-muted text-muted-foreground hover:bg-accent"
               }`}
             >
@@ -233,7 +233,7 @@ export default function WizardAddFeed({ onNext, onBack, onSkip }: Props) {
               onClick={() => setMode("full")}
               className={`flex-1 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
                 mode === "full"
-                  ? "bg-primary text-primary-foreground"
+                  ? "bg-action text-action-foreground"
                   : "bg-muted text-muted-foreground hover:bg-accent"
               }`}
             >

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-action text-action-foreground hover:bg-action/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-link underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/apps/web/src/lib/citations.tsx
+++ b/apps/web/src/lib/citations.tsx
@@ -61,7 +61,7 @@ export function renderAnswerWithCitations(
             key={`cite-${match.index}`}
             type="button"
             onClick={() => onCitationClick(matchedSource.episode_id, citedSeconds)}
-            className="inline-flex items-center gap-0.5 text-primary hover:underline font-medium"
+            className="inline-flex items-center gap-0.5 text-link hover:underline font-medium"
             title={`${matchedSource.episode_title} at ${citedTimestamp}`}
           >
             [{citedTitle}, {citedTimestamp}]
@@ -72,7 +72,7 @@ export function renderAnswerWithCitations(
           <Link
             key={`cite-${match.index}`}
             href={episodeTimestampHref(matchedSource.episode_id, citedSeconds)}
-            className="inline-flex items-center gap-0.5 text-primary hover:underline font-medium"
+            className="inline-flex items-center gap-0.5 text-link hover:underline font-medium"
             title={`${matchedSource.episode_title} at ${citedTimestamp}`}
           >
             [{citedTitle}, {citedTimestamp}]

--- a/apps/web/tests/unit/episode-chat-trigger-icon.test.tsx
+++ b/apps/web/tests/unit/episode-chat-trigger-icon.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import EpisodeChat from "@/components/EpisodeChat";
+
+describe("EpisodeChat trigger icon", () => {
+  test("uses BrainCircuit icon for ask trigger", () => {
+    const { container } = render(
+      <EpisodeChat episodeId="ep-1" episodeTitle="Example Episode" />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /ask about this episode/i })
+    ).toBeInTheDocument();
+    expect(container.querySelector(".lucide-brain-circuit")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-message-square")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/search-spinner.test.tsx
+++ b/apps/web/tests/unit/search-spinner.test.tsx
@@ -74,7 +74,7 @@ describe("Search page loading spinner", () => {
     expect(await screen.findByText("Searching...")).toBeInTheDocument();
     expect(
       container.querySelector(
-        ".bg-primary.h-6.origin-center.animate-\\[eqBar_1\\.4s_ease-in-out_infinite\\]"
+        ".bg-foreground.h-6.origin-center.animate-\\[eqBar_1\\.4s_ease-in-out_infinite\\]"
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- switch primary action styling to a centralized action token (--color-action)
- move focus/ring and action surfaces to monochrome grayscale palette
- keep blue for links via dedicated link token (--color-link)
- update Search spinner bars to bg-foreground and search view toggle active states to action styling
- update episode page Ask trigger to use BrainCircuit icon and action button styling
- replace hardcoded indigo Save button styles in Notification Settings tabs with centralized action styling
- normalize feed mode toggle active indicators to monochrome action styling

## Tests
- npm test -- --runTestsByPath tests/unit/search-spinner.test.tsx tests/unit/episode-chat-trigger-icon.test.tsx tests/unit/notification-settings.test.tsx
- npm run lint (warnings only; no errors)

Closes #320