### PR TITLE
fix: rebuild Fireworks segments from word-level speaker data (#349)

### DIFF
--- a/apps/pipeline/app/services/fireworks_audio.py
+++ b/apps/pipeline/app/services/fireworks_audio.py
@@ -201,6 +201,113 @@ def assign_segment_speakers_from_words(transcript_segments: list[dict], raw: dic
     return assignments
 
 
+def rebuild_segments_from_words(raw: dict) -> list[dict]:
+    """
+    Rebuild sentence-level segments from Fireworks word-level speaker data.
+
+    Mirrors the WhisperX word-level alignment path used by the local provider:
+    groups consecutive same-speaker words within the same original Fireworks
+    segment boundary into a single DB segment, splitting on speaker changes.
+
+    This ensures the Fireworks path produces the same granularity of segments
+    as the local path — one per sentence fragment per speaker — so per-sentence
+    timestamps are shown in the transcript view.
+
+    Returns list of {"start": float, "end": float, "text": str, "speaker": str}.
+    Returns empty list if word-level speaker data is unavailable (caller falls back).
+    """
+    words = raw.get("words", []) or []
+    segments = raw.get("segments", []) or []
+
+    if not words:
+        return []
+
+    # Build ordered segment end-times to map each word to its parent segment.
+    # Fireworks words always fall within a segment boundary, so we iterate
+    # segments in order and assign each word to the first segment whose end
+    # time is after the word's start.
+    seg_ends = [float(s.get("end", 0.0)) for s in segments]
+
+    def _seg_idx_for(word_start: float) -> int:
+        for i, end in enumerate(seg_ends):
+            if word_start < end + 0.05:  # small tolerance for rounding
+                return i
+        return max(0, len(seg_ends) - 1)
+
+    # Build tagged word list (skip words missing required fields).
+    tagged: list[dict] = []
+    for w in words:
+        start = w.get("start")
+        end = w.get("end")
+        word_text = w.get("word", "")
+        speaker_id = w.get("speaker_id")
+        if start is None or end is None or not word_text:
+            continue
+        tagged.append({
+            "word": word_text,
+            "start": float(start),
+            "end": float(end),
+            "speaker": _normalize_speaker(str(speaker_id)) if speaker_id is not None else None,
+            "seg_idx": _seg_idx_for(float(start)),
+        })
+
+    if not tagged:
+        return []
+
+    # If no word has a speaker label, can't rebuild with diarization.
+    if not any(w["speaker"] for w in tagged):
+        return []
+
+    # Propagate speaker labels forward/backward to cover unlabeled words.
+    last_known: str | None = None
+    for w in tagged:
+        if w["speaker"] is not None:
+            last_known = w["speaker"]
+        elif last_known is not None:
+            w["speaker"] = last_known
+    # Fill any remaining gaps at the start (backward pass).
+    first_known = next((w["speaker"] for w in tagged if w["speaker"]), "SPEAKER_00")
+    for w in tagged:
+        if w["speaker"] is None:
+            w["speaker"] = first_known
+
+    # Rebuild segments: split on speaker change OR original segment boundary —
+    # same logic as alignment.assign_speakers_wordlevel for the local path.
+    rebuilt: list[dict] = []
+    cur = tagged[0]
+    c_speaker = cur["speaker"]
+    c_seg = cur["seg_idx"]
+    c_start = cur["start"]
+    c_end = cur["end"]
+    c_words: list[str] = [cur["word"]]
+
+    for tw in tagged[1:]:
+        if tw["speaker"] == c_speaker and tw["seg_idx"] == c_seg:
+            c_end = tw["end"]
+            c_words.append(tw["word"])
+        else:
+            rebuilt.append({
+                "start": c_start,
+                "end": c_end,
+                "text": " ".join(w.strip() for w in c_words),
+                "speaker": c_speaker,
+            })
+            c_speaker = tw["speaker"]
+            c_seg = tw["seg_idx"]
+            c_start = tw["start"]
+            c_end = tw["end"]
+            c_words = [tw["word"]]
+
+    rebuilt.append({
+        "start": c_start,
+        "end": c_end,
+        "text": " ".join(w.strip() for w in c_words),
+        "speaker": c_speaker,
+    })
+
+    return rebuilt
+
+
 def _normalize_speaker(raw_speaker: str) -> str:
     clean = raw_speaker.strip().replace("-", "_").upper()
     if clean.startswith("SPEAKER_"):

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -54,32 +54,61 @@ def diarize_episode(episode_id: str) -> str:
                 from app.services.fireworks_audio import (
                     diarization_segments_from_transcription,
                     assign_segment_speakers_from_words,
+                    rebuild_segments_from_words,
                 )
 
-                diarization_segments = diarization_segments_from_transcription(raw)
-                if diarization_segments:
-                    _diarize_segment_level(db, episode_id, diarization_segments)
-                else:
-                    transcript_segments = (
-                        db.query(Segment)
-                        .filter(Segment.episode_id == episode_id)
-                        .order_by(Segment.start_time)
-                        .all()
-                    )
-                    assignments = assign_segment_speakers_from_words(
-                        transcript_segments=[
-                            {"id": s.id, "start": s.start_time, "end": s.end_time}
-                            for s in transcript_segments
-                        ],
-                        raw=raw,
-                    )
-                    if not assignments:
-                        raise RuntimeError("No speaker labels found in Fireworks transcript words")
-                    for seg_id, speaker in assignments.items():
-                        db.query(Segment).filter(Segment.id == seg_id).update(
-                            {"speaker_label": speaker}
+                # Preferred path: rebuild segments from word-level speaker data,
+                # mirroring the WhisperX word-level alignment used by the local
+                # provider. This gives per-sentence granularity and correct
+                # speaker labels without the segment-level majority-overlap
+                # approximation.
+                rebuilt = rebuild_segments_from_words(raw)
+                if rebuilt:
+                    db.query(Segment).filter(Segment.episode_id == episode_id).delete()
+                    for seg in rebuilt:
+                        db.add(
+                            Segment(
+                                episode_id=episode_id,
+                                start_time=seg["start"],
+                                end_time=seg["end"],
+                                text=seg["text"],
+                                speaker_label=seg["speaker"],
+                            )
                         )
                     db.flush()
+                    logger.info(
+                        '"action": "diarize_fireworks_wordlevel_complete", "episode_id": "%s", '
+                        '"segments": %d, "speakers": %d',
+                        episode_id,
+                        len(rebuilt),
+                        len({s["speaker"] for s in rebuilt}),
+                    )
+                else:
+                    # Fallback: segment-level speaker assignment (no word data available).
+                    diarization_segments = diarization_segments_from_transcription(raw)
+                    if diarization_segments:
+                        _diarize_segment_level(db, episode_id, diarization_segments)
+                    else:
+                        transcript_segments = (
+                            db.query(Segment)
+                            .filter(Segment.episode_id == episode_id)
+                            .order_by(Segment.start_time)
+                            .all()
+                        )
+                        assignments = assign_segment_speakers_from_words(
+                            transcript_segments=[
+                                {"id": s.id, "start": s.start_time, "end": s.end_time}
+                                for s in transcript_segments
+                            ],
+                            raw=raw,
+                        )
+                        if not assignments:
+                            raise RuntimeError("No speaker labels found in Fireworks transcript words")
+                        for seg_id, speaker in assignments.items():
+                            db.query(Segment).filter(Segment.id == seg_id).update(
+                                {"speaker_label": speaker}
+                            )
+                        db.flush()
                 diarize_secs = round(time.monotonic() - t0, 1)
                 update_episode(
                     db, episode_id,

--- a/apps/pipeline/tests/unit/test_fireworks_audio_service.py
+++ b/apps/pipeline/tests/unit/test_fireworks_audio_service.py
@@ -10,6 +10,7 @@ from app.services.fireworks_audio import (
     _classify_http_error,
     diarization_segments_from_transcription,
     assign_segment_speakers_from_words,
+    rebuild_segments_from_words,
     transcribe,
 )
 
@@ -48,6 +49,103 @@ def test_assign_segment_speakers_from_words_majority_overlap():
 
     assert mapping[1] == "SPEAKER_00"
     assert mapping[2] == "SPEAKER_01"
+
+
+def _make_raw(words: list[dict], segments: list[dict] | None = None) -> dict:
+    """Helper to build a minimal Fireworks response dict for tests."""
+    return {"words": words, "segments": segments or [{"start": 0.0, "end": 999.0}]}
+
+
+class TestRebuildSegmentsFromWords:
+    def test_basic_two_speakers(self):
+        raw = _make_raw(
+            words=[
+                {"word": "Hello", "start": 0.0, "end": 0.5, "speaker_id": "0"},
+                {"word": "world", "start": 0.5, "end": 1.0, "speaker_id": "0"},
+                {"word": "Hi", "start": 1.1, "end": 1.5, "speaker_id": "1"},
+                {"word": "there", "start": 1.5, "end": 2.0, "speaker_id": "1"},
+            ],
+            segments=[{"start": 0.0, "end": 2.0}],
+        )
+        result = rebuild_segments_from_words(raw)
+        assert len(result) == 2
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "Hello world"
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 1.0
+        assert result[1]["speaker"] == "SPEAKER_01"
+        assert result[1]["text"] == "Hi there"
+
+    def test_segment_boundary_splits_same_speaker(self):
+        """Same speaker across two Fireworks segments → two DB segments."""
+        raw = _make_raw(
+            words=[
+                {"word": "First", "start": 0.0, "end": 0.5, "speaker_id": "0"},
+                {"word": "sentence.", "start": 0.5, "end": 1.0, "speaker_id": "0"},
+                {"word": "Second", "start": 1.1, "end": 1.5, "speaker_id": "0"},
+                {"word": "sentence.", "start": 1.5, "end": 2.0, "speaker_id": "0"},
+            ],
+            segments=[
+                {"start": 0.0, "end": 1.0},
+                {"start": 1.0, "end": 2.0},
+            ],
+        )
+        result = rebuild_segments_from_words(raw)
+        assert len(result) == 2
+        assert result[0]["text"] == "First sentence."
+        assert result[1]["text"] == "Second sentence."
+        assert result[0]["speaker"] == result[1]["speaker"] == "SPEAKER_00"
+
+    def test_speaker_change_within_segment(self):
+        """Speaker changes mid-sentence → split within the same Fireworks segment."""
+        raw = _make_raw(
+            words=[
+                {"word": "Yes", "start": 0.0, "end": 0.4, "speaker_id": "0"},
+                {"word": "but", "start": 0.4, "end": 0.7, "speaker_id": "1"},
+                {"word": "actually", "start": 0.7, "end": 1.0, "speaker_id": "1"},
+            ],
+            segments=[{"start": 0.0, "end": 1.0}],
+        )
+        result = rebuild_segments_from_words(raw)
+        assert len(result) == 2
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "Yes"
+        assert result[1]["speaker"] == "SPEAKER_01"
+        assert result[1]["text"] == "but actually"
+
+    def test_returns_empty_when_no_words(self):
+        raw = _make_raw(words=[])
+        assert rebuild_segments_from_words(raw) == []
+
+    def test_returns_empty_when_no_speaker_ids(self):
+        raw = _make_raw(
+            words=[
+                {"word": "Hello", "start": 0.0, "end": 0.5},
+                {"word": "world", "start": 0.5, "end": 1.0},
+            ]
+        )
+        assert rebuild_segments_from_words(raw) == []
+
+    def test_propagates_speaker_to_unlabeled_words(self):
+        """Words without speaker_id should inherit from adjacent labeled words."""
+        raw = _make_raw(
+            words=[
+                {"word": "Hello", "start": 0.0, "end": 0.5, "speaker_id": "0"},
+                {"word": "world", "start": 0.5, "end": 1.0},  # no speaker_id
+            ]
+        )
+        result = rebuild_segments_from_words(raw)
+        assert len(result) == 1
+        assert result[0]["speaker"] == "SPEAKER_00"
+        assert result[0]["text"] == "Hello world"
+
+    def test_normalizes_speaker_ids(self):
+        """Numeric speaker IDs like "0", "1" should be normalized to SPEAKER_00."""
+        raw = _make_raw(
+            words=[{"word": "Test", "start": 0.0, "end": 0.5, "speaker_id": "2"}]
+        )
+        result = rebuild_segments_from_words(raw)
+        assert result[0]["speaker"] == "SPEAKER_02"
 
 
 def test_classify_http_error_marks_429_and_5xx_as_retryable():


### PR DESCRIPTION
## Summary

- Added `rebuild_segments_from_words()` to `fireworks_audio.py` that mirrors the local WhisperX word-level path: groups consecutive same-speaker words within original Fireworks segment boundaries into fine-grained DB segments, splitting on speaker changes or segment boundaries
- Updated the Fireworks diarize path in `diarize.py` to prefer this word-level rebuild over the previous coarse segment-level assignment
- Kept the existing fallback chain (`diarization_segments_from_transcription` → `assign_segment_speakers_from_words`) for cases where word-level speaker data is unavailable

## Root Cause

The local WhisperX path calls `assign_speakers_wordlevel()` which rebuilds segments at word level — producing many fine-grained segments per speaker turn with sub-timestamps. The Fireworks path only called `_diarize_segment_level()`, which assigns speaker labels to whatever segments Fireworks returned without splitting them further — so each speaker turn produced just one coarse DB segment with no intermediate timestamps.

## Testing

- 7 new unit tests in `TestRebuildSegmentsFromWords` covering: basic two-speaker split, segment boundary splitting same speaker, speaker change within a segment, empty words, no speaker IDs, speaker propagation to unlabeled words, and speaker ID normalization
- All 12 tests in `test_fireworks_audio_service.py` pass

Closes #349