### PR TITLE
docs: align stage/status docs and make test-unit scope (#324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ This uses `docker-compose.remote.yml` on top of the default compose file.
                                        │
                         ┌──────────────▼───────────────────────────────┐
                         │  worker (Python)                             │
-                        │    download → transcribe → diarize → embed  │
-                        │    → infer speakers → archive                │
+                        │    download → transcribe → diarize → chunk  │
+                        │    → embed → infer speakers → archive        │
                         │    Sequential processing (concurrency=1)     │
                         │    Whisper + pyannote never in memory at once│
                         └──────────────┬───────────────────────────────┘
@@ -146,7 +146,7 @@ make down-remote     # Stop Fireworks remote-inference profile
 make build           # Rebuild Docker images
 make logs            # Follow logs for all services
 make logs-remote     # Follow logs for remote-inference profile
-make test-unit       # Run unit tests
+make test-unit       # Run pipeline unit tests + healthcheck script tests
 make shell-db        # Open psql shell
 make health-install  # Install health monitoring cron (every 15 min)
 make help            # List all available commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -159,7 +159,7 @@ make build              Rebuild all Docker images
 make logs               Follow logs for all services
 make migrate            Run database migrations
 make test               Run all tests
-make test-unit          Run unit tests only
+make test-unit          Run pipeline unit tests + host healthcheck tests (no web unit tests)
 make test-integration   Run integration tests
 make test-e2e           Run Playwright e2e tests
 make shell-db           Open psql shell

--- a/docs/episode-lifecycle.md
+++ b/docs/episode-lifecycle.md
@@ -7,7 +7,7 @@ This document describes the complete processing pipeline for an episode and what
 An episode moves through these stages sequentially. Each stage produces specific data that downstream features depend on.
 
 ```
-pending → download → transcribe → diarize → embed → infer → archive → done
+pending → download → transcribe → diarize → chunk → embed → infer → archive → done
 ```
 
 ### 1. Download
@@ -74,9 +74,30 @@ pending → download → transcribe → diarize → embed → infer → archive 
 
 ---
 
-### 4. Embed
+### 4. Chunk
 
-**Status:** (no episode status change — runs as a job queue task)
+**Status:** `chunking`
+
+**What it does:**
+- Merges diarized segments into larger speaker-turn chunks for higher-quality RAG retrieval
+- Rebuilds chunks idempotently for the episode (removes old chunks first)
+- Enqueues the embed step when finished
+
+**Data produced:**
+| Field | Table | Description |
+|-------|-------|-------------|
+| `text` | chunks | Merged speaker-turn text |
+| `start_time` / `end_time` | chunks | Chunk timing boundaries |
+| `speaker_label` | chunks | Speaker label carried from diarized segments |
+| `segment_ids` | chunks | Source segment IDs merged into each chunk |
+
+**Failure mode:** Non-fatal — pipeline continues to embed even if chunking fails.
+
+---
+
+### 5. Embed
+
+**Status:** `embedding`
 
 **What it does:**
 - Loads all segments for the episode
@@ -88,14 +109,15 @@ pending → download → transcribe → diarize → embed → infer → archive 
 | Field | Table | Description |
 |-------|-------|-------------|
 | `embedding` | segments | 384-dim normalized vector per segment |
+| `embedding` | chunks | 384-dim normalized vector per merged chunk |
 
 **Failure mode:** Non-fatal — episode continues to infer. Segments without embeddings are excluded from vector search but still found by FTS.
 
 ---
 
-### 5. Infer (Speaker Name Inference)
+### 6. Infer (Speaker Name Inference)
 
-**Status:** (no episode status change)
+**Status:** `inferring`
 
 **What it does:**
 - Extracts host/guest names from episode title and description using spaCy NER (`en_core_web_lg`)
@@ -117,7 +139,7 @@ pending → download → transcribe → diarize → embed → infer → archive 
 
 ---
 
-### 6. Archive
+### 7. Archive
 
 **Status:** `archiving` → `done`
 

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -93,7 +93,7 @@ Service details:
 |---|---|---|
 | **web** | 3000 | Next.js frontend — home, search, episodes, queue, Ask |
 | **pipeline** | 8000 | FastAPI control plane — feed management, health |
-| **worker** | — | Processes episodes: download, transcribe, diarize, archive |
+| **worker** | — | Processes episodes: download, transcribe, diarize, chunk, embed, infer, archive |
 | **db** | 5432 | PostgreSQL 15 with pgvector for FTS + semantic search |
 | **ollama** | 11434 | Local Ask AI generation provider (local-first profile) |
 
@@ -110,7 +110,7 @@ make build           # Rebuild Docker images
 make logs            # Follow logs for all services
 make logs-remote     # Follow logs for remote-inference profile
 make shell-db        # Open a psql shell
-make test-unit       # Run unit tests
+make test-unit       # Run pipeline unit tests + healthcheck script tests
 make health-install  # Install health monitoring cron job (every 15 min)
 make health-check    # Run health check once (manual)
 make help            # List all available commands

--- a/docs/guide/02-first-run.md
+++ b/docs/guide/02-first-run.md
@@ -52,9 +52,11 @@ After adding a feed, go to `/queue` to watch the episode move through the pipeli
 2. **Downloading** — fetching audio from the RSS feed
 3. **Transcribing** — running Whisper speech-to-text
 4. **Diarizing** — running pyannote speaker separation
-5. **Inferring** — extracting speaker names via NER
-6. **Archiving** — compressing audio to MP3
-7. **Done**
+5. **Chunking** — merging diarized segments into speaker-turn chunks for RAG
+6. **Embedding** — generating vector embeddings for segments and chunks
+7. **Inferring** — extracting speaker names via NER
+8. **Archiving** — compressing audio to MP3
+9. **Done**
 
 For more detail on each stage and error handling, see [Queue Dashboard](08-queue.md).
 

--- a/docs/guide/08-queue.md
+++ b/docs/guide/08-queue.md
@@ -12,6 +12,8 @@ Every episode moves through these stages in order:
 | **Downloading** | Fetching audio from the RSS feed URL |
 | **Transcribing** | Running Whisper speech-to-text |
 | **Diarizing** | Running pyannote speaker separation |
+| **Chunking** | Merging diarized segments into speaker-turn chunks for RAG |
+| **Embedding** | Generating vector embeddings for segments and chunks |
 | **Inferring** | Extracting speaker names via spaCy NER |
 | **Archiving** | Compressing audio to MP3 and writing transcript file |
 | **Done** | Fully processed and searchable |


### PR DESCRIPTION
## Summary
- update docs/episode-lifecycle.md pipeline order to include chunk between diarize and embed
- document chunking, embedding, and inferring as explicit episode statuses
- add chunk embedding output to embed stage data section
- update queue and first-run stage lists to include Chunking and Embedding
- clarify make test-unit scope in README, installation guide, and development guide as pipeline unit tests plus healthcheck tests (no web unit tests)
- refresh worker pipeline stage description in docs where it omitted chunk/embed/infer

## Verification
- verified status transitions in pipeline task code:
  - apps/pipeline/app/tasks/chunk.py sets status chunking
  - apps/pipeline/app/tasks/embed.py sets status embedding
  - apps/pipeline/app/tasks/infer.py sets status inferring
  - apps/pipeline/app/tasks/diarize.py enqueues chunk step
- docs-only change; no runtime code paths modified

Closes #324