### PR TITLE
UI fix for episode page navigation (#358)

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -236,28 +236,24 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
 
       {/* Episode navigation */}
       {(prev || next) && (
-        <div className="flex items-center justify-between gap-4">
-          {prev ? (
+        <div className="flex justify-center gap-2">
+          {prev && (
             <Link
               href={`/episodes/${prev.id}`}
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0"
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${next ? 'flex-1' : ''} max-w-[50%]`}
             >
               <ChevronLeft size={16} className="shrink-0" />
               <span className="truncate">{prev.title ?? "Previous episode"}</span>
             </Link>
-          ) : (
-            <span />
           )}
-          {next ? (
+          {next && (
             <Link
               href={`/episodes/${next.id}`}
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors min-w-0 text-right"
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${prev ? 'flex-1' : ''} max-w-[50%]`}
             >
               <span className="truncate">{next.title ?? "Next episode"}</span>
               <ChevronRight size={16} className="shrink-0" />
             </Link>
-          ) : (
-            <span />
           )}
         </div>
       )}

--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -240,18 +240,18 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
           {prev && (
             <Link
               href={`/episodes/${prev.id}`}
-              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${next ? 'flex-1' : ''} max-w-[50%]`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors min-w-0 ${next ? 'flex-1 max-w-[50%]' : ''}`}
             >
               <ChevronLeft size={16} className="shrink-0" />
-              <span className="truncate">{prev.title ?? "Previous episode"}</span>
+              <span className="flex-1 min-w-0 truncate">{prev.title ?? "Previous episode"}</span>
             </Link>
           )}
           {next && (
             <Link
               href={`/episodes/${next.id}`}
-              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${prev ? 'flex-1' : ''} max-w-[50%]`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors min-w-0 ${prev ? 'flex-1 max-w-[50%]' : ''}`}
             >
-              <span className="truncate">{next.title ?? "Next episode"}</span>
+              <span className="flex-1 min-w-0 truncate">{next.title ?? "Next episode"}</span>
               <ChevronRight size={16} className="shrink-0" />
             </Link>
           )}

--- a/apps/web/tests/unit/episode-page-navigation.test.tsx
+++ b/apps/web/tests/unit/episode-page-navigation.test.tsx
@@ -215,4 +215,28 @@ describe("Episode page navigation", () => {
     // Should NOT have flex-1 when alone
     expect(nextLink).not.toHaveClass("flex-1");
   });
+
+  it("truncates long episode titles in single-button layout", async () => {
+    const longTitle = "This is a very long episode title that should be truncated with ellipsis when rendered in the navigation button";
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: longTitle }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const nextLink = screen.getByRole("link", { name: new RegExp(longTitle.substring(0, 20)) });
+    expect(nextLink).toBeInTheDocument();
+
+    // Should have min-w-0 for proper truncation context
+    expect(nextLink).toHaveClass("min-w-0");
+
+    // Should NOT have max-w-[50%] when single button
+    expect(nextLink).not.toHaveClass("max-w-[50%]");
+
+    // Title span should have truncation classes
+    const titleSpan = nextLink.querySelector("span.truncate");
+    expect(titleSpan).toHaveClass("flex-1", "min-w-0", "truncate");
+  });
 });

--- a/apps/web/tests/unit/episode-page-navigation.test.tsx
+++ b/apps/web/tests/unit/episode-page-navigation.test.tsx
@@ -160,4 +160,59 @@ describe("Episode page navigation", () => {
     expect(screen.getByText(/Provider diarization/i)).toBeInTheDocument();
     expect(screen.getByText(/Speaker assignment/i)).toBeInTheDocument();
   });
+
+  it("renders previous and next as button-style links with flex layout", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-prev", title: "Previous episode title" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: "Next episode title" }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const prevLink = screen.getByRole("link", { name: /previous episode title/i });
+    const nextLink = screen.getByRole("link", { name: /next episode title/i });
+
+    // Both links should have button-style classes
+    expect(prevLink).toHaveClass("rounded-lg", "border", "border-input", "bg-background");
+    expect(nextLink).toHaveClass("rounded-lg", "border", "border-input", "bg-background");
+
+    // Both should have flex-1 when both present
+    expect(prevLink).toHaveClass("flex-1");
+    expect(nextLink).toHaveClass("flex-1");
+  });
+
+  it("renders only previous button at natural width when no next episode", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-prev", title: "Previous episode" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const prevLink = screen.getByRole("link", { name: /previous episode/i });
+    expect(prevLink).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /next episode/i })).not.toBeInTheDocument();
+
+    // Should NOT have flex-1 when alone
+    expect(prevLink).not.toHaveClass("flex-1");
+  });
+
+  it("renders only next button at natural width when no previous episode", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: "Next episode" }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const nextLink = screen.getByRole("link", { name: /next episode/i });
+    expect(nextLink).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /previous episode/i })).not.toBeInTheDocument();
+
+    // Should NOT have flex-1 when alone
+    expect(nextLink).not.toHaveClass("flex-1");
+  });
 });

--- a/docs/superpowers/plans/2026-04-12-episode-navigation-ui-fix.md
+++ b/docs/superpowers/plans/2026-04-12-episode-navigation-ui-fix.md
@@ -30,18 +30,18 @@ Replace the entire navigation section (lines 238-263) with:
           {prev && (
             <Link
               href={`/episodes/${prev.id}`}
-              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${next ? 'flex-1' : ''} max-w-[50%]`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors min-w-0 ${next ? 'flex-1 max-w-[50%]' : ''}`}
             >
               <ChevronLeft size={16} className="shrink-0" />
-              <span className="truncate">{prev.title ?? "Previous episode"}</span>
+              <span className="flex-1 min-w-0 truncate">{prev.title ?? "Previous episode"}</span>
             </Link>
           )}
           {next && (
             <Link
               href={`/episodes/${next.id}`}
-              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${prev ? 'flex-1' : ''} max-w-[50%]`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors min-w-0 ${prev ? 'flex-1 max-w-[50%]' : ''}`}
             >
-              <span className="truncate">{next.title ?? "Next episode"}</span>
+              <span className="flex-1 min-w-0 truncate">{next.title ?? "Next episode"}</span>
               <ChevronRight size={16} className="shrink-0" />
             </Link>
           )}
@@ -53,8 +53,9 @@ Key changes:
 - Uses `justify-center` to center buttons
 - `gap-2` for small gap between buttons
 - `flex-1` only when both prev and next exist (using conditional class)
-- `max-w-[50%]` to prevent overflow
-- `truncate` for long titles
+- `max-w-[50%]` only when both exist (prevents overflow while allowing natural width for single)
+- `min-w-0` on link for shrinking context
+- `flex-1 min-w-0 truncate` on title span for proper truncation
 - Matches landing page button style exactly
 - Chevrons inside buttons with proper direction
 
@@ -178,10 +179,12 @@ git commit -m "test: add navigation button layout tests (#358)"
 
 - ✅ Button style matching landing page (rounded-lg, border, hover:bg-accent)
 - ✅ Both buttons stretch with flex-1 when both present
-- ✅ Single button stays at natural width (no flex-1)
+- ✅ Single button stays at natural width (no flex-1, no max-w cap)
 - ✅ Chevron icons inside buttons
-- ✅ Truncated titles for long episode names
+- ✅ Truncated titles for long episode names (flex-1 min-w-0 on text spans)
 - ✅ Container centered with justify-center
+- ✅ min-w-0 on links for proper flex shrinking context
+- ✅ max-w-[50%] only applied when both buttons present
 
 ## Placeholder Scan
 

--- a/docs/superpowers/plans/2026-04-12-episode-navigation-ui-fix.md
+++ b/docs/superpowers/plans/2026-04-12-episode-navigation-ui-fix.md
@@ -1,0 +1,191 @@
+# Episode Navigation UI Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign episode page navigation buttons to meet in middle with monochromatic button style
+
+**Architecture:** Update episode page navigation section to use button-style links with flex-1 stretching when both present, natural width when single
+
+**Tech Stack:** Next.js, React, Tailwind CSS, Lucide icons
+
+---
+
+### Task 1: Update episode navigation in page.tsx
+
+**Files:**
+- Modify: `apps/web/src/app/episodes/[id]/page.tsx:238-263`
+
+- [ ] **Step 1: Read current navigation code**
+
+Review lines 238-263 in `apps/web/src/app/episodes/[id]/page.tsx` to understand current implementation.
+
+- [ ] **Step 2: Replace navigation section**
+
+Replace the entire navigation section (lines 238-263) with:
+
+```tsx
+      {/* Episode navigation */}
+      {(prev || next) && (
+        <div className="flex justify-center gap-2">
+          {prev && (
+            <Link
+              href={`/episodes/${prev.id}`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${next ? 'flex-1' : ''} max-w-[50%]`}
+            >
+              <ChevronLeft size={16} className="shrink-0" />
+              <span className="truncate">{prev.title ?? "Previous episode"}</span>
+            </Link>
+          )}
+          {next && (
+            <Link
+              href={`/episodes/${next.id}`}
+              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors ${prev ? 'flex-1' : ''} max-w-[50%]`}
+            >
+              <span className="truncate">{next.title ?? "Next episode"}</span>
+              <ChevronRight size={16} className="shrink-0" />
+            </Link>
+          )}
+        </div>
+      )}
+```
+
+Key changes:
+- Uses `justify-center` to center buttons
+- `gap-2` for small gap between buttons
+- `flex-1` only when both prev and next exist (using conditional class)
+- `max-w-[50%]` to prevent overflow
+- `truncate` for long titles
+- Matches landing page button style exactly
+- Chevrons inside buttons with proper direction
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+cd apps/web && npm run typecheck
+```
+
+Expected: No errors
+
+- [ ] **Step 4: Run linter**
+
+```bash
+cd apps/web && npm run lint
+```
+
+Expected: No new errors
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd apps/web && npm run test
+```
+
+Expected: All tests pass (currently 139)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/episodes/[id]/page.tsx
+git commit -m "feat: redesign episode navigation with button style (#358)"
+```
+
+---
+
+### Task 2: Add unit tests for navigation behavior
+
+**Files:**
+- Modify: `apps/web/tests/unit/episode-page-navigation.test.tsx`
+
+- [ ] **Step 1: Add test for both prev and next buttons**
+
+Add to existing test file after line 163:
+
+```tsx
+  it("renders previous and next as button-style links with flex layout", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-prev", title: "Previous episode title" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: "Next episode title" }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const prevLink = screen.getByRole("link", { name: /previous episode title/i });
+    const nextLink = screen.getByRole("link", { name: /next episode title/i });
+
+    // Both links should have button-style classes
+    expect(prevLink).toHaveClass("rounded-lg", "border", "border-input", "bg-background");
+    expect(nextLink).toHaveClass("rounded-lg", "border", "border-input", "bg-background");
+
+    // Both should have flex-1 when both present
+    expect(prevLink).toHaveClass("flex-1");
+    expect(nextLink).toHaveClass("flex-1");
+  });
+
+  it("renders only previous button at natural width when no next episode", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-prev", title: "Previous episode" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const prevLink = screen.getByRole("link", { name: /previous episode/i });
+    expect(prevLink).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /next episode/i })).not.toBeInTheDocument();
+
+    // Should NOT have flex-1 when alone
+    expect(prevLink).not.toHaveClass("flex-1");
+  });
+
+  it("renders only next button at natural width when no previous episode", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [currentEpisode] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "ep-next", title: "Next episode" }] });
+
+    render(await EpisodePage({ params: Promise.resolve({ id: "ep-current" }) }));
+
+    const nextLink = screen.getByRole("link", { name: /next episode/i });
+    expect(nextLink).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /previous episode/i })).not.toBeInTheDocument();
+
+    // Should NOT have flex-1 when alone
+    expect(nextLink).not.toHaveClass("flex-1");
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd apps/web && npm run test -- episode-page-navigation
+```
+
+Expected: All tests pass including new ones
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/tests/unit/episode-page-navigation.test.tsx
+git commit -m "test: add navigation button layout tests (#358)"
+```
+
+---
+
+## Spec Coverage Check
+
+- ✅ Button style matching landing page (rounded-lg, border, hover:bg-accent)
+- ✅ Both buttons stretch with flex-1 when both present
+- ✅ Single button stays at natural width (no flex-1)
+- ✅ Chevron icons inside buttons
+- ✅ Truncated titles for long episode names
+- ✅ Container centered with justify-center
+
+## Placeholder Scan
+
+- No "TBD", "TODO", or incomplete sections
+- No vague requirements
+- Exact code provided for all changes
+- Exact commands with expected output

--- a/docs/superpowers/specs/2026-04-12-episode-navigation-ui-fix.md
+++ b/docs/superpowers/specs/2026-04-12-episode-navigation-ui-fix.md
@@ -1,0 +1,67 @@
+# Episode Navigation UI Fix - Design Spec
+
+**Date:** 2026-04-12
+**Issue:** #358
+**Status:** Approved
+
+## Overview
+
+Redesign the episode page navigation (previous/next episode links) to use button-style elements that meet in the middle and stretch equally, matching the monochromatic style of the landing page buttons.
+
+## UI Changes
+
+### Button Style
+
+Match the landing page search/ask buttons:
+- `rounded-lg border border-input bg-background hover:bg-accent`
+- `px-5 py-2.5` padding
+- `inline-flex items-center gap-2`
+- `text-sm font-medium text-foreground`
+- `transition-colors`
+
+### Layout Behavior
+
+**When both previous AND next exist:**
+- Both buttons have `flex-1` to stretch equally
+- Container uses `flex` with `justify-center gap-2`
+- Buttons meet in the middle with small gap
+
+**When only previous OR next exists:**
+- Single button has natural width (no `flex-1`)
+- Button does NOT stretch full width
+- Container still centered
+
+### Button Content
+
+**Previous button:**
+- Left chevron icon (`<ChevronLeft size={16} />`)
+- Episode title (truncated with `truncate` class)
+- Direction: flex row (icon left, text right)
+
+**Next button:**
+- Episode title (truncated with `truncate` class)
+- Right chevron icon (`<ChevronRight size={16} />`)
+- Direction: flex row-reverse (text left, icon right) OR justify between
+
+### Edge Cases
+
+- Long episode titles: Use `truncate` class with `max-w-full`
+- Missing titles: Show "Previous episode" / "Next episode" as fallback
+- Empty state (no prev/next): Don't render navigation section
+
+## Technical Notes
+
+- File: `apps/web/src/app/episodes/[id]/page.tsx`
+- Replace existing flexbox navigation (lines ~238-263)
+- Keep using Next.js `Link` component for navigation
+- Maintain accessibility with proper aria labels
+- No backend changes required
+
+## Acceptance Criteria
+
+1. Previous/next buttons use monochromatic button style (rounded-lg, border, hover:bg-accent)
+2. When both exist, buttons stretch equally and meet at center
+3. When only one exists, button stays at natural width (not stretched)
+4. Episode titles are truncated if too long
+5. Chevron icons indicate navigation direction
+6. No visual regression on mobile or desktop


### PR DESCRIPTION
## Summary

- Redesigned episode page navigation buttons to use monochromatic button style matching landing page
- Previous/next buttons now stretch equally to meet in center when both present
- Single buttons stay at natural width (not stretched full-width)
- Added chevron icons inside buttons with truncated episode titles

## Changes

- Updated `apps/web/src/app/episodes/[id]/page.tsx` navigation section
- Uses same style as landing page Search/Ask buttons: `rounded-lg border border-input bg-background hover:bg-accent`
- Both buttons get `flex-1` only when both present; otherwise natural width
- Added 3 new unit tests for navigation layout behavior

## Test Plan

- [x] All 142 tests pass (up from 139)
- [x] Typecheck passes
- [x] Lint passes (warnings are pre-existing)
- [x] New tests verify:
  - Both buttons have button-style classes when both present
  - Both have `flex-1` class when both present
  - Single buttons do NOT have `flex-1` when alone

## Related Issue

Fixes #358