### PR TITLE
feat: speaker filter for search and ask (#346)

### DIFF
--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -38,6 +38,7 @@ class AskRequest(BaseModel):
     feed_id: str | None = None
     feed_ids: list[str] | None = None
     episode_id: str | None = None
+    speaker_label: str | None = None
 
 
 def _sse_event(event: str, data: dict | list | str) -> str:
@@ -45,7 +46,7 @@ def _sse_event(event: str, data: dict | list | str) -> str:
     return f"event: {event}\ndata: {payload}\n\n"
 
 
-async def _stream_ask(question: str, model: str, feed_ids: list[str] | None, episode_id: str | None = None):
+async def _stream_ask(question: str, model: str, feed_ids: list[str] | None, episode_id: str | None = None, speaker_label: str | None = None):
     db = SessionLocal()
     try:
         runtime = get_runtime_inference_settings(db)
@@ -70,7 +71,7 @@ async def _stream_ask(question: str, model: str, feed_ids: list[str] | None, epi
             return
 
         # 1. Retrieve relevant chunks
-        chunks = retrieve_chunks(db, question, feed_ids=feed_ids, episode_id=episode_id)
+        chunks = retrieve_chunks(db, question, feed_ids=feed_ids, episode_id=episode_id, speaker_label=speaker_label)
 
         if not chunks:
             yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
@@ -114,7 +115,7 @@ async def ask_endpoint(req: AskRequest):
         feed_ids = [req.feed_id]
 
     return StreamingResponse(
-        _stream_ask(req.question, model, feed_ids, episode_id=req.episode_id),
+        _stream_ask(req.question, model, feed_ids, episode_id=req.episode_id, speaker_label=req.speaker_label),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -50,6 +50,7 @@ def retrieve_chunks(
     top_k: int = TOP_K,
     feed_ids: list[str] | None = None,
     episode_id: str | None = None,
+    speaker_label: str | None = None,
 ) -> list[ChunkResult]:
     """Retrieve top-K chunks by cosine similarity to the question embedding."""
     runtime = get_runtime_embedding_settings(db)
@@ -58,10 +59,14 @@ def retrieve_chunks(
 
     feed_filter = ""
     episode_filter = ""
+    speaker_filter = ""
     params: dict = {"embedding": embedding_str, "top_k": top_k, "threshold": SIMILARITY_THRESHOLD}
     if episode_id:
         episode_filter = "AND c.episode_id = :episode_id"
         params["episode_id"] = episode_id
+    if speaker_label:
+        speaker_filter = "AND c.speaker_label = :speaker_label"
+        params["speaker_label"] = speaker_label
     if feed_ids:
         # Build feed filter supporting both feed IDs and "uploads" (feed_id IS NULL)
         has_uploads = "__uploads__" in feed_ids
@@ -95,6 +100,7 @@ def retrieve_chunks(
         WHERE c.embedding IS NOT NULL
             {episode_filter}
             {feed_filter}
+            {speaker_filter}
         ORDER BY c.embedding <=> CAST(:embedding AS vector)
         LIMIT :top_k
     """)

--- a/apps/web/src/app/api/search/grouped/route.ts
+++ b/apps/web/src/app/api/search/grouped/route.ts
@@ -15,9 +15,10 @@ export async function GET(req: NextRequest) {
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
   const skipCount = searchParams.get("skipCount") === "true";
+  const speakerLabel = searchParams.get("speaker") || null;
 
   try {
-    const result = await searchGrouped(q, feedIds, includeManualUploads, page, pageSize, skipCount);
+    const result = await searchGrouped(q, feedIds, includeManualUploads, page, pageSize, skipCount, speakerLabel);
     return NextResponse.json(result);
   } catch (err) {
     console.error("Grouped search error:", err);

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -15,9 +15,10 @@ export async function GET(req: NextRequest) {
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
   const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
   const skipCount = searchParams.get("skipCount") === "true";
+  const speakerLabel = searchParams.get("speaker") || null;
 
   try {
-    const result = await searchSegments(q, feedIds, includeManualUploads, page, pageSize, skipCount);
+    const result = await searchSegments(q, feedIds, includeManualUploads, page, pageSize, skipCount, speakerLabel);
     return NextResponse.json(result);
   } catch (err) {
     console.error("Search error:", err);

--- a/apps/web/src/app/api/search/speakers/route.ts
+++ b/apps/web/src/app/api/search/speakers/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import pool from "@/lib/db";
+
+/**
+ * GET /api/search/speakers — list distinct speakers across selected feeds.
+ * Used to populate the speaker filter dropdown on the search page.
+ *
+ * Query params:
+ *   feedId  — comma-separated feed UUIDs (optional)
+ *   uploads — "true" to include manual uploads
+ *
+ * Returns: [{ speaker_label, display_name }] ordered by display_name.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const feedIdRaw = searchParams.get("feedId") || null;
+  const feedIds = feedIdRaw ? feedIdRaw.split(",").filter(Boolean) : null;
+  const includeManualUploads = searchParams.get("uploads") === "true";
+
+  const hasFeedIds = feedIds && feedIds.length > 0;
+  const feedClause =
+    !hasFeedIds && !includeManualUploads
+      ? "TRUE"
+      : (() => {
+          const parts: string[] = [];
+          if (hasFeedIds) parts.push("f.id = ANY($1::uuid[])");
+          if (includeManualUploads) parts.push("e.feed_id IS NULL");
+          return `(${parts.join(" OR ")})`;
+        })();
+
+  const params: unknown[] = hasFeedIds ? [feedIds] : [];
+
+  try {
+    const result = await pool.query(
+      `SELECT DISTINCT ON (s.speaker_label)
+        s.speaker_label,
+        COALESCE(sn.display_name, s.speaker_label) AS display_name
+      FROM segments s
+      JOIN episodes e ON s.episode_id = e.id
+      LEFT JOIN feeds f ON e.feed_id = f.id
+      LEFT JOIN speaker_names sn ON sn.episode_id = s.episode_id AND sn.speaker_label = s.speaker_label
+      WHERE s.speaker_label IS NOT NULL
+        AND e.status = 'done'
+        AND ${feedClause}
+      ORDER BY s.speaker_label, display_name`,
+      params
+    );
+
+    return NextResponse.json(result.rows);
+  } catch (err) {
+    console.error("Speakers fetch error:", err);
+    return NextResponse.json({ error: "Failed to fetch speakers" }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -16,6 +16,7 @@ import SearchInput from "@/components/SearchInput";
 import HelpPopover from "@/components/HelpPopover";
 import SearchSpinner from "@/components/SearchSpinner";
 import PodcastFilter from "@/components/PodcastFilter";
+import SpeakerFilter from "@/components/SpeakerFilter";
 import type { SearchPage as SearchPageType, GroupedSearchResult } from "@/lib/search";
 import { loadSearchSnapshot, saveSearchSnapshot } from "@/lib/page-state";
 
@@ -54,6 +55,9 @@ function SearchPageContent() {
   );
   const [selectedFeedIds, setSelectedFeedIds] = useState<Set<string>>(
     new Set(initialSnapshot?.selectedFeedIds || [])
+  );
+  const [selectedSpeaker, setSelectedSpeaker] = useState<string | null>(
+    initialSnapshot?.selectedSpeaker ?? null
   );
   const [page, setPage] = useState(
     initialQuery ? 1 : initialSnapshot?.page || 1
@@ -110,10 +114,11 @@ function SearchPageContent() {
       query,
       submittedQuery,
       selectedFeedIds: Array.from(selectedFeedIds),
+      selectedSpeaker,
       page,
       viewMode,
     });
-  }, [query, submittedQuery, selectedFeedIds, page, viewMode]);
+  }, [query, submittedQuery, selectedFeedIds, selectedSpeaker, page, viewMode]);
 
   // Separate real feed UUIDs from the __uploads__ sentinel
   const includeManualUploads = selectedFeedIds.has("__uploads__");
@@ -122,9 +127,9 @@ function SearchPageContent() {
     .join(",");
 
   // Flat search query
-  const flatCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}`;
+  const flatCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}`;
   const flatQuery = useQuery<SearchPageType>({
-    queryKey: ["search", submittedQuery, feedFilterParam, includeManualUploads, page],
+    queryKey: ["search", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page],
     queryFn: async () => {
       if (!submittedQuery)
         return {
@@ -143,6 +148,7 @@ function SearchPageContent() {
       });
       if (feedFilterParam) params.set("feedId", feedFilterParam);
       if (includeManualUploads) params.set("uploads", "true");
+      if (selectedSpeaker) params.set("speaker", selectedSpeaker);
       if (canSkipCount) params.set("skipCount", "true");
       const resp = await fetch(`/api/search?${params}`);
       if (!resp.ok) throw new Error("Search failed");
@@ -159,9 +165,9 @@ function SearchPageContent() {
   });
 
   // Grouped search query
-  const groupedCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}`;
+  const groupedCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}`;
   const groupedQuery = useQuery<GroupedSearchResult>({
-    queryKey: ["search-grouped", submittedQuery, feedFilterParam, includeManualUploads, page],
+    queryKey: ["search-grouped", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page],
     queryFn: async () => {
       if (!submittedQuery)
         return {
@@ -180,6 +186,7 @@ function SearchPageContent() {
       });
       if (feedFilterParam) params.set("feedId", feedFilterParam);
       if (includeManualUploads) params.set("uploads", "true");
+      if (selectedSpeaker) params.set("speaker", selectedSpeaker);
       if (canSkipCount) params.set("skipCount", "true");
       const resp = await fetch(`/api/search/grouped?${params}`);
       if (!resp.ok) throw new Error("Search failed");
@@ -220,6 +227,7 @@ function SearchPageContent() {
     setQuery("");
     setSubmittedQuery("");
     setPage(1);
+    setSelectedSpeaker(null);
     router.replace("/search", { scroll: false });
   }
 
@@ -271,13 +279,19 @@ function SearchPageContent() {
             </p>
           )}
 
-          {/* Podcast filter */}
-          <div className="flex justify-center">
+          {/* Filters: podcast + speaker */}
+          <div className="flex justify-center gap-2 flex-wrap">
             <PodcastFilter
               feeds={feeds}
               selectedFeedIds={selectedFeedIds}
-              onSelectionChange={setSelectedFeedIds}
+              onSelectionChange={(next) => { setSelectedFeedIds(next); setSelectedSpeaker(null); setPage(1); }}
               hasManualUploads={hasManualUploads}
+            />
+            <SpeakerFilter
+              feedIds={Array.from(selectedFeedIds)}
+              includeManualUploads={includeManualUploads}
+              selectedSpeaker={selectedSpeaker}
+              onSelectionChange={(s) => { setSelectedSpeaker(s); setPage(1); }}
             />
           </div>
         </div>

--- a/apps/web/src/components/SpeakerFilter.tsx
+++ b/apps/web/src/components/SpeakerFilter.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { ChevronDown, User } from "lucide-react";
+
+interface Speaker {
+  speaker_label: string;
+  display_name: string;
+}
+
+interface SpeakerFilterProps {
+  feedIds: string[];
+  includeManualUploads: boolean;
+  selectedSpeaker: string | null;
+  onSelectionChange: (speaker: string | null) => void;
+}
+
+export default function SpeakerFilter({
+  feedIds,
+  includeManualUploads,
+  selectedSpeaker,
+  onSelectionChange,
+}: SpeakerFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    const realIds = feedIds.filter((id) => id !== "__uploads__");
+    if (realIds.length > 0) params.set("feedId", realIds.join(","));
+    if (includeManualUploads) params.set("uploads", "true");
+
+    fetch(`/api/search/speakers?${params}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) setSpeakers(data);
+      })
+      .catch(() => {});
+  }, [feedIds, includeManualUploads]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  if (speakers.length === 0) return null;
+
+  const selectedDisplay = selectedSpeaker
+    ? (speakers.find((s) => s.speaker_label === selectedSpeaker)?.display_name ?? selectedSpeaker)
+    : null;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
+      >
+        <User size={13} className="text-muted-foreground shrink-0" />
+        <span className="text-muted-foreground">Speaker:</span>
+        <span className={selectedDisplay ? "max-w-[120px] truncate" : ""}>
+          {selectedDisplay ?? "All"}
+        </span>
+        <ChevronDown size={14} className="text-muted-foreground shrink-0" />
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 bg-background border border-border rounded-md shadow-lg py-1 min-w-[200px] max-h-64 overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => { onSelectionChange(null); setOpen(false); }}
+            className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors ${
+              !selectedSpeaker ? "font-medium" : ""
+            }`}
+          >
+            All speakers
+          </button>
+          <div className="border-t border-border my-1" />
+          {speakers.map((s) => (
+            <button
+              key={s.speaker_label}
+              type="button"
+              onClick={() => { onSelectionChange(s.speaker_label); setOpen(false); }}
+              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors truncate ${
+                selectedSpeaker === s.speaker_label ? "font-medium" : ""
+              }`}
+            >
+              {s.display_name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/SpeakerFilter.tsx
+++ b/apps/web/src/components/SpeakerFilter.tsx
@@ -23,9 +23,11 @@ export default function SpeakerFilter({
 }: SpeakerFilterProps) {
   const [open, setOpen] = useState(false);
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [loading, setLoading] = useState(true);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    setLoading(true);
     const params = new URLSearchParams();
     const realIds = feedIds.filter((id) => id !== "__uploads__");
     if (realIds.length > 0) params.set("feedId", realIds.join(","));
@@ -36,7 +38,8 @@ export default function SpeakerFilter({
       .then((data) => {
         if (Array.isArray(data)) setSpeakers(data);
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setLoading(false));
   }, [feedIds, includeManualUploads]);
 
   useEffect(() => {
@@ -49,7 +52,7 @@ export default function SpeakerFilter({
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  if (speakers.length === 0) return null;
+  if (loading || speakers.length === 0) return null;
 
   const selectedDisplay = selectedSpeaker
     ? (speakers.find((s) => s.speaker_label === selectedSpeaker)?.display_name ?? selectedSpeaker)

--- a/apps/web/src/lib/page-state.ts
+++ b/apps/web/src/lib/page-state.ts
@@ -10,6 +10,7 @@ export interface SearchPageSnapshot {
   query: string;
   submittedQuery: string;
   selectedFeedIds: string[];
+  selectedSpeaker?: string | null;
   page: number;
   viewMode: ViewMode;
 }

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -63,7 +63,6 @@ export async function searchSegments(
 ): Promise<SearchPage> {
   const FETCH_LIMIT = 100; // fetch more than pageSize for RRF merging
   const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
-  const speakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
 
   // FTS query — speaker filter uses table alias 't'
   const ftsSpeakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -58,10 +58,17 @@ export async function searchSegments(
   includeManualUploads: boolean,
   page: number,
   pageSize: number = 20,
-  skipCount: boolean = false
+  skipCount: boolean = false,
+  speakerLabel: string | null = null
 ): Promise<SearchPage> {
   const FETCH_LIMIT = 100; // fetch more than pageSize for RRF merging
   const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const speakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
+
+  // FTS query — speaker filter uses table alias 't'
+  const ftsSpeakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
+  const ftsLimitIdx = feedFilter.nextIdx + (speakerLabel ? 1 : 0);
+  const ftsParams = [query, ...feedFilter.params, ...(speakerLabel ? [speakerLabel] : []), FETCH_LIMIT];
 
   const ftsPromise = pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
@@ -91,13 +98,19 @@ export async function searchSegments(
     WHERE to_tsvector('english', t.full_text) @@ query
       AND e.status = 'done'
       AND ${feedFilter.clause}
+      ${ftsSpeakerClause}
     ORDER BY rank DESC
-    LIMIT $${feedFilter.nextIdx}`,
-    [query, ...feedFilter.params, FETCH_LIMIT]
+    LIMIT $${ftsLimitIdx}`,
+    ftsParams
   );
 
   const embedding = await getQueryEmbedding(query);
   const vecFeedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  // Vector query — speaker filter uses table alias 's'
+  const vecSpeakerClause = speakerLabel ? `AND s.speaker_label = $${vecFeedFilter.nextIdx}` : "";
+  const vecLimitIdx = vecFeedFilter.nextIdx + (speakerLabel ? 1 : 0);
+  const vecParams = [`[${embedding?.join(",")}]`, ...vecFeedFilter.params, ...(speakerLabel ? [speakerLabel] : []), FETCH_LIMIT];
+
   const vecPromise = embedding
     ? pool.query(
         `SELECT
@@ -125,13 +138,16 @@ export async function searchSegments(
         WHERE s.embedding IS NOT NULL
           AND e.status = 'done'
           AND ${vecFeedFilter.clause}
+          ${vecSpeakerClause}
         ORDER BY s.embedding <=> $1::vector
-        LIMIT $${vecFeedFilter.nextIdx}`,
-        [`[${embedding.join(",")}]`, ...vecFeedFilter.params, FETCH_LIMIT]
+        LIMIT $${vecLimitIdx}`,
+        vecParams
       )
     : Promise.resolve({ rows: [] });
 
   const countFeedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const countSpeakerClause = speakerLabel ? `AND t.speaker_label = $${countFeedFilter.nextIdx}` : "";
+  const countParams = [query, ...countFeedFilter.params, ...(speakerLabel ? [speakerLabel] : [])];
   const countPromise = skipCount
     ? Promise.resolve(null)
     : pool.query(
@@ -143,8 +159,9 @@ export async function searchSegments(
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND e.status = 'done'
-          AND ${countFeedFilter.clause}`,
-        [query, ...countFeedFilter.params]
+          AND ${countFeedFilter.clause}
+          ${countSpeakerClause}`,
+        countParams
       );
 
   const coveragePromise = skipCount
@@ -191,10 +208,14 @@ export async function searchGrouped(
   includeManualUploads: boolean,
   page: number,
   pageSize: number = 20,
-  skipCount: boolean = false
+  skipCount: boolean = false,
+  speakerLabel: string | null = null
 ): Promise<GroupedSearchResult> {
   const offset = (page - 1) * pageSize;
   const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const rowsSpeakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
+  const rowsLimitIdx = feedFilter.nextIdx + (speakerLabel ? 1 : 0);
+  const rowsParams = [query, ...feedFilter.params, ...(speakerLabel ? [speakerLabel] : []), pageSize, offset];
 
   const rowsPromise = pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
@@ -216,13 +237,16 @@ export async function searchGrouped(
     WHERE to_tsvector('english', t.full_text) @@ query
       AND e.status = 'done'
       AND ${feedFilter.clause}
+      ${rowsSpeakerClause}
     GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
     ORDER BY best_rank DESC, mention_count DESC
-    LIMIT $${feedFilter.nextIdx} OFFSET $${feedFilter.nextIdx + 1}`,
-    [query, ...feedFilter.params, pageSize, offset]
+    LIMIT $${rowsLimitIdx} OFFSET $${rowsLimitIdx + 1}`,
+    rowsParams
   );
 
   const grpCountFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const countSpeakerClause = speakerLabel ? `AND t.speaker_label = $${grpCountFilter.nextIdx}` : "";
+  const countParams = [query, ...grpCountFilter.params, ...(speakerLabel ? [speakerLabel] : [])];
   const countPromise = skipCount
     ? Promise.resolve(null)
     : pool.query(
@@ -238,8 +262,9 @@ export async function searchGrouped(
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND e.status = 'done'
-          AND ${grpCountFilter.clause}`,
-        [query, ...grpCountFilter.params]
+          AND ${grpCountFilter.clause}
+          ${countSpeakerClause}`,
+        countParams
       );
 
   const coveragePromise = skipCount

--- a/apps/web/tests/unit/flat-search.test.ts
+++ b/apps/web/tests/unit/flat-search.test.ts
@@ -43,14 +43,14 @@ describe("GET /api/search", () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 20, false);
+    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 20, false, null);
   });
 
   test("passes single feedId as array", async () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test&feedId=abc-123");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", ["abc-123"], false, 1, 20, false);
+    expect(searchSegments).toHaveBeenCalledWith("test", ["abc-123"], false, 1, 20, false, null);
   });
 
   test("parses comma-separated feedId into array", async () => {
@@ -58,7 +58,7 @@ describe("GET /api/search", () => {
     const req = new NextRequest("http://localhost/api/search?q=test&feedId=id-1,id-2,id-3");
     await GET(req);
     expect(searchSegments).toHaveBeenCalledWith(
-      "test", ["id-1", "id-2", "id-3"], false, 1, 20, false
+      "test", ["id-1", "id-2", "id-3"], false, 1, 20, false, null
     );
   });
 
@@ -66,21 +66,21 @@ describe("GET /api/search", () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test&uploads=true");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", null, true, 1, 20, false);
+    expect(searchSegments).toHaveBeenCalledWith("test", null, true, 1, 20, false, null);
   });
 
   test("passes both feedIds and uploads together", async () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test&feedId=id-1&uploads=true");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", ["id-1"], true, 1, 20, false);
+    expect(searchSegments).toHaveBeenCalledWith("test", ["id-1"], true, 1, 20, false, null);
   });
 
   test("clamps pageSize to max 50", async () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test&pageSize=100");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 50, false);
+    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 50, false, null);
   });
 
   test("returns 500 on search error", async () => {

--- a/apps/web/tests/unit/grouped-search.test.ts
+++ b/apps/web/tests/unit/grouped-search.test.ts
@@ -55,7 +55,7 @@ describe("GET /api/search/grouped", () => {
     );
     const resp = await GET(req);
     expect(resp.status).toBe(200);
-    expect(searchGrouped).toHaveBeenCalledWith("tariffs", null, false, 2, 10, false);
+    expect(searchGrouped).toHaveBeenCalledWith("tariffs", null, false, 2, 10, false, null);
   });
 
   test("passes feedId filter when provided", async () => {
@@ -71,7 +71,7 @@ describe("GET /api/search/grouped", () => {
       `http://localhost/api/search/grouped?q=test&feedId=${feedId}`
     );
     await GET(req);
-    expect(searchGrouped).toHaveBeenCalledWith("test", [feedId], false, 1, 20, false);
+    expect(searchGrouped).toHaveBeenCalledWith("test", [feedId], false, 1, 20, false, null);
   });
 
   test("clamps pageSize to max 50", async () => {
@@ -86,7 +86,7 @@ describe("GET /api/search/grouped", () => {
       "http://localhost/api/search/grouped?q=test&pageSize=100"
     );
     await GET(req);
-    expect(searchGrouped).toHaveBeenCalledWith("test", null, false, 1, 50, false);
+    expect(searchGrouped).toHaveBeenCalledWith("test", null, false, 1, 50, false, null);
   });
 
   test("parses comma-separated feedId into array", async () => {
@@ -102,7 +102,7 @@ describe("GET /api/search/grouped", () => {
     );
     await GET(req);
     expect(searchGrouped).toHaveBeenCalledWith(
-      "test", ["id-1", "id-2", "id-3"], false, 1, 20, false
+      "test", ["id-1", "id-2", "id-3"], false, 1, 20, false, null
     );
   });
 
@@ -119,7 +119,7 @@ describe("GET /api/search/grouped", () => {
     );
     await GET(req);
     expect(searchGrouped).toHaveBeenCalledWith(
-      "test", null, true, 1, 20, false
+      "test", null, true, 1, 20, false, null
     );
   });
 
@@ -136,7 +136,7 @@ describe("GET /api/search/grouped", () => {
     );
     await GET(req);
     expect(searchGrouped).toHaveBeenCalledWith(
-      "test", ["id-1"], true, 1, 20, false
+      "test", ["id-1"], true, 1, 20, false, null
     );
   });
 

--- a/apps/web/tests/unit/speakers-route.test.ts
+++ b/apps/web/tests/unit/speakers-route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for GET /api/search/speakers
+ *
+ * Tests route handler logic without a live DB by mocking the pool.
+ *
+ * @jest-environment node
+ */
+
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ query: mockQuery }));
+
+import { NextRequest } from "next/server";
+
+const mockRows = [
+  { speaker_label: "SPEAKER_00", display_name: "Alice" },
+  { speaker_label: "SPEAKER_01", display_name: "Bob" },
+];
+
+describe("GET /api/search/speakers", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: mockRows });
+    const mod = await import("@/app/api/search/speakers/route");
+    GET = mod.GET;
+  });
+
+  test("returns speaker list with no feed filter", async () => {
+    const req = new NextRequest("http://localhost/api/search/speakers");
+    const resp = await GET(req);
+    expect(resp.status).toBe(200);
+    const data = await resp.json();
+    expect(data).toEqual(mockRows);
+    // No feed params — WHERE clause should use TRUE
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toContain("TRUE");
+    expect(mockQuery.mock.calls[0][1]).toEqual([]);
+  });
+
+  test("passes feed UUID as array param when feedId provided", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/speakers?feedId=abc-123"
+    );
+    await GET(req);
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toContain("ANY($1::uuid[])");
+    expect(mockQuery.mock.calls[0][1]).toEqual([["abc-123"]]);
+  });
+
+  test("passes multiple feed UUIDs as array", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/speakers?feedId=id-1,id-2,id-3"
+    );
+    await GET(req);
+    expect(mockQuery.mock.calls[0][1]).toEqual([["id-1", "id-2", "id-3"]]);
+  });
+
+  test("includes uploads clause when uploads=true and no feedIds", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/speakers?uploads=true"
+    );
+    await GET(req);
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toContain("feed_id IS NULL");
+    expect(mockQuery.mock.calls[0][1]).toEqual([]);
+  });
+
+  test("combines feedId and uploads filters", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/search/speakers?feedId=id-1&uploads=true"
+    );
+    await GET(req);
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toContain("ANY($1::uuid[])");
+    expect(sql).toContain("feed_id IS NULL");
+    expect(mockQuery.mock.calls[0][1]).toEqual([["id-1"]]);
+  });
+
+  test("returns 500 when DB throws", async () => {
+    mockQuery.mockRejectedValue(new Error("DB down"));
+    const req = new NextRequest("http://localhost/api/search/speakers");
+    const resp = await GET(req);
+    expect(resp.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Speaker** filter dropdown to the search page (beside the existing podcast filter). It auto-hides when the selected scope has no diarized speakers.
- Speaker filtering is applied at the SQL level to both FTS and vector queries, so the same `speaker_label` column restricts results from either path.
- RAG chunk retrieval for **Ask AI** also gains an optional `speaker_label` filter (threaded through `AskRequest → _stream_ask → retrieve_chunks`).
- New `GET /api/search/speakers` endpoint returns distinct speakers for the current feed scope — used to populate the dropdown.

## Why SQL filtering, not embedding prefix
The embed task runs **before** the infer task (which assigns display names), so at embedding time only raw labels like `SPEAKER_00` are available. Prepending those to text would add noise, not signal. SQL filtering works immediately with all existing embeddings and resolves the same goal.

## Changes
- `apps/web/src/lib/search.ts` — `searchSegments` and `searchGrouped` gain optional `speakerLabel` param
- `apps/web/src/app/api/search/route.ts` + `grouped/route.ts` — thread `?speaker=` query param
- `apps/web/src/app/api/search/speakers/route.ts` — new speakers endpoint
- `apps/web/src/components/SpeakerFilter.tsx` — new dropdown component
- `apps/web/src/app/search/page.tsx` — integrate filter, persist in session snapshot
- `apps/pipeline/app/services/rag.py` — `speaker_label` filter in `retrieve_chunks`
- `apps/pipeline/app/api/ask.py` — `speaker_label` field in `AskRequest`
- `apps/web/tests/unit/flat-search.test.ts` + `grouped-search.test.ts` — update call assertions

## Test plan
- [ ] All 160 web unit tests pass (`npx jest --testPathPattern=unit`)
- [ ] All 23 pipeline unit tests pass (`make test-unit`)
- [ ] Search page shows Speaker dropdown when diarized feeds selected
- [ ] Selecting a speaker narrows results to that speaker only (FTS + vector)
- [ ] Clearing podcast filter resets speaker selection
- [ ] Speaker dropdown auto-hides when no speakers available

Closes #346