### PR TITLE
fix: selective episodes dialog overflow and speaker-click re-scroll

### DIFF
--- a/apps/web/src/app/feeds/page.tsx
+++ b/apps/web/src/app/feeds/page.tsx
@@ -201,7 +201,7 @@ export default function FeedsPage() {
               Add Feed
             </Button>
           </DialogTrigger>
-          <DialogContent className={previewStep ? "max-w-2xl" : undefined}>
+          <DialogContent className={previewStep ? "max-w-2xl flex flex-col max-h-[90vh]" : undefined}>
             <DialogHeader>
               <DialogTitle>
                 {previewStep
@@ -278,8 +278,8 @@ export default function FeedsPage() {
 
             {/* Step 2: Episode selection (selective mode only) */}
             {previewStep && preview && (
-              <form onSubmit={handleAddOrPreview} className="space-y-3">
-                <div className="flex items-center justify-between">
+              <form onSubmit={handleAddOrPreview} className="flex flex-col flex-1 overflow-hidden space-y-3 min-h-0">
+                <div className="flex items-center justify-between shrink-0">
                   <span className="text-sm text-muted-foreground">
                     {preview.episodes.length} episodes found
                   </span>
@@ -291,7 +291,7 @@ export default function FeedsPage() {
                     {selectedGuids.size === preview.episodes.length ? "Deselect all" : "Select all"}
                   </button>
                 </div>
-                <div className="max-h-72 overflow-y-auto overflow-x-hidden divide-y rounded-md border">
+                <div className="flex-1 overflow-y-auto overflow-x-hidden divide-y rounded-md border min-h-[80px]">
                   {preview.episodes.map((ep) => (
                     <label
                       key={ep.guid}
@@ -316,8 +316,8 @@ export default function FeedsPage() {
                     </label>
                   ))}
                 </div>
-                {addError && <p className="text-sm text-destructive">{addError}</p>}
-                <div className="flex justify-end gap-2">
+                {addError && <p className="text-sm text-destructive shrink-0">{addError}</p>}
+                <div className="flex justify-end gap-2 shrink-0">
                   <Button
                     type="button"
                     variant="outline"

--- a/apps/web/src/components/TranscriptView.tsx
+++ b/apps/web/src/components/TranscriptView.tsx
@@ -34,6 +34,7 @@ export default function TranscriptView({
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const { playEpisode } = useAudioPlayer();
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasScrolledToHashRef = useRef(false);
 
   /**
    * Find the segment element closest to a given time (in seconds) and
@@ -68,14 +69,17 @@ export default function TranscriptView({
     [segments],
   );
 
-  // Handle initial hash navigation (from search results or direct links)
+  // Handle initial hash navigation (from search results or direct links).
+  // Guard with a ref so speaker-filter re-renders don't re-trigger the scroll.
   useEffect(() => {
+    if (hasScrolledToHashRef.current) return;
     const hash = window.location.hash;
     if (hash.startsWith("#t-")) {
       const targetSecs = parseInt(hash.slice(3), 10);
       if (!isNaN(targetSecs)) {
         // Small delay to ensure DOM is rendered
         requestAnimationFrame(() => scrollToTime(targetSecs));
+        hasScrolledToHashRef.current = true;
       }
     }
   }, [segments, scrollToTime]);


### PR DESCRIPTION
## Summary

- Fixes the \"Add\" button being hidden when the selective episodes dialog overflows the viewport (#344)
- Fixes clicking a speaker card re-triggering scroll-to-timestamp when the URL has a hash (#345)

## Changes

**Issue #344 — Dialog overflow (`feeds/page.tsx`)**
- Added `max-h-[90vh] flex flex-col` to `DialogContent` in preview mode
- Converted the episode-selection form to a flex column with `flex-1 overflow-hidden`
- Episode list uses `flex-1 overflow-y-auto` so it takes remaining space and scrolls internally
- Error message and Back/Add buttons are `shrink-0` — always visible at the bottom

**Issue #345 — Speaker filter re-triggers hash scroll (`TranscriptView.tsx`)**
- Added `hasScrolledToHashRef` (`useRef(false)`) to guard the initial hash-scroll effect
- The effect that reads `window.location.hash` now sets the ref on first execution and skips on all subsequent re-runs
- Clicking a speaker to filter no longer scrolls the page back to the linked timestamp

## Testing

- All 159 web unit tests pass
- Manually verified: dialog with many episodes shows Back/Add buttons without scrolling the outer page
- Manually verified: speaker filter click no longer re-triggers hash scroll

Closes #344
Closes #345