### PR TITLE
test: add targeted coverage for queue/search/speaker and pipeline embed flows

### DIFF
--- a/apps/pipeline/tests/unit/test_api_embed.py
+++ b/apps/pipeline/tests/unit/test_api_embed.py
@@ -1,0 +1,38 @@
+"""Unit tests for /api/embed endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_embed_endpoint_returns_embedding_and_uses_runtime_settings():
+    mock_db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    try:
+        with (
+            patch(
+                "app.api.embed.get_runtime_embedding_settings",
+                return_value={"embedding_provider": "local"},
+            ) as mock_runtime,
+            patch("app.services.embed.embed_query", return_value=[0.1, 0.2, 0.3]) as mock_embed,
+        ):
+            resp = client.post("/api/embed", json={"text": "hello world"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"embedding": [0.1, 0.2, 0.3]}
+        mock_runtime.assert_called_once_with(mock_db)
+        mock_embed.assert_called_once_with(
+            "hello world", runtime={"embedding_provider": "local"}
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_embed_endpoint_validates_payload():
+    resp = client.post("/api/embed", json={})
+    assert resp.status_code == 422

--- a/apps/pipeline/tests/unit/test_notification_events.py
+++ b/apps/pipeline/tests/unit/test_notification_events.py
@@ -1,0 +1,28 @@
+"""Unit tests for app.services.notification_events dataclasses."""
+
+from app.services.events import Event
+from app.services.notification_events import EpisodeDoneEvent, EpisodeFailedEvent
+
+
+def test_episode_done_event_defaults_and_base_type():
+    event = EpisodeDoneEvent()
+    assert isinstance(event, Event)
+    assert event.episode_id == ""
+    assert event.queue_remaining == 0
+    assert event.processing_factor is None
+
+
+def test_episode_failed_event_fields():
+    event = EpisodeFailedEvent(
+        episode_id="ep-1",
+        error_class="TRANSIENT_NETWORK",
+        error_message="timeout",
+        retry_count=1,
+        retry_max=3,
+    )
+    assert isinstance(event, Event)
+    assert event.episode_id == "ep-1"
+    assert event.error_class == "TRANSIENT_NETWORK"
+    assert event.error_message == "timeout"
+    assert event.retry_count == 1
+    assert event.retry_max == 3

--- a/apps/web/tests/unit/queue-status.test.tsx
+++ b/apps/web/tests/unit/queue-status.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import QueueStatus from "@/components/QueueStatus";
+
+jest.mock("next/link", () => {
+  return ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+describe("QueueStatus", () => {
+  test("renders failed episode and retries via API", async () => {
+    const queuePayload = {
+      active_count: 0,
+      pending_count: 0,
+      failed_count: 1,
+      done_count: 0,
+      stuck_count: 0,
+      active_jobs: [],
+      pending_jobs: [],
+      failed_jobs: [
+        {
+          episode_id: "ep-failed",
+          title: "Broken Episode",
+          status: "failed",
+          error_message: "network timeout",
+          error_class: "TRANSIENT_NETWORK",
+          retry_count: 1,
+          retry_max: 3,
+          feed_mode: "full",
+          feed_title: "My Podcast",
+          updated_at: new Date().toISOString(),
+        },
+      ],
+      done_jobs: [],
+      stuck_jobs: [],
+    };
+
+    global.fetch = jest.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/queue") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => queuePayload,
+        } as Response);
+      }
+      if (url === "/api/pipeline/queue/ep-failed/retry") {
+        expect(init?.method).toBe("POST");
+        return Promise.resolve({ ok: true } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch URL: ${url}`));
+    }) as jest.Mock;
+
+    render(<QueueStatus />);
+
+    const episodeTitle = await screen.findByText("Broken Episode");
+    expect(episodeTitle).toBeInTheDocument();
+    const failedRow = episodeTitle.closest("tr");
+    expect(failedRow).not.toBeNull();
+    fireEvent.click(failedRow!);
+    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/pipeline/queue/ep-failed/retry",
+        { method: "POST" }
+      );
+    });
+  });
+});

--- a/apps/web/tests/unit/search-lib.test.ts
+++ b/apps/web/tests/unit/search-lib.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/db", () => ({
+  __esModule: true,
+  default: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/searchHybrid", () => ({
+  mergeHybridSearchResults: jest.fn(() => ({ results: [], total: 0 })),
+}));
+
+import pool from "@/lib/db";
+import { searchSegments } from "@/lib/search";
+
+const mockQuery = (pool as { query: jest.Mock }).query;
+
+describe("search.ts feed filtering", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    global.fetch = jest.fn(async () => ({ ok: false, json: async () => ({}) } as Response));
+  });
+
+  test("uses TRUE filter when no feed IDs and uploads are excluded", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // fts
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // count
+      .mockResolvedValueOnce({ rows: [{ processed: 0, total: 0 }] }); // coverage
+
+    await searchSegments("hello", null, false, 1, 20, false);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("AND TRUE");
+    expect(params).toEqual(["hello", 100]);
+  });
+
+  test("includes feed UUID and manual uploads in SQL filter when both selected", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // fts
+      .mockResolvedValueOnce({ rows: [{ count: "1" }] }) // count
+      .mockResolvedValueOnce({ rows: [{ processed: 3, total: 5 }] }); // coverage
+
+    await searchSegments("hello", ["feed-1"], true, 1, 20, false);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("f.id = ANY($2::uuid[])");
+    expect(sql).toContain("e.feed_id IS NULL");
+    expect(params).toEqual(["hello", ["feed-1"], 100]);
+  });
+});

--- a/apps/web/tests/unit/speaker-panel.test.tsx
+++ b/apps/web/tests/unit/speaker-panel.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SpeakerPanel from "@/components/SpeakerPanel";
+import type { Segment } from "@/lib/types";
+
+function makeSegment(overrides: Partial<Segment> = {}): Segment {
+  return {
+    id: 1,
+    start_time: 0,
+    end_time: 5,
+    speaker_label: "SPEAKER_00",
+    display_name: "Alice",
+    inferred: false,
+    confirmed_by_user: true,
+    text: "hello",
+    ...overrides,
+  };
+}
+
+describe("SpeakerPanel", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  test("renames speaker on successful save", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const onRenamed = jest.fn();
+
+    const segments: Segment[] = [
+      makeSegment({ id: 1, speaker_label: "SPEAKER_00", display_name: "Alice" }),
+      makeSegment({ id: 2, speaker_label: "SPEAKER_01", display_name: "Bob", start_time: 6, end_time: 10 }),
+    ];
+
+    render(
+      <SpeakerPanel
+        episodeId="ep-1"
+        segments={segments}
+        onRenamed={onRenamed}
+        onMerged={jest.fn()}
+        activeSpeaker={null}
+        onFilterSpeaker={jest.fn()}
+      />
+    );
+
+    const aliceLabel = screen.getByText("Alice");
+    fireEvent.doubleClick(aliceLabel);
+
+    const input = await screen.findByDisplayValue("Alice");
+    fireEvent.change(input, { target: { value: "Alice Cooper" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/episodes/ep-1/speakers",
+        expect.objectContaining({
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+      expect(onRenamed).toHaveBeenCalledWith("SPEAKER_00", "Alice Cooper");
+    });
+  });
+
+  test("merges selected speakers via merge endpoint", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const onMerged = jest.fn();
+
+    const segments: Segment[] = [
+      makeSegment({ id: 1, speaker_label: "SPEAKER_00", display_name: "Alice" }),
+      makeSegment({ id: 2, speaker_label: "SPEAKER_00", display_name: "Alice", start_time: 6, end_time: 10 }),
+      makeSegment({ id: 3, speaker_label: "SPEAKER_01", display_name: "Bob", start_time: 11, end_time: 15 }),
+    ];
+
+    render(
+      <SpeakerPanel
+        episodeId="ep-1"
+        segments={segments}
+        onRenamed={jest.fn()}
+        onMerged={onMerged}
+        activeSpeaker={null}
+        onFilterSpeaker={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /merge speakers/i }));
+    fireEvent.click(screen.getByText("Alice"));
+    fireEvent.click(screen.getByText("Bob"));
+    fireEvent.click(screen.getByRole("button", { name: /^merge$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/episodes/ep-1/speakers/merge",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source_labels: ["SPEAKER_01"],
+            target_label: "SPEAKER_00",
+          }),
+        })
+      );
+      expect(onMerged).toHaveBeenCalledWith(["SPEAKER_01"], "SPEAKER_00");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit tests for high-risk web queue/search/speaker behaviors called out in issue #328
- add pipeline unit tests for `/api/embed` response/validation and notification event dataclasses
- keep scope to tests only (no production code changes)

## What is covered
- `SpeakerPanel`: rename speaker flow and merge speaker flow API interactions
- `QueueStatus`: failed episode row expansion and retry API request
- `search.ts`: feed filtering SQL behavior including manual uploads
- `/api/embed`: runtime settings + embedding call behavior and payload validation
- `notification_events`: event defaults and field propagation

## Verification
- `cd apps/web && npm test -- --runTestsByPath tests/unit/speaker-panel.test.tsx tests/unit/queue-status.test.tsx tests/unit/search-lib.test.ts`
- `cd apps/pipeline && python3 -m pytest tests/unit/test_api_embed.py tests/unit/test_notification_events.py -v`

Closes #328