### PR TITLE
refactor: decouple pipeline API and worker task wiring

### DIFF
--- a/apps/pipeline/app/api/backfill.py
+++ b/apps/pipeline/app/api/backfill.py
@@ -4,6 +4,8 @@ from threading import Lock, Thread
 
 from fastapi import APIRouter
 
+from app.services.pipeline_commands import run_chunk_backfill
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["backfill"])
@@ -28,9 +30,7 @@ async def backfill_chunks_endpoint(embed: bool = True) -> dict:
     def _run() -> None:
         global _running
         try:
-            from app.tasks.backfill_chunks import backfill_chunks
-
-            backfill_chunks(embed=embed)
+            run_chunk_backfill(embed=embed)
         except Exception:
             logger.exception('"action": "backfill_chunks_api_error"')
         finally:

--- a/apps/pipeline/app/api/episodes.py
+++ b/apps/pipeline/app/api/episodes.py
@@ -19,8 +19,8 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.database import get_db
 from app.models import Episode
-from app.tasks.ingest import ingest_episode
 from app import job_queue
+from app.services.pipeline_commands import enqueue_episode_ingest
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -50,7 +50,7 @@ def ingest_manual(body: IngestEpisodeRequest, db: Session = Depends(get_db)) -> 
     db.commit()
     db.refresh(episode)
 
-    ingest_episode(episode.id)
+    enqueue_episode_ingest(db, str(episode.id))
     logger.info('"action": "manual_ingest", "episode_id": "%s"', episode.id)
     return {"episode_id": episode.id}
 

--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models import Episode, Job
-from app.tasks.ingest import ingest_episode
+from app.services.pipeline_commands import enqueue_episode_ingest
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -57,7 +57,7 @@ def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
     episode.has_diarization = False
     db.commit()
 
-    ingest_episode(episode.id)
+    enqueue_episode_ingest(db, str(episode.id))
 
     logger.info('"action": "manual_retry", "episode_id": "%s"', episode.id)
     return {"queued": True, "episode_id": episode.id}

--- a/apps/pipeline/app/services/pipeline_commands.py
+++ b/apps/pipeline/app/services/pipeline_commands.py
@@ -1,0 +1,21 @@
+"""Command-style entrypoints for queueing/running pipeline actions.
+
+This module provides a thin boundary between transport handlers (API routes)
+and task internals, reducing API coupling to task module details.
+"""
+
+from sqlalchemy.orm import Session
+
+from app import job_queue
+
+
+def enqueue_episode_ingest(db: Session, episode_id: str) -> None:
+    """Queue an episode for full pipeline ingestion (starts at download)."""
+    job_queue.enqueue(db, episode_id, "download")
+
+
+def run_chunk_backfill(embed: bool = True) -> dict:
+    """Execute chunk backfill once; intended for background thread invocation."""
+    from app.tasks.backfill_chunks import backfill_chunks
+
+    return backfill_chunks(embed=embed)

--- a/apps/pipeline/app/worker.py
+++ b/apps/pipeline/app/worker.py
@@ -10,6 +10,7 @@ Usage:
 import logging
 import signal
 import time
+import importlib
 from datetime import datetime, timezone
 from typing import Callable
 
@@ -18,6 +19,13 @@ from app.database import SessionLocal
 from app import job_queue
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_handler(dotted_path: str):
+    """Resolve 'module.path:function_name' to a callable."""
+    module_path, func_name = dotted_path.rsplit(":", 1)
+    mod = importlib.import_module(module_path)
+    return getattr(mod, func_name)
 
 def _download_handler(episode_id: str) -> None:
     from app.tasks.download import download_episode
@@ -72,7 +80,19 @@ TASK_HANDLERS: dict[str, Callable[[str], None]] = {
     "archive": _archive_handler,
 }
 
+TASK_HANDLER_TARGETS: dict[str, str] = {
+    "download": "app.tasks.download:download_episode",
+    "transcribe": "app.tasks.transcribe:transcribe_episode",
+    "diarize": "app.tasks.diarize:diarize_episode",
+    "chunk": "app.tasks.chunk:chunk_episode",
+    "embed": "app.tasks.embed:embed_episode",
+    "infer": "app.tasks.infer:infer_speakers",
+    "archive": "app.tasks.archive:archive_episode",
+}
+
 POLL_INTERVAL = 2  # seconds between queue polls when idle
+
+
 def _poll_all_feeds() -> None:
     from app.tasks.ingest import poll_all_feeds
 
@@ -98,6 +118,12 @@ PERIODIC_TASKS: list[tuple[str, Callable[[], None], int | None]] = [
     ("send_digest", _send_digest, 15 * 60),
 ]
 
+PERIODIC_TASK_TARGETS: dict[str, str] = {
+    "poll_all_feeds": "app.tasks.ingest:poll_all_feeds",
+    "cleanup_zombie_jobs": "app.tasks.cleanup:cleanup_zombie_jobs",
+    "send_digest": "app.services.digest:send_digest_if_due",
+}
+
 _shutdown = False
 
 
@@ -111,19 +137,34 @@ def _validate_worker_wiring() -> None:
     """Validate task/periodic handler references at startup."""
     errors: list[str] = []
 
+    if set(TASK_HANDLERS) != set(TASK_HANDLER_TARGETS):
+        errors.append("TASK_HANDLERS and TASK_HANDLER_TARGETS keys differ")
+
     for task, handler in TASK_HANDLERS.items():
         try:
             if not callable(handler):
                 raise TypeError("resolved object is not callable")
+            target = TASK_HANDLER_TARGETS[task]
+            resolved = _resolve_handler(target)
+            if not callable(resolved):
+                raise TypeError("import target is not callable")
         except Exception as exc:
             errors.append(
                 f'TASK_HANDLERS["{task}"]: {type(exc).__name__}: {exc}'
             )
 
+    periodic_names = {name for name, _, _ in PERIODIC_TASKS}
+    if periodic_names != set(PERIODIC_TASK_TARGETS):
+        errors.append("PERIODIC_TASKS and PERIODIC_TASK_TARGETS keys differ")
+
     for name, handler, _ in PERIODIC_TASKS:
         try:
             if not callable(handler):
                 raise TypeError("resolved object is not callable")
+            target = PERIODIC_TASK_TARGETS[name]
+            resolved = _resolve_handler(target)
+            if not callable(resolved):
+                raise TypeError("import target is not callable")
         except Exception as exc:
             errors.append(
                 f'PERIODIC_TASKS["{name}"]: {type(exc).__name__}: {exc}'

--- a/apps/pipeline/app/worker.py
+++ b/apps/pipeline/app/worker.py
@@ -11,6 +11,7 @@ import logging
 import signal
 import time
 from datetime import datetime, timezone
+from typing import Callable
 
 from app.config import settings
 from app.database import SessionLocal
@@ -18,23 +19,83 @@ from app import job_queue
 
 logger = logging.getLogger(__name__)
 
-# Task name -> handler function (lazily resolved to avoid circular imports)
-TASK_HANDLERS: dict[str, str] = {
-    "download": "app.tasks.download:download_episode",
-    "transcribe": "app.tasks.transcribe:transcribe_episode",
-    "diarize": "app.tasks.diarize:diarize_episode",
-    "chunk": "app.tasks.chunk:chunk_episode",
-    "embed": "app.tasks.embed:embed_episode",
-    "infer": "app.tasks.infer:infer_speakers",
-    "archive": "app.tasks.archive:archive_episode",
+def _download_handler(episode_id: str) -> None:
+    from app.tasks.download import download_episode
+
+    download_episode(episode_id)
+
+
+def _transcribe_handler(episode_id: str) -> None:
+    from app.tasks.transcribe import transcribe_episode
+
+    transcribe_episode(episode_id)
+
+
+def _diarize_handler(episode_id: str) -> None:
+    from app.tasks.diarize import diarize_episode
+
+    diarize_episode(episode_id)
+
+
+def _chunk_handler(episode_id: str) -> None:
+    from app.tasks.chunk import chunk_episode
+
+    chunk_episode(episode_id)
+
+
+def _embed_handler(episode_id: str) -> None:
+    from app.tasks.embed import embed_episode
+
+    embed_episode(episode_id)
+
+
+def _infer_handler(episode_id: str) -> None:
+    from app.tasks.infer import infer_speakers
+
+    infer_speakers(episode_id)
+
+
+def _archive_handler(episode_id: str) -> None:
+    from app.tasks.archive import archive_episode
+
+    archive_episode(episode_id)
+
+
+# Task name -> handler function (typed callable registry; lazy imports inside wrappers)
+TASK_HANDLERS: dict[str, Callable[[str], None]] = {
+    "download": _download_handler,
+    "transcribe": _transcribe_handler,
+    "diarize": _diarize_handler,
+    "chunk": _chunk_handler,
+    "embed": _embed_handler,
+    "infer": _infer_handler,
+    "archive": _archive_handler,
 }
 
 POLL_INTERVAL = 2  # seconds between queue polls when idle
-PERIODIC_TASKS = [
-    # (name, function_path, interval_seconds)
-    ("poll_all_feeds", "app.tasks.ingest:poll_all_feeds", None),  # interval set from settings
-    ("cleanup_zombie_jobs", "app.tasks.cleanup:cleanup_zombie_jobs", 30 * 60),
-    ("send_digest", "app.services.digest:send_digest_if_due", 15 * 60),
+def _poll_all_feeds() -> None:
+    from app.tasks.ingest import poll_all_feeds
+
+    poll_all_feeds()
+
+
+def _cleanup_zombie_jobs() -> None:
+    from app.tasks.cleanup import cleanup_zombie_jobs
+
+    cleanup_zombie_jobs()
+
+
+def _send_digest() -> None:
+    from app.services.digest import send_digest_if_due
+
+    send_digest_if_due()
+
+
+PERIODIC_TASKS: list[tuple[str, Callable[[], None], int | None]] = [
+    # (name, function, interval_seconds)
+    ("poll_all_feeds", _poll_all_feeds, None),  # interval set from settings
+    ("cleanup_zombie_jobs", _cleanup_zombie_jobs, 30 * 60),
+    ("send_digest", _send_digest, 15 * 60),
 ]
 
 _shutdown = False
@@ -46,36 +107,26 @@ def _handle_signal(signum, frame):
     _shutdown = True
 
 
-def _resolve_handler(dotted_path: str):
-    """Resolve 'module.path:function_name' to a callable."""
-    module_path, func_name = dotted_path.rsplit(":", 1)
-    import importlib
-    mod = importlib.import_module(module_path)
-    return getattr(mod, func_name)
-
-
 def _validate_worker_wiring() -> None:
     """Validate task/periodic handler references at startup."""
     errors: list[str] = []
 
-    for task, handler_path in TASK_HANDLERS.items():
+    for task, handler in TASK_HANDLERS.items():
         try:
-            handler = _resolve_handler(handler_path)
             if not callable(handler):
                 raise TypeError("resolved object is not callable")
         except Exception as exc:
             errors.append(
-                f'TASK_HANDLERS["{task}"] -> "{handler_path}": {type(exc).__name__}: {exc}'
+                f'TASK_HANDLERS["{task}"]: {type(exc).__name__}: {exc}'
             )
 
-    for name, handler_path, _ in PERIODIC_TASKS:
+    for name, handler, _ in PERIODIC_TASKS:
         try:
-            handler = _resolve_handler(handler_path)
             if not callable(handler):
                 raise TypeError("resolved object is not callable")
         except Exception as exc:
             errors.append(
-                f'PERIODIC_TASKS["{name}"] -> "{handler_path}": {type(exc).__name__}: {exc}'
+                f'PERIODIC_TASKS["{name}"]: {type(exc).__name__}: {exc}'
             )
 
     if errors:
@@ -85,14 +136,13 @@ def _validate_worker_wiring() -> None:
 
 def _run_periodic_tasks(last_run: dict[str, datetime], now: datetime) -> None:
     """Run any periodic tasks that are due."""
-    for name, func_path, interval_secs in PERIODIC_TASKS:
+    for name, handler, interval_secs in PERIODIC_TASKS:
         if interval_secs is None:
             interval_secs = settings.feed_poll_interval_hours * 3600
 
         last = last_run.get(name)
         if last is None or (now - last).total_seconds() >= interval_secs:
             try:
-                handler = _resolve_handler(func_path)
                 handler()
                 last_run[name] = now
                 logger.info('"action": "periodic_task_ran", "task": "%s"', name)
@@ -140,13 +190,12 @@ def main() -> None:
                 job.id, job.task, job.episode_id,
             )
 
-            handler_path = TASK_HANDLERS.get(job.task)
-            if handler_path is None:
+            handler = TASK_HANDLERS.get(job.task)
+            if handler is None:
                 job_queue.fail(db, job, f"Unknown task: {job.task}")
                 continue
 
             try:
-                handler = _resolve_handler(handler_path)
                 handler(job.episode_id)
                 job_queue.complete(db, job)
             except Exception as exc:

--- a/apps/pipeline/tests/unit/test_episodes_api.py
+++ b/apps/pipeline/tests/unit/test_episodes_api.py
@@ -36,7 +36,7 @@ class TestIngestEndpoint:
         mock_db.refresh.side_effect = refresh_side_effect
         _override_db(mock_db)
         try:
-            with patch("app.api.episodes.ingest_episode") as mock_ingest:
+            with patch("app.api.episodes.enqueue_episode_ingest") as mock_ingest:
                 resp = client.post("/api/episodes/ingest", json={
                     "audio_url": "https://example.com/episode.mp3",
                     "title": "Test Episode",
@@ -47,7 +47,7 @@ class TestIngestEndpoint:
                 assert data["episode_id"] == "ep-123"
                 mock_db.add.assert_called_once()
                 mock_db.commit.assert_called_once()
-                mock_ingest.assert_called_once_with("ep-123")
+                mock_ingest.assert_called_once_with(mock_db, "ep-123")
         finally:
             _cleanup_db()
 
@@ -77,7 +77,7 @@ class TestIngestEndpoint:
         mock_db.refresh.side_effect = refresh_side_effect
         _override_db(mock_db)
         try:
-            with patch("app.api.episodes.ingest_episode"):
+            with patch("app.api.episodes.enqueue_episode_ingest"):
                 resp = client.post("/api/episodes/ingest", json={
                     "audio_url": "https://example.com/ep.mp3",
                 })

--- a/apps/pipeline/tests/unit/test_queue_api.py
+++ b/apps/pipeline/tests/unit/test_queue_api.py
@@ -51,7 +51,7 @@ class TestRetryJob:
 
         db.query.side_effect = query_side_effect
         try:
-            with patch("app.api.queue.ingest_episode"):
+            with patch("app.api.queue.enqueue_episode_ingest"):
                 return retry_job("ep-1", db=db)
         except HTTPException as exc:
             return exc

--- a/apps/pipeline/tests/unit/test_worker.py
+++ b/apps/pipeline/tests/unit/test_worker.py
@@ -1,25 +1,9 @@
 """Unit tests for app.worker — DB-backed job worker."""
 import signal
-from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch, call
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
-
-
-class TestResolveHandler:
-    def test_resolves_known_module(self):
-        from app.worker import _resolve_handler
-
-        handler = _resolve_handler("app.tasks.chunk:chunk_episode")
-        from app.tasks.chunk import chunk_episode
-
-        assert handler is chunk_episode
-
-    def test_raises_on_bad_path(self):
-        from app.worker import _resolve_handler
-
-        with pytest.raises(ModuleNotFoundError):
-            _resolve_handler("nonexistent.module:func")
 
 
 class TestHandleSignal:
@@ -32,92 +16,72 @@ class TestHandleSignal:
         w._shutdown = False  # reset
 
 
+class TestWorkerRegistry:
+    def test_worker_registries_are_callable(self):
+        import app.worker as w
+
+        for name, handler in w.TASK_HANDLERS.items():
+            assert callable(handler), f"task handler for {name} is not callable"
+
+        for name, handler, _ in w.PERIODIC_TASKS:
+            assert callable(handler), f"periodic handler for {name} is not callable"
+
+    def test_validate_worker_wiring_raises_for_non_callable_task(self):
+        import app.worker as w
+
+        with patch.dict(w.TASK_HANDLERS, {"chunk": object()}):
+            with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
+                w._validate_worker_wiring()
+
+    def test_validate_worker_wiring_raises_for_non_callable_periodic(self):
+        import app.worker as w
+
+        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", object(), None)]):
+            with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
+                w._validate_worker_wiring()
+
+
 class TestRunPeriodicTasks:
-    @patch("app.worker._resolve_handler")
     @patch("app.worker.settings")
-    def test_runs_task_when_due(self, mock_settings, mock_resolve):
+    def test_runs_task_when_due(self, mock_settings):
+        import app.worker as w
+
         mock_settings.feed_poll_interval_hours = 1
         mock_handler = MagicMock()
-        mock_resolve.return_value = mock_handler
+        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", mock_handler, None)]):
+            last_run = {}
+            now = datetime.now(timezone.utc)
+            w._run_periodic_tasks(last_run, now)
 
-        from app.worker import _run_periodic_tasks
+        mock_handler.assert_called_once()
+        assert "poll_all_feeds" in last_run
 
-        last_run = {}
-        now = datetime.now(timezone.utc)
-        _run_periodic_tasks(last_run, now)
-
-        assert mock_handler.call_count >= 1
-        assert len(last_run) > 0
-
-
-class TestValidateWorkerWiring:
-    @patch("app.worker._resolve_handler")
-    def test_valid_wiring_passes(self, mock_resolve):
-        mock_resolve.return_value = MagicMock()
-
-        from app.worker import _validate_worker_wiring
-
-        _validate_worker_wiring()
-
-    @patch("app.worker._resolve_handler")
-    def test_invalid_task_handler_raises(self, mock_resolve):
-        def fake_resolve(path: str):
-            if path == "app.tasks.chunk:chunk_episode":
-                raise ModuleNotFoundError("broken")
-            return MagicMock()
-
-        mock_resolve.side_effect = fake_resolve
-
-        from app.worker import _validate_worker_wiring
-
-        with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
-            _validate_worker_wiring()
-
-    @patch("app.worker._resolve_handler")
-    def test_non_callable_handler_raises(self, mock_resolve):
-        def fake_resolve(path: str):
-            if path == "app.tasks.chunk:chunk_episode":
-                return object()
-            return MagicMock()
-
-        mock_resolve.side_effect = fake_resolve
-
-        from app.worker import _validate_worker_wiring
-
-        with pytest.raises(RuntimeError, match="not callable"):
-            _validate_worker_wiring()
-
-    @patch("app.worker._resolve_handler")
     @patch("app.worker.settings")
-    def test_skips_task_when_not_due(self, mock_settings, mock_resolve):
+    def test_skips_task_when_not_due(self, mock_settings):
+        import app.worker as w
+
         mock_settings.feed_poll_interval_hours = 1
         mock_handler = MagicMock()
-        mock_resolve.return_value = mock_handler
-
-        from app.worker import _run_periodic_tasks, PERIODIC_TASKS
-
-        now = datetime.now(timezone.utc)
-        last_run = {name: now for name, _, _ in PERIODIC_TASKS}
-
-        mock_handler.reset_mock()
-        _run_periodic_tasks(last_run, now)
+        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", mock_handler, None)]):
+            now = datetime.now(timezone.utc)
+            last_run = {"poll_all_feeds": now - timedelta(minutes=30)}
+            w._run_periodic_tasks(last_run, now)
 
         mock_handler.assert_not_called()
 
-    @patch("app.worker._resolve_handler")
     @patch("app.worker.settings")
-    def test_failure_still_updates_last_run(self, mock_settings, mock_resolve):
+    def test_failure_still_updates_last_run(self, mock_settings):
+        import app.worker as w
+
         mock_settings.feed_poll_interval_hours = 1
-        mock_resolve.return_value = MagicMock(side_effect=RuntimeError("boom"))
-
-        from app.worker import _run_periodic_tasks
-
-        last_run = {}
-        now = datetime.now(timezone.utc)
-        _run_periodic_tasks(last_run, now)
+        crashing_handler = MagicMock(side_effect=RuntimeError("boom"))
+        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", crashing_handler, None)]):
+            last_run = {}
+            now = datetime.now(timezone.utc)
+            w._run_periodic_tasks(last_run, now)
 
         # Should still mark as run to avoid immediate retry
-        assert len(last_run) > 0
+        assert "poll_all_feeds" in last_run
 
 
 class TestMainLoop:
@@ -156,11 +120,18 @@ class TestMainLoop:
     @patch("app.worker.signal")
     @patch("app.services.events.bus")
     @patch("app.services.digest.register_notification_handlers")
-    def test_processes_job_and_stops(self, mock_register, mock_bus, mock_signal,
-                                     mock_session_cls, mock_jq, mock_periodic, mock_time):
+    def test_processes_job_and_stops(
+        self,
+        mock_register,
+        mock_bus,
+        mock_signal,
+        mock_session_cls,
+        mock_jq,
+        mock_periodic,
+        mock_time,
+    ):
         import app.worker as w
 
-        # Set up: one job found, then shutdown
         job = MagicMock()
         job.id = 1
         job.task = "chunk"
@@ -170,28 +141,18 @@ class TestMainLoop:
         mock_session_cls.return_value = db
         mock_jq.poll.return_value = job
 
-        # Stop after first iteration
-        call_count = 0
-        original_shutdown = w._shutdown
-
         def stop_after_one(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 1:
-                w._shutdown = True
+            w._shutdown = True
 
         mock_jq.complete.side_effect = stop_after_one
+        mock_handler = MagicMock()
 
-        with patch("app.worker._resolve_handler") as mock_resolve:
-            mock_handler = MagicMock()
-            mock_resolve.return_value = mock_handler
-
+        with patch.dict(w.TASK_HANDLERS, {"chunk": mock_handler}, clear=False):
             w._shutdown = False
             w.main()
 
         mock_handler.assert_called_once_with("ep1")
         mock_jq.complete.assert_called_once_with(db, job)
-        w._shutdown = original_shutdown
 
     @patch("app.worker.time")
     @patch("app.worker._run_periodic_tasks")
@@ -200,8 +161,16 @@ class TestMainLoop:
     @patch("app.worker.signal")
     @patch("app.services.events.bus")
     @patch("app.services.digest.register_notification_handlers")
-    def test_unknown_task_fails_job(self, mock_register, mock_bus, mock_signal,
-                                    mock_session_cls, mock_jq, mock_periodic, mock_time):
+    def test_unknown_task_fails_job(
+        self,
+        mock_register,
+        mock_bus,
+        mock_signal,
+        mock_session_cls,
+        mock_jq,
+        mock_periodic,
+        mock_time,
+    ):
         import app.worker as w
 
         job = MagicMock()
@@ -231,8 +200,16 @@ class TestMainLoop:
     @patch("app.worker.signal")
     @patch("app.services.events.bus")
     @patch("app.services.digest.register_notification_handlers")
-    def test_handler_exception_fails_job(self, mock_register, mock_bus, mock_signal,
-                                          mock_session_cls, mock_jq, mock_periodic, mock_time):
+    def test_handler_exception_fails_job(
+        self,
+        mock_register,
+        mock_bus,
+        mock_signal,
+        mock_session_cls,
+        mock_jq,
+        mock_periodic,
+        mock_time,
+    ):
         import app.worker as w
 
         job = MagicMock()
@@ -248,10 +225,9 @@ class TestMainLoop:
             w._shutdown = True
 
         mock_jq.fail.side_effect = stop
+        crashing_handler = MagicMock(side_effect=RuntimeError("task crash"))
 
-        with patch("app.worker._resolve_handler") as mock_resolve:
-            mock_resolve.return_value = MagicMock(side_effect=RuntimeError("task crash"))
-
+        with patch.dict(w.TASK_HANDLERS, {"chunk": crashing_handler}, clear=False):
             w._shutdown = False
             w.main()
 
@@ -264,8 +240,16 @@ class TestMainLoop:
     @patch("app.worker.signal")
     @patch("app.services.events.bus")
     @patch("app.services.digest.register_notification_handlers")
-    def test_no_job_sleeps(self, mock_register, mock_bus, mock_signal,
-                            mock_session_cls, mock_jq, mock_periodic, mock_time):
+    def test_no_job_sleeps(
+        self,
+        mock_register,
+        mock_bus,
+        mock_signal,
+        mock_session_cls,
+        mock_jq,
+        mock_periodic,
+        mock_time,
+    ):
         import app.worker as w
 
         db = MagicMock()

--- a/apps/pipeline/tests/unit/test_worker.py
+++ b/apps/pipeline/tests/unit/test_worker.py
@@ -17,6 +17,18 @@ class TestHandleSignal:
 
 
 class TestWorkerRegistry:
+    def test_resolves_known_module(self):
+        import app.worker as w
+        from app.tasks.chunk import chunk_episode
+
+        assert w._resolve_handler("app.tasks.chunk:chunk_episode") is chunk_episode
+
+    def test_raises_on_bad_path(self):
+        import app.worker as w
+
+        with pytest.raises(ModuleNotFoundError):
+            w._resolve_handler("nonexistent.module:func")
+
     def test_worker_registries_are_callable(self):
         import app.worker as w
 
@@ -39,6 +51,20 @@ class TestWorkerRegistry:
         with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", object(), None)]):
             with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
                 w._validate_worker_wiring()
+
+    @patch("app.worker._resolve_handler")
+    def test_validate_worker_wiring_raises_for_broken_import_target(self, mock_resolve):
+        import app.worker as w
+
+        def side_effect(path: str):
+            if path == "app.tasks.chunk:chunk_episode":
+                raise ModuleNotFoundError("broken import")
+            return MagicMock()
+
+        mock_resolve.side_effect = side_effect
+
+        with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
+            w._validate_worker_wiring()
 
 
 class TestRunPeriodicTasks:


### PR DESCRIPTION
## Summary
- replace string-based worker registry entries with typed callable handlers (lazy imports kept via wrapper functions)
- add a thin `pipeline_commands` service boundary for API-triggered pipeline actions
- route API endpoints through the command layer instead of importing task functions directly
- update worker/API unit tests to validate callable wiring and command usage

## Changes
- `app/worker.py`
  - remove dotted-path runtime resolution from normal execution path
  - keep `TASK_HANDLERS` and `PERIODIC_TASKS` as callable registries
  - keep startup validation but validate callables directly
- `app/services/pipeline_commands.py` (new)
  - `enqueue_episode_ingest(db, episode_id)`
  - `run_chunk_backfill(embed=True)`
- `app/api/episodes.py`
  - `/episodes/ingest` now calls `enqueue_episode_ingest(...)`
- `app/api/queue.py`
  - `/queue/{episode_id}/retry` now calls `enqueue_episode_ingest(...)`
- `app/api/backfill.py`
  - background runner now calls `run_chunk_backfill(...)`

## Verification
- `cd apps/pipeline && python3 -m pytest tests/unit/test_worker.py tests/unit/test_episodes_api.py tests/unit/test_queue_api.py tests/unit/test_api_backfill.py -q`
  - Result: `35 passed`

Closes #325