### PR TITLE
chore: remove dead stubs and unused exports (#327)

### DIFF
--- a/apps/pipeline/tests/e2e/test_full_flow.py
+++ b/apps/pipeline/tests/e2e/test_full_flow.py
@@ -10,10 +10,12 @@ import os
 import time
 
 import httpx
+import pytest
 
 PIPELINE_URL = os.environ.get("PIPELINE_API_URL", "http://pipeline_test:8000")
 
 
+@pytest.mark.e2e
 class TestFullIngestionFlow:
     """Requires a running Docker stack (docker compose -f docker-compose.test.yml up)."""
 

--- a/apps/pipeline/tests/e2e/test_full_flow.py
+++ b/apps/pipeline/tests/e2e/test_full_flow.py
@@ -10,12 +10,10 @@ import os
 import time
 
 import httpx
-import pytest
 
 PIPELINE_URL = os.environ.get("PIPELINE_API_URL", "http://pipeline_test:8000")
 
 
-@pytest.mark.e2e
 class TestFullIngestionFlow:
     """Requires a running Docker stack (docker compose -f docker-compose.test.yml up)."""
 
@@ -25,16 +23,3 @@ class TestFullIngestionFlow:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] in ("OK", "WARMING_UP")
-
-    def test_add_feed_and_poll(self):
-        """
-        POST a feed → trigger poll → verify episode(s) enqueued.
-        """
-        pytest.skip("E2E stub — requires mock RSS server in test stack")
-
-    def test_full_ingestion_produces_transcript(self):
-        """
-        POST a feed with a 10-second audio file → wait for completion
-        → assert segments exist and transcript file written.
-        """
-        pytest.skip("E2E stub — requires mock RSS server + audio fixture in test stack")

--- a/apps/web/src/lib/searchHybrid.ts
+++ b/apps/web/src/lib/searchHybrid.ts
@@ -1,4 +1,4 @@
-export interface HybridSearchResultItem {
+interface HybridSearchResultItem {
   id: number;
   startTime: number;
   endTime: number;

--- a/apps/web/src/lib/speakerColors.ts
+++ b/apps/web/src/lib/speakerColors.ts
@@ -3,7 +3,7 @@
  * Colors are assigned by speaker slot index (SPEAKER_00 = blue, etc.).
  */
 
-export interface SpeakerColor {
+interface SpeakerColor {
   name: string;
   hex: string;
   bg: string;       // Tailwind-compatible bg tint (rgba)


### PR DESCRIPTION
## Summary
- remove permanently skipped e2e stub tests from apps/pipeline/tests/e2e/test_full_flow.py
- keep the real e2e health check test in place
- remove unused exported type declarations:
  - HybridSearchResultItem export in apps/web/src/lib/searchHybrid.ts
  - SpeakerColor export in apps/web/src/lib/speakerColors.ts

## Verification
- python3 -m py_compile apps/pipeline/tests/e2e/test_full_flow.py
- npm run lint (warnings only; no errors)

Closes #327