### PR TITLE
feat: add per-step diarization timing breakdowns (issue #347)

### DIFF
--- a/apps/pipeline/alembic/versions/011_add_diarize_step_durations_column.py
+++ b/apps/pipeline/alembic/versions/011_add_diarize_step_durations_column.py
@@ -1,0 +1,25 @@
+"""Add diarize_step_durations JSONB column to episodes.
+
+Stores per-step timing breakdown for diarization flow observability.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "episodes",
+        sa.Column("diarize_step_durations", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("episodes", "diarize_step_durations")

--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -55,6 +55,9 @@ def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
     episode.retry_count = 0
     episode.diarization_error = None
     episode.has_diarization = False
+    episode.transcribe_duration_secs = None
+    episode.diarize_duration_secs = None
+    episode.diarize_step_durations = None
     db.commit()
 
     enqueue_episode_ingest(db, str(episode.id))

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from pgvector.sqlalchemy import Vector
@@ -98,6 +99,7 @@ class Episode(Base):
     # Processing duration (seconds)
     transcribe_duration_secs: Mapped[float | None] = mapped_column(Float)
     diarize_duration_secs: Mapped[float | None] = mapped_column(Float)
+    diarize_step_durations: Mapped[dict[str, float] | None] = mapped_column(JSONB)
 
     # Remote inference observability (Issue #261)
     inference_provider_used: Mapped[str | None] = mapped_column(Text)

--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -73,6 +73,7 @@ class DigestItem:
     error_class: str | None  # failure events
     retry_count: int | None
     retry_max: int | None
+    diarize_step_durations: dict[str, float] | None = None
 
 
 @dataclass
@@ -89,6 +90,21 @@ class DigestData:
     processing_factor: float | None = None
 
 
+def _humanize_step_key(key: str) -> str:
+    words = key.replace("_secs", "").replace("_", " ").strip()
+    return words[:1].upper() + words[1:] if words else key
+
+
+def _fmt_diarization_steps(step_durations: dict[str, float] | None) -> str:
+    if not step_durations:
+        return ""
+    parts = [
+        f"{_humanize_step_key(name)} {_fmt_short_duration(secs)}"
+        for name, secs in step_durations.items()
+    ]
+    return f"Diarization steps: {'; '.join(parts)}"
+
+
 def format_digest_html(data: DigestData) -> str:
     freq_label = "Daily" if data.frequency == "daily" else "Weekly"
     done_count = sum(1 for i in data.items if i.event_type == "episode.done")
@@ -100,6 +116,9 @@ def format_digest_html(data: DigestData) -> str:
         if item.event_type == "episode.done":
             icon = "&#9989;"
             detail = f"processed in {_fmt_short_duration(item.total_duration_secs)}"
+            step_detail = _fmt_diarization_steps(item.diarize_step_durations)
+            if step_detail:
+                detail = f"{detail}. {step_detail}"
         else:
             detail = f"{item.error_class} after {item.retry_count}/{item.retry_max} retries"
             icon = "&#10060;"
@@ -179,6 +198,9 @@ def format_digest_telegram(data: DigestData) -> str:
         duration = _fmt_duration(item.duration_secs)
         if item.event_type == "episode.done":
             detail = f"processed in {_fmt_short_duration(item.total_duration_secs)}"
+            step_detail = _fmt_diarization_steps(item.diarize_step_durations)
+            if step_detail:
+                detail = f"{detail}. {step_detail}"
             lines.append(f"✅ \"{item.episode_title}\" ({item.podcast_title}) — {duration}, {detail}")
         else:
             lines.append(
@@ -302,6 +324,7 @@ def send_digest_if_due(now: datetime | None = None) -> None:
                 podcast_title=payload.get("podcast_title", ""),
                 duration_secs=payload.get("duration_secs"),
                 total_duration_secs=payload.get("total_duration_secs"),
+                diarize_step_durations=payload.get("diarize_step_durations"),
                 error_class=payload.get("error_class"),
                 retry_count=payload.get("retry_count"),
                 retry_max=payload.get("retry_max"),

--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -23,6 +23,7 @@ from app.services.notifications import (
     send_email,
     send_telegram,
 )
+from app.services.timing_labels import humanize_timing_key
 
 logger = logging.getLogger(__name__)
 
@@ -90,16 +91,11 @@ class DigestData:
     processing_factor: float | None = None
 
 
-def _humanize_step_key(key: str) -> str:
-    words = key.replace("_secs", "").replace("_", " ").strip()
-    return words[:1].upper() + words[1:] if words else key
-
-
 def _fmt_diarization_steps(step_durations: dict[str, float] | None) -> str:
     if not step_durations:
         return ""
     parts = [
-        f"{_humanize_step_key(name)} {_fmt_short_duration(secs)}"
+        f"{humanize_timing_key(name)} {_fmt_short_duration(secs)}"
         for name, secs in step_durations.items()
     ]
     return f"Diarization steps: {'; '.join(parts)}"

--- a/apps/pipeline/app/services/notification_events.py
+++ b/apps/pipeline/app/services/notification_events.py
@@ -14,6 +14,7 @@ class EpisodeDoneEvent(Event):
     duration_secs: int | None = None
     transcribe_duration_secs: float | None = None
     diarize_duration_secs: float | None = None
+    diarize_step_durations: dict[str, float] | None = None
     total_duration_secs: float | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None

--- a/apps/pipeline/app/services/notification_runtime.py
+++ b/apps/pipeline/app/services/notification_runtime.py
@@ -122,6 +122,7 @@ def emit_episode_done_event(db: Session, episode: Episode) -> None:
             duration_secs=episode.duration_secs,
             transcribe_duration_secs=episode.transcribe_duration_secs,
             diarize_duration_secs=episode.diarize_duration_secs,
+            diarize_step_durations=episode.diarize_step_durations,
             total_duration_secs=total_secs,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -54,6 +54,39 @@ def _fmt_factor(factor: float | None) -> str:
     return f"{factor:.1f}x"
 
 
+def _humanize_step_key(key: str) -> str:
+    words = key.replace("_secs", "").replace("_", " ").strip()
+    return words[:1].upper() + words[1:] if words else key
+
+
+def _fmt_diarize_steps_html(step_durations: dict[str, float] | None) -> str:
+    if not step_durations:
+        return ""
+    rows = []
+    for idx, (name, secs) in enumerate(step_durations.items()):
+        row_bg = ' style="background: #f9f9f9;"' if idx % 2 else ""
+        rows.append(
+            f"""\
+    <tr{row_bg}><td style="padding: 4px 12px; color: #666;">{_humanize_step_key(name)}</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(secs)}</td></tr>"""
+        )
+    rows_html = "\n".join(rows)
+    return f"""\
+  <h3 style="margin-top: 20px; margin-bottom: 8px;">Diarization Step Breakdown</h3>
+  <table style="border-collapse: collapse; width: 100%;">
+{rows_html}
+  </table>"""
+
+
+def _fmt_diarize_steps_telegram(step_durations: dict[str, float] | None) -> str:
+    if not step_durations:
+        return ""
+    lines = "\n*Diarization Step Breakdown*\n"
+    for name, secs in step_durations.items():
+        lines += f"`{_humanize_step_key(name)}: {_fmt_short_duration(secs)}`\n"
+    return lines
+
+
 def _fmt_avg_section_html(event) -> str:
     """Render the HTML averages section if avg data is available."""
     if (event.avg_transcribe_secs is None and event.avg_diarize_secs is None
@@ -107,6 +140,7 @@ def _fmt_avg_section_telegram(event) -> str:
 
 def format_done_html(event: EpisodeDoneEvent) -> str:
     avg_html = _fmt_avg_section_html(event)
+    diarize_steps_html = _fmt_diarize_steps_html(event.diarize_step_durations)
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 520px; margin: 0 auto; padding: 16px;">
@@ -133,6 +167,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
     <tr><td style="padding: 4px 12px; color: #666;">Total</td>
         <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(event.total_duration_secs)}</td></tr>
   </table>
+{diarize_steps_html}
 {avg_html}
   <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
   <table style="border-collapse: collapse; width: 100%;">
@@ -150,6 +185,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
 
 def format_done_telegram(event: EpisodeDoneEvent) -> str:
     avg_section = _fmt_avg_section_telegram(event)
+    diarize_steps_section = _fmt_diarize_steps_telegram(event.diarize_step_durations)
     return (
         f"*✅ Episode Processed*\n\n"
         f"*Podcast:* {event.podcast_title}\n"
@@ -160,6 +196,7 @@ def format_done_telegram(event: EpisodeDoneEvent) -> str:
         f"`Transcription:  {_fmt_short_duration(event.transcribe_duration_secs)}`\n"
         f"`Diarization:    {_fmt_short_duration(event.diarize_duration_secs)}`\n"
         f"`Total:          {_fmt_short_duration(event.total_duration_secs)}`\n"
+        f"{diarize_steps_section}"
         f"{avg_section}\n"
         f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"
     )

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -13,6 +13,7 @@ from app.services.notification_runtime import (
     compute_avg_processing_stats,
     estimate_queue_status,
 )
+from app.services.timing_labels import humanize_timing_key
 
 logger = logging.getLogger(__name__)
 
@@ -54,11 +55,6 @@ def _fmt_factor(factor: float | None) -> str:
     return f"{factor:.1f}x"
 
 
-def _humanize_step_key(key: str) -> str:
-    words = key.replace("_secs", "").replace("_", " ").strip()
-    return words[:1].upper() + words[1:] if words else key
-
-
 def _fmt_diarize_steps_html(step_durations: dict[str, float] | None) -> str:
     if not step_durations:
         return ""
@@ -67,7 +63,7 @@ def _fmt_diarize_steps_html(step_durations: dict[str, float] | None) -> str:
         row_bg = ' style="background: #f9f9f9;"' if idx % 2 else ""
         rows.append(
             f"""\
-    <tr{row_bg}><td style="padding: 4px 12px; color: #666;">{_humanize_step_key(name)}</td>
+    <tr{row_bg}><td style="padding: 4px 12px; color: #666;">{humanize_timing_key(name)}</td>
         <td style="padding: 4px 12px;">{_fmt_short_duration(secs)}</td></tr>"""
         )
     rows_html = "\n".join(rows)
@@ -83,7 +79,7 @@ def _fmt_diarize_steps_telegram(step_durations: dict[str, float] | None) -> str:
         return ""
     lines = "\n*Diarization Step Breakdown*\n"
     for name, secs in step_durations.items():
-        lines += f"`{_humanize_step_key(name)}: {_fmt_short_duration(secs)}`\n"
+        lines += f"`{humanize_timing_key(name)}: {_fmt_short_duration(secs)}`\n"
     return lines
 
 

--- a/apps/pipeline/app/services/timing_labels.py
+++ b/apps/pipeline/app/services/timing_labels.py
@@ -1,0 +1,7 @@
+"""Shared label helpers for timing/diagnostic keys."""
+
+
+def humanize_timing_key(key: str) -> str:
+    """Convert machine timing keys to concise user-facing labels."""
+    words = key.replace("_secs", "").replace("_", " ").strip()
+    return words[:1].upper() + words[1:] if words else key

--- a/apps/pipeline/app/services/timing_labels.py
+++ b/apps/pipeline/app/services/timing_labels.py
@@ -1,7 +1,23 @@
 """Shared label helpers for timing/diagnostic keys."""
 
 
+_ABBREVIATIONS = {
+    "io": "I/O",
+    "api": "API",
+    "stt": "STT",
+    "url": "URL",
+}
+
+
 def humanize_timing_key(key: str) -> str:
     """Convert machine timing keys to concise user-facing labels."""
     words = key.replace("_secs", "").replace("_", " ").strip()
-    return words[:1].upper() + words[1:] if words else key
+    if not words:
+        return key
+
+    formatted_words = [
+        _ABBREVIATIONS.get(word.lower(), word.lower())
+        for word in words.split()
+    ]
+    label = " ".join(formatted_words)
+    return label[:1].upper() + label[1:]

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -24,6 +24,10 @@ from app import job_queue
 logger = logging.getLogger(__name__)
 
 
+def _elapsed_seconds(start: float) -> float:
+    return round(time.monotonic() - start, 1)
+
+
 def diarize_episode(episode_id: str) -> str:
     db = SessionLocal()
     alignment_path = Path(settings.transcript_dir) / f"{episode_id}.whisperx.json"
@@ -38,18 +42,26 @@ def diarize_episode(episode_id: str) -> str:
 
         if provider == "fireworks":
             # Fireworks mode uses remote diarization metadata and never loads pyannote locally.
+            step_durations: dict[str, float] = {}
             try:
                 t0 = time.monotonic()
                 if not bool(runtime.get("fireworks_stt_diarize", True)):
                     # Provider is remote and diarization is intentionally disabled.
-                    update_episode(db, episode_id, has_diarization=False, diarization_error=None)
+                    update_episode(
+                        db, episode_id,
+                        has_diarization=False,
+                        diarization_error=None,
+                        diarize_step_durations=None,
+                    )
                     job_queue.enqueue(db, episode_id, "chunk")
                     return episode_id
                 if not fireworks_path.exists():
                     raise RuntimeError("Missing Fireworks transcript artifact for diarization")
 
+                t_load = time.monotonic()
                 with open(fireworks_path) as f:
                     raw = json.load(f)
+                step_durations["artifact_load_secs"] = _elapsed_seconds(t_load)
 
                 from app.services.fireworks_audio import (
                     diarization_segments_from_transcription,
@@ -62,6 +74,7 @@ def diarize_episode(episode_id: str) -> str:
                 # provider. This gives per-sentence granularity and correct
                 # speaker labels without the segment-level majority-overlap
                 # approximation.
+                t_rebuild = time.monotonic()
                 rebuilt = rebuild_segments_from_words(raw)
                 if rebuilt:
                     db.query(Segment).filter(Segment.episode_id == episode_id).delete()
@@ -76,6 +89,7 @@ def diarize_episode(episode_id: str) -> str:
                             )
                         )
                     db.flush()
+                    step_durations["segment_rebuild_secs"] = _elapsed_seconds(t_rebuild)
                     logger.info(
                         '"action": "diarize_fireworks_wordlevel_complete", "episode_id": "%s", '
                         '"segments": %d, "speakers": %d',
@@ -85,9 +99,11 @@ def diarize_episode(episode_id: str) -> str:
                     )
                 else:
                     # Fallback: segment-level speaker assignment (no word data available).
+                    t_provider = time.monotonic()
                     diarization_segments = diarization_segments_from_transcription(raw)
+                    step_durations["provider_diarization_secs"] = _elapsed_seconds(t_provider)
                     if diarization_segments:
-                        _diarize_segment_level(db, episode_id, diarization_segments)
+                        step_durations.update(_diarize_segment_level(db, episode_id, diarization_segments))
                     else:
                         transcript_segments = (
                             db.query(Segment)
@@ -95,6 +111,7 @@ def diarize_episode(episode_id: str) -> str:
                             .order_by(Segment.start_time)
                             .all()
                         )
+                        t_assign = time.monotonic()
                         assignments = assign_segment_speakers_from_words(
                             transcript_segments=[
                                 {"id": s.id, "start": s.start_time, "end": s.end_time}
@@ -109,16 +126,21 @@ def diarize_episode(episode_id: str) -> str:
                                 {"speaker_label": speaker}
                             )
                         db.flush()
+                        step_durations["speaker_assignment_secs"] = _elapsed_seconds(t_assign)
                 diarize_secs = round(time.monotonic() - t0, 1)
                 update_episode(
                     db, episode_id,
-                    has_diarization=True, diarization_error=None, diarize_duration_secs=diarize_secs,
+                    has_diarization=True,
+                    diarization_error=None,
+                    diarize_duration_secs=diarize_secs,
+                    diarize_step_durations=step_durations,
                 )
             except Exception as exc:
                 update_episode(
                     db, episode_id,
                     has_diarization=False,
                     diarization_error=str(exc),
+                    diarize_step_durations=step_durations or None,
                 )
                 logger.warning(
                     '"action": "diarize_failed_graceful", "episode_id": "%s", "error": "%s"',
@@ -127,23 +149,31 @@ def diarize_episode(episode_id: str) -> str:
                 )
         else:
             audio_path = episode.audio_local_path
+            step_durations: dict[str, float] = {}
 
             try:
                 from app.services.pyannote import diarize
 
                 t0 = time.monotonic()
+                t_provider = time.monotonic()
                 diarization_segments = diarize(audio_path)
+                step_durations["provider_diarization_secs"] = _elapsed_seconds(t_provider)
 
                 # Try word-level alignment first (preferred)
                 if alignment_path.exists():
-                    _diarize_wordlevel(db, episode_id, alignment_path, diarization_segments)
+                    step_durations.update(
+                        _diarize_wordlevel(db, episode_id, alignment_path, diarization_segments)
+                    )
                 else:
-                    _diarize_segment_level(db, episode_id, diarization_segments)
+                    step_durations.update(_diarize_segment_level(db, episode_id, diarization_segments))
 
                 diarize_secs = round(time.monotonic() - t0, 1)
                 update_episode(
                     db, episode_id,
-                    has_diarization=True, diarization_error=None, diarize_duration_secs=diarize_secs,
+                    has_diarization=True,
+                    diarization_error=None,
+                    diarize_duration_secs=diarize_secs,
+                    diarize_step_durations=step_durations,
                 )
 
             except Exception as exc:
@@ -152,6 +182,7 @@ def diarize_episode(episode_id: str) -> str:
                     db, episode_id,
                     has_diarization=False,
                     diarization_error=str(exc),
+                    diarize_step_durations=step_durations or None,
                 )
                 logger.warning(
                     '"action": "diarize_failed_graceful", "episode_id": "%s", "error": "%s"',
@@ -182,12 +213,15 @@ def diarize_episode(episode_id: str) -> str:
 
 def _diarize_wordlevel(
     db, episode_id: str, alignment_path: Path, diarization_segments: list[dict]
-) -> None:
+) -> dict[str, float]:
     """Word-level speaker assignment: rebuild segments at speaker boundaries."""
     from app.services.alignment import assign_speakers_wordlevel
 
+    step_durations: dict[str, float] = {}
+    t_load = time.monotonic()
     with open(alignment_path) as f:
         aligned_result = json.load(f)
+    step_durations["alignment_io_secs"] = _elapsed_seconds(t_load)
 
     aligned_segments = aligned_result.get("segments", [])
 
@@ -199,10 +233,12 @@ def _diarize_wordlevel(
             '"reason": "alignment data has no word timestamps, falling back to segment-level"',
             episode_id,
         )
-        _diarize_segment_level(db, episode_id, diarization_segments)
-        return
+        step_durations.update(_diarize_segment_level(db, episode_id, diarization_segments))
+        return step_durations
 
+    t_assign = time.monotonic()
     rebuilt_segments = assign_speakers_wordlevel(aligned_segments, diarization_segments)
+    step_durations["speaker_assignment_secs"] = _elapsed_seconds(t_assign)
 
     if not rebuilt_segments:
         logger.warning(
@@ -210,8 +246,8 @@ def _diarize_wordlevel(
             '"reason": "word-level assignment produced 0 segments, falling back to segment-level"',
             episode_id,
         )
-        _diarize_segment_level(db, episode_id, diarization_segments)
-        return
+        step_durations.update(_diarize_segment_level(db, episode_id, diarization_segments))
+        return step_durations
 
     # Replace existing segments with rebuilt ones
     db.query(Segment).filter(Segment.episode_id == episode_id).delete()
@@ -234,11 +270,12 @@ def _diarize_wordlevel(
         len(rebuilt_segments),
         len({s["speaker"] for s in rebuilt_segments}),
     )
+    return step_durations
 
 
 def _diarize_segment_level(
     db, episode_id: str, diarization_segments: list[dict]
-) -> None:
+) -> dict[str, float]:
     """Fallback: segment-level majority overlap speaker assignment."""
     from app.services.alignment import assign_speakers
 
@@ -249,6 +286,7 @@ def _diarize_segment_level(
         .all()
     )
 
+    t_assign = time.monotonic()
     assignments = assign_speakers(
         transcript_segments=[
             {"id": s.id, "start": s.start_time, "end": s.end_time}
@@ -262,6 +300,7 @@ def _diarize_segment_level(
             {"speaker_label": speaker}
         )
     db.flush()
+    step_durations = {"speaker_assignment_secs": _elapsed_seconds(t_assign)}
 
     logger.info(
         '"action": "diarize_segment_level_complete", "episode_id": "%s", '
@@ -270,3 +309,4 @@ def _diarize_segment_level(
         len(assignments),
         len(set(assignments.values())),
     )
+    return step_durations

--- a/apps/pipeline/tests/unit/test_digest.py
+++ b/apps/pipeline/tests/unit/test_digest.py
@@ -269,3 +269,53 @@ def test_digest_telegram_shows_new_metrics_when_legacy_absent():
     assert "40m 00s" in md
     assert "Processing factor" in md
     assert "1.5x" in md
+
+@patch("app.services.digest.SessionLocal")
+@patch("app.services.digest._send_digest")
+@patch("app.services.digest.compute_avg_duration", return_value=None)
+@patch("app.services.digest.compute_avg_processing_stats", return_value=(None, None, None))
+@patch("app.services.digest.estimate_queue_status", return_value=(0, None, None))
+@patch("app.services.digest.get_notification_settings")
+def test_send_digest_maps_diarize_step_durations(
+    mock_get_ns,
+    mock_estimate,
+    mock_avg_stats,
+    mock_avg_dur,
+    mock_send_digest,
+    mock_session_cls,
+):
+    mock_get_ns.return_value = {
+        "notification_frequency": "daily",
+        "email_configured": False,
+        "telegram_configured": False,
+    }
+
+    db = MagicMock()
+    mock_session_cls.return_value = db
+
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    log_row = MagicMock()
+    log_row.event_type = "episode.done"
+    log_row.payload = json.dumps({
+        "episode_title": "Test Ep",
+        "podcast_title": "Pod",
+        "duration_secs": 3600,
+        "total_duration_secs": 200.0,
+        "diarize_step_durations": {
+            "provider_diarization_secs": 42.0,
+            "speaker_assignment_secs": 13.0,
+        },
+    })
+    log_row.sent = False
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [log_row]
+
+    now = datetime(2026, 3, 15, 8, 30, tzinfo=timezone.utc)
+    send_digest_if_due(now=now)
+
+    digest = mock_send_digest.call_args[0][0]
+    assert len(digest.items) == 1
+    assert digest.items[0].diarize_step_durations == {
+        "provider_diarization_secs": 42.0,
+        "speaker_assignment_secs": 13.0,
+    }

--- a/apps/pipeline/tests/unit/test_digest_formatting.py
+++ b/apps/pipeline/tests/unit/test_digest_formatting.py
@@ -16,6 +16,10 @@ def _make_digest_data() -> DigestData:
                 podcast_title="Tech Talk",
                 duration_secs=3600,
                 total_duration_secs=200.0,
+                diarize_step_durations={
+                    "provider_diarization_secs": 42.0,
+                    "speaker_assignment_secs": 13.0,
+                },
                 error_class=None,
                 retry_count=None,
                 retry_max=None,
@@ -26,6 +30,7 @@ def _make_digest_data() -> DigestData:
                 podcast_title="My Podcast",
                 duration_secs=2700,
                 total_duration_secs=130.0,
+                diarize_step_durations=None,
                 error_class=None,
                 retry_count=None,
                 retry_max=None,
@@ -36,6 +41,7 @@ def _make_digest_data() -> DigestData:
                 podcast_title="Other Pod",
                 duration_secs=1800,
                 total_duration_secs=None,
+                diarize_step_durations=None,
                 error_class="OOM",
                 retry_count=3,
                 retry_max=3,
@@ -118,3 +124,19 @@ def test_format_digest_telegram_duration_uses_unit_labels():
     data = _make_digest_data()
     md = format_digest_telegram(data)
     assert "1h 00m 00s" in md  # first item: 3600s
+
+
+def test_format_digest_html_includes_diarization_step_breakdown():
+    data = _make_digest_data()
+    html = format_digest_html(data)
+    assert "Diarization steps:" in html
+    assert "Provider diarization" in html
+    assert "Speaker assignment" in html
+
+
+def test_format_digest_telegram_includes_diarization_step_breakdown():
+    data = _make_digest_data()
+    md = format_digest_telegram(data)
+    assert "Diarization steps:" in md
+    assert "Provider diarization" in md
+    assert "Speaker assignment" in md

--- a/apps/pipeline/tests/unit/test_notification_events.py
+++ b/apps/pipeline/tests/unit/test_notification_events.py
@@ -10,6 +10,7 @@ def test_episode_done_event_defaults_and_base_type():
     assert event.episode_id == ""
     assert event.queue_remaining == 0
     assert event.processing_factor is None
+    assert event.diarize_step_durations is None
 
 
 def test_episode_failed_event_fields():

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -73,7 +73,7 @@ def test_format_done_html_contains_diarization_step_breakdown():
     html = format_done_html(_make_done_event())
     assert "Diarization Step Breakdown" in html
     assert "Provider diarization" in html
-    assert "Alignment io" in html
+    assert "Alignment I/O" in html
     assert "Speaker assignment" in html
 
 
@@ -81,7 +81,7 @@ def test_format_done_telegram_contains_diarization_step_breakdown():
     md = format_done_telegram(_make_done_event())
     assert "Diarization Step Breakdown" in md
     assert "Provider diarization" in md
-    assert "Alignment io" in md
+    assert "Alignment I/O" in md
     assert "Speaker assignment" in md
 
 

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -23,6 +23,11 @@ def _make_done_event() -> EpisodeDoneEvent:
         duration_secs=3600,
         transcribe_duration_secs=120.5,
         diarize_duration_secs=60.2,
+        diarize_step_durations={
+            "provider_diarization_secs": 42.0,
+            "alignment_io_secs": 5.0,
+            "speaker_assignment_secs": 13.2,
+        },
         total_duration_secs=200.0,
         queue_remaining=5,
         queue_estimated_secs=3600.0,
@@ -62,6 +67,22 @@ def test_format_done_telegram_contains_key_info():
     assert "How AI Works" in md
     assert "1h 00m 00s" in md  # duration with unit labels
     assert "5" in md
+
+
+def test_format_done_html_contains_diarization_step_breakdown():
+    html = format_done_html(_make_done_event())
+    assert "Diarization Step Breakdown" in html
+    assert "Provider diarization" in html
+    assert "Alignment io" in html
+    assert "Speaker assignment" in html
+
+
+def test_format_done_telegram_contains_diarization_step_breakdown():
+    md = format_done_telegram(_make_done_event())
+    assert "Diarization Step Breakdown" in md
+    assert "Provider diarization" in md
+    assert "Alignment io" in md
+    assert "Speaker assignment" in md
 
 
 def test_format_failed_html_contains_error():

--- a/apps/pipeline/tests/unit/test_queue_api.py
+++ b/apps/pipeline/tests/unit/test_queue_api.py
@@ -15,6 +15,9 @@ def _make_episode(status, **kwargs):
     ep.error_class = kwargs.get("error_class", None)
     ep.retry_count = kwargs.get("retry_count", 0)
     ep.retry_max = kwargs.get("retry_max", 3)
+    ep.transcribe_duration_secs = kwargs.get("transcribe_duration_secs", None)
+    ep.diarize_duration_secs = kwargs.get("diarize_duration_secs", None)
+    ep.diarize_step_durations = kwargs.get("diarize_step_durations", None)
     ep.updated_at = kwargs.get("updated_at", None)
     ep.feed = MagicMock()
     ep.feed.mode = kwargs.get("feed_mode", "live")
@@ -57,10 +60,20 @@ class TestRetryJob:
             return exc
 
     def test_retry_failed_episode_succeeds(self):
-        ep = _make_episode("failed", error_class="TRANSIENT_NETWORK", retry_count=3)
+        ep = _make_episode(
+            "failed",
+            error_class="TRANSIENT_NETWORK",
+            retry_count=3,
+            transcribe_duration_secs=120.0,
+            diarize_duration_secs=60.0,
+            diarize_step_durations={"provider_diarization_secs": 40.0},
+        )
         result = self._call_retry(ep)
         assert result["queued"] is True
         assert ep.retry_count == 0
+        assert ep.transcribe_duration_secs is None
+        assert ep.diarize_duration_secs is None
+        assert ep.diarize_step_durations is None
 
     def test_retry_stalled_episode_with_error_class_succeeds(self):
         """Stalled jobs with error_class set should be retryable (issue #46)."""

--- a/apps/pipeline/tests/unit/test_task_diarize.py
+++ b/apps/pipeline/tests/unit/test_task_diarize.py
@@ -53,10 +53,16 @@ class TestDiarizeEpisode:
             result = diarize_episode("ep1")
 
         assert result == "ep1"
-        mock_update.assert_any_call(
-            db, "ep1", has_diarization=True, diarization_error=None,
-            diarize_duration_secs=pytest.approx(0.0, abs=5),
-        )
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is True
+            and call.kwargs.get("diarization_error") is None
+            and "diarize_duration_secs" in call.kwargs
+            and "diarize_step_durations" in call.kwargs
+        ]
+        assert matching
+        assert "provider_diarization_secs" in matching[0].kwargs["diarize_step_durations"]
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.job_queue")
@@ -87,6 +93,15 @@ class TestDiarizeEpisode:
             result = diarize_episode("ep1")
 
         assert result == "ep1"
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is True
+            and call.kwargs.get("diarization_error") is None
+            and "diarize_step_durations" in call.kwargs
+        ]
+        assert matching
+        assert "speaker_assignment_secs" in matching[0].kwargs["diarize_step_durations"]
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.job_queue")
@@ -112,9 +127,13 @@ class TestDiarizeEpisode:
 
         assert result == "ep1"
         # Should mark diarization as failed but continue
-        mock_update.assert_any_call(
-            db, "ep1", has_diarization=False, diarization_error="pyannote crash"
-        )
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is False
+            and call.kwargs.get("diarization_error") == "pyannote crash"
+        ]
+        assert matching
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.SessionLocal")
@@ -173,10 +192,16 @@ class TestDiarizeEpisode:
             result = diarize_episode("ep1")
 
         assert result == "ep1"
-        mock_update.assert_any_call(
-            db, "ep1", has_diarization=True, diarization_error=None,
-            diarize_duration_secs=pytest.approx(0.0, abs=5),
-        )
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is True
+            and call.kwargs.get("diarization_error") is None
+            and "diarize_duration_secs" in call.kwargs
+            and "diarize_step_durations" in call.kwargs
+        ]
+        assert matching
+        assert "artifact_load_secs" in matching[0].kwargs["diarize_step_durations"]
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.job_queue")
@@ -205,5 +230,7 @@ class TestDiarizeEpisode:
             result = diarize_episode("ep1")
 
         assert result == "ep1"
-        mock_update.assert_any_call(db, "ep1", has_diarization=False, diarization_error=None)
+        mock_update.assert_any_call(
+            db, "ep1", has_diarization=False, diarization_error=None, diarize_step_durations=None
+        )
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")

--- a/apps/pipeline/tests/unit/test_task_diarize.py
+++ b/apps/pipeline/tests/unit/test_task_diarize.py
@@ -202,6 +202,7 @@ class TestDiarizeEpisode:
         ]
         assert matching
         assert "artifact_load_secs" in matching[0].kwargs["diarize_step_durations"]
+        assert "speaker_assignment_secs" in matching[0].kwargs["diarize_step_durations"]
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.job_queue")

--- a/apps/pipeline/tests/unit/test_task_diarize.py
+++ b/apps/pipeline/tests/unit/test_task_diarize.py
@@ -165,10 +165,13 @@ class TestDiarizeEpisode:
         mock_session_cls.return_value = db
 
         fireworks_raw = {
+            "segments": [
+                {"start": 0.0, "end": 2.0},
+            ],
             "words": [
-                {"speaker_id": "0", "start": 0.0, "end": 1.0},
-                {"speaker_id": "0", "start": 1.0, "end": 2.0},
-            ]
+                {"speaker_id": "0", "word": "Hello", "start": 0.0, "end": 1.0},
+                {"speaker_id": "0", "word": "world.", "start": 1.0, "end": 2.0},
+            ],
         }
 
         with (
@@ -201,8 +204,7 @@ class TestDiarizeEpisode:
             and "diarize_step_durations" in call.kwargs
         ]
         assert matching
-        assert "artifact_load_secs" in matching[0].kwargs["diarize_step_durations"]
-        assert "speaker_assignment_secs" in matching[0].kwargs["diarize_step_durations"]
+        assert "segment_rebuild_secs" in matching[0].kwargs["diarize_step_durations"]
         mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
 
     @patch("app.tasks.diarize.job_queue")

--- a/apps/pipeline/tests/unit/test_timing_labels.py
+++ b/apps/pipeline/tests/unit/test_timing_labels.py
@@ -1,0 +1,17 @@
+from app.services.timing_labels import humanize_timing_key
+
+
+def test_humanize_alignment_io_key():
+    assert humanize_timing_key("alignment_io_secs") == "Alignment I/O"
+
+
+def test_humanize_provider_diarization_key():
+    assert humanize_timing_key("provider_diarization_secs") == "Provider diarization"
+
+
+def test_humanize_speaker_assignment_key():
+    assert humanize_timing_key("speaker_assignment_secs") == "Speaker assignment"
+
+
+def test_humanize_empty_key_returns_input():
+    assert humanize_timing_key("") == ""

--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -55,6 +55,7 @@ interface Episode {
   inference_error: string | null;
   transcribe_duration_secs: number | null;
   diarize_duration_secs: number | null;
+  diarize_step_durations: Record<string, number> | null;
   inference_provider_used: string | null;
   fireworks_audio_secs: number | null;
   fireworks_audio_minutes: number | null;
@@ -70,6 +71,12 @@ interface Episode {
   feed_website_url: string | null;
   created_at: string;
   feed_url: string | null;
+}
+
+function formatDiarizeStepLabel(key: string): string {
+  const label = key.replace(/_secs$/, "").replaceAll("_", " ").trim();
+  if (!label) return key;
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 interface AdjacentEpisode {
@@ -193,6 +200,17 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
             {episode.diarize_duration_secs != null && (
               <span>Diarization: {formatTimestamp(episode.diarize_duration_secs)}</span>
             )}
+          </div>
+        )}
+        {episode.diarize_step_durations && Object.keys(episode.diarize_step_durations).length > 0 && (
+          <div className="mt-1 text-xs text-muted-foreground">
+            <span className="mr-1">Diarization steps:</span>
+            {Object.entries(episode.diarize_step_durations).map(([step, secs], idx) => (
+              <span key={step}>
+                {idx > 0 ? " · " : ""}
+                {formatDiarizeStepLabel(step)}: {formatTimestamp(secs)}
+              </span>
+            ))}
           </div>
         )}
         {episode.inference_provider_used === "fireworks" && (

--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -73,9 +73,15 @@ interface Episode {
   feed_url: string | null;
 }
 
+const STEP_ABBREVIATIONS: Record<string, string> = {
+  io: "I/O", api: "API", stt: "STT", url: "URL",
+};
+
 function formatDiarizeStepLabel(key: string): string {
-  const label = key.replace(/_secs$/, "").replaceAll("_", " ").trim();
-  if (!label) return key;
+  const words = key.replace(/_secs$/, "").split("_").filter(Boolean);
+  if (!words.length) return key;
+  const formatted = words.map(w => STEP_ABBREVIATIONS[w.toLowerCase()] ?? w.toLowerCase());
+  const label = formatted.join(" ");
   return label.charAt(0).toUpperCase() + label.slice(1);
 }
 

--- a/apps/web/tests/unit/episode-page-navigation.test.tsx
+++ b/apps/web/tests/unit/episode-page-navigation.test.tsx
@@ -48,6 +48,12 @@ const currentEpisode = {
   inference_error: null,
   transcribe_duration_secs: null,
   diarize_duration_secs: null,
+  diarize_step_durations: null,
+  inference_provider_used: null,
+  fireworks_audio_secs: null,
+  fireworks_audio_minutes: null,
+  fireworks_stt_cost_per_minute_usd: null,
+  fireworks_stt_cost_usd: null,
   audio_url: null,
   audio_local_path: null,
   guid: null,
@@ -126,5 +132,32 @@ describe("Episode page navigation", () => {
     const transcript = screen.getByTestId("transcript-section");
 
     expect(prevLink.compareDocumentPosition(transcript) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders diarization step timing details when available", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            ...currentEpisode,
+            transcribe_duration_secs: 120,
+            diarize_duration_secs: 60,
+            diarize_step_durations: {
+              provider_diarization_secs: 42,
+              alignment_io_secs: 5,
+              speaker_assignment_secs: 13,
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    expect(screen.getByText(/Diarization steps:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Provider diarization/i)).toBeInTheDocument();
+    expect(screen.getByText(/Speaker assignment/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add a persisted `episodes.diarize_step_durations` JSONB field and migration
- capture detailed per-step diarization timings in `tasks/diarize.py` for local + Fireworks paths
- include diarization step breakdown in done notification payloads and render in email/Telegram templates
- show per-step diarization timing details on the episode detail page
- add/update unit tests for diarization task timing capture, notification formatting/events, and episode page rendering

## Verification
- `cd apps/pipeline && pytest -q tests/unit/test_notification_formatting.py tests/unit/test_task_diarize.py tests/unit/test_notification_events.py`
- `cd apps/pipeline && pytest -q tests/unit/test_email_handler.py tests/unit/test_telegram_handler.py tests/unit/test_notifications.py`
- `cd apps/web && npm test -- --runTestsByPath tests/unit/episode-page-navigation.test.tsx`

Closes #347