### PR TITLE
fix: wizard skip/completion navigation regressions (#329)

### DIFF
--- a/apps/web/src/components/SetupWizard.tsx
+++ b/apps/web/src/components/SetupWizard.tsx
@@ -18,7 +18,6 @@ export default function SetupWizard() {
   const router = useRouter();
 
   function handleHealthCheckSkip() {
-    markCompleted(true);
     close();
   }
 
@@ -39,6 +38,11 @@ export default function SetupWizard() {
     close();
     if (feedAdded) router.push("/queue");
     else router.push("/");
+  }
+
+  function handleNavigateFromCompletion() {
+    markCompleted(dontShow);
+    close();
   }
 
   function goToStep(s: Step) {
@@ -76,6 +80,7 @@ export default function SetupWizard() {
             feedAdded={feedAdded}
             onFinish={handleFinish}
             onDontShowChange={setDontShow}
+            onNavigate={handleNavigateFromCompletion}
           />
         )}
 

--- a/apps/web/src/components/WizardComplete.tsx
+++ b/apps/web/src/components/WizardComplete.tsx
@@ -16,9 +16,15 @@ interface Props {
   feedAdded: boolean;
   onFinish: () => void;
   onDontShowChange: (checked: boolean) => void;
+  onNavigate?: () => void;
 }
 
-export default function WizardComplete({ feedAdded, onFinish, onDontShowChange }: Props) {
+export default function WizardComplete({
+  feedAdded,
+  onFinish,
+  onDontShowChange,
+  onNavigate,
+}: Props) {
   const [dontShow, setDontShow] = useState(false);
 
   const links: LinkItem[] = feedAdded
@@ -61,7 +67,7 @@ export default function WizardComplete({ feedAdded, onFinish, onDontShowChange }
             <Link
               key={link.href}
               href={link.href}
-              onClick={onFinish}
+              onClick={onNavigate}
               className={`flex items-center gap-3 p-2.5 rounded-md transition-colors ${
                 link.highlight
                   ? "border-2 border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30"

--- a/apps/web/tests/unit/setup-wizard.test.tsx
+++ b/apps/web/tests/unit/setup-wizard.test.tsx
@@ -16,10 +16,11 @@ jest.mock("@/components/WizardProvider", () => ({
 }));
 
 const mockUseWizard = useWizard as jest.Mock;
+const mockPush = jest.fn();
 
 // Mock next/navigation
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 const mockFetch = jest.fn();
@@ -32,6 +33,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockPush.mockReset();
 });
 
 describe("WizardHealthCheck", () => {
@@ -530,5 +532,49 @@ describe("SetupWizard", () => {
     expect(mockSetOpen).not.toHaveBeenCalled();
     expect(screen.getByText(/Ready When You Are/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /get started/i })).toBeInTheDocument();
+  });
+
+  it("does not mark wizard completed when Skip wizard is clicked on screen 1", async () => {
+    const mockMarkCompleted = jest.fn();
+    const mockSetOpen = jest.fn();
+    mockUseWizard.mockReturnValue({ open: true, setOpen: mockSetOpen, markCompleted: mockMarkCompleted });
+    render(<SetupWizard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome to Podlog")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /skip wizard/i }));
+
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+    expect(mockSetOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("uses link destination from completion cards instead of generic onFinish redirect", async () => {
+    const mockMarkCompleted = jest.fn();
+    const mockSetOpen = jest.fn();
+    mockUseWizard.mockReturnValue({ open: true, setOpen: mockSetOpen, markCompleted: mockMarkCompleted });
+    render(<SetupWizard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome to Podlog")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Add Your First Podcast/i)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /skip/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ready When You Are/i)).toBeInTheDocument();
+    });
+
+    const targetLink = screen.getByRole("link", { name: /add your first feed/i });
+    fireEvent.click(targetLink);
+
+    expect(mockMarkCompleted).toHaveBeenCalledWith(false);
+    expect(mockSetOpen).toHaveBeenCalledWith(false);
+    expect(mockPush).not.toHaveBeenCalledWith("/");
   });
 });

--- a/apps/web/tests/unit/setup-wizard.test.tsx
+++ b/apps/web/tests/unit/setup-wizard.test.tsx
@@ -577,4 +577,35 @@ describe("SetupWizard", () => {
     expect(mockSetOpen).toHaveBeenCalledWith(false);
     expect(mockPush).not.toHaveBeenCalledWith("/");
   });
+
+  it("does not trigger generic /queue redirect when clicking completion links after adding a feed", async () => {
+    const mockMarkCompleted = jest.fn();
+    const mockSetOpen = jest.fn();
+    mockUseWizard.mockReturnValue({ open: true, setOpen: mockSetOpen, markCompleted: mockMarkCompleted });
+    render(<SetupWizard />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome to Podlog")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Add Your First Podcast/i)).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByPlaceholderText(/feeds\.example\.com/i), {
+      target: { value: "https://example.com/feed.xml" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add feed/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/You're All Set!/i)).toBeInTheDocument();
+    });
+
+    const searchLink = screen.getByRole("link", { name: /search/i });
+    fireEvent.click(searchLink);
+
+    expect(mockMarkCompleted).toHaveBeenCalledWith(false);
+    expect(mockSetOpen).toHaveBeenCalledWith(false);
+    expect(mockPush).not.toHaveBeenCalledWith("/queue");
+  });
 });


### PR DESCRIPTION
## Summary
- stop marking wizard as completed when user clicks Skip wizard on screen 1
- separate completion actions:
  - Get Started keeps existing finish behavior (mark completion + close + route)
  - link-card navigation now marks completion + closes but does not force a generic redirect
- add regression tests for:
  - screen 1 skip not marking completion
  - completion card click not invoking generic / route redirect logic

## Verification
- npm test -- --runTestsByPath tests/unit/setup-wizard.test.tsx
- npm run lint (warnings only; no errors)

Closes #329