### PR TITLE
Add episode title search filter (#356)

### DIFF
--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -7,9 +7,12 @@ import {
   ArrowUpDown,
   ChevronDown,
   ChevronUp,
+  Search,
+  X,
 } from "lucide-react";
 
 import ReprocessButton from "./ReprocessButton";
+import { Input } from "@/components/ui/input";
 
 export interface SpeakerNameTag {
   display_name: string;
@@ -184,7 +187,15 @@ function ProcessingProgress({ status }: { status: string }) {
   );
 }
 
-function StatsBar({ episodes }: { episodes: EnrichedEpisode[] }) {
+function StatsBar({
+  episodes,
+  filteredCount,
+  searchQuery
+}: {
+  episodes: EnrichedEpisode[];
+  filteredCount: number;
+  searchQuery: string;
+}) {
   const counts = useMemo(() => {
     const c = { total: episodes.length, done: 0, processing: 0, failed: 0, pending: 0 };
     for (const ep of episodes) {
@@ -198,7 +209,13 @@ function StatsBar({ episodes }: { episodes: EnrichedEpisode[] }) {
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-      <span className="font-medium text-foreground">{counts.total} episodes</span>
+      {searchQuery ? (
+        <span className="font-medium text-foreground">
+          Showing {filteredCount} of {counts.total} episodes
+        </span>
+      ) : (
+        <span className="font-medium text-foreground">{counts.total} episodes</span>
+      )}
       <span className="text-muted-foreground/50">·</span>
       <span>{counts.done} transcribed</span>
       {counts.processing > 0 && (
@@ -234,6 +251,7 @@ export default function EpisodesList({ episodes, feedId }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("published_at");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [expandedErrors, setExpandedErrors] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     try {
@@ -252,8 +270,16 @@ export default function EpisodesList({ episodes, feedId }: Props) {
     } catch {}
   }, [sortKey, sortDir]);
 
-  const sorted = useMemo(() => {
-    const arr = [...episodes];
+  const filteredAndSorted = useMemo(() => {
+    // First filter by search query
+    const filtered = searchQuery
+      ? episodes.filter((ep) =>
+          ep.title?.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+      : episodes;
+
+    // Then sort
+    const arr = [...filtered];
     arr.sort((a, b) => {
       let cmp = 0;
       switch (sortKey) {
@@ -283,7 +309,7 @@ export default function EpisodesList({ episodes, feedId }: Props) {
       return sortDir === "asc" ? cmp : -cmp;
     });
     return arr;
-  }, [episodes, sortKey, sortDir]);
+  }, [episodes, sortKey, sortDir, searchQuery]);
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
@@ -310,7 +336,29 @@ export default function EpisodesList({ episodes, feedId }: Props) {
 
   return (
     <div className="space-y-4">
-      <StatsBar episodes={episodes} />
+      <StatsBar episodes={episodes} filteredCount={filteredAndSorted.length} searchQuery={searchQuery} />
+
+      {/* Search input */}
+      <div className="relative">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder="Search episodes..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-10 pr-10"
+          aria-label="Search episodes by title"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => setSearchQuery("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
 
       <div className="flex flex-wrap items-center gap-2">
         <ArrowUpDown size={14} className="text-muted-foreground" />
@@ -335,7 +383,12 @@ export default function EpisodesList({ episodes, feedId }: Props) {
       </div>
 
       <div className="space-y-2">
-        {sorted.map((ep) => {
+        {filteredAndSorted.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">
+            No episodes match your search
+          </p>
+        ) : (
+          filteredAndSorted.map((ep) => {
           const isProcessing = PROCESSING_STEPS.includes(ep.status);
           const isFailed = ep.status === "failed";
           const lang = ep.language?.toLowerCase() ?? "";
@@ -487,7 +540,7 @@ export default function EpisodesList({ episodes, feedId }: Props) {
               )}
             </div>
           );
-        })}
+        }))}
       </div>
     </div>
   );

--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -272,9 +272,10 @@ export default function EpisodesList({ episodes, feedId }: Props) {
 
   const filteredAndSorted = useMemo(() => {
     // First filter by search query
+    const normalizedQuery = searchQuery.toLowerCase();
     const filtered = searchQuery
       ? episodes.filter((ep) =>
-          ep.title?.toLowerCase().includes(searchQuery.toLowerCase())
+          ep.title?.toLowerCase().includes(normalizedQuery)
         )
       : episodes;
 

--- a/apps/web/tests/unit/EpisodesList.test.tsx
+++ b/apps/web/tests/unit/EpisodesList.test.tsx
@@ -153,4 +153,356 @@ describe("EpisodesList", () => {
     expect(screen.queryByText(/Transcribed:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Diarized:/)).not.toBeInTheDocument();
   });
+
+  it("filters episodes by title case-insensitively", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for "test" should match "Test Episode One"
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Should show only "Test Episode One"
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+  });
+
+  it("filters episodes by partial title match", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for "ep" should match both episodes
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "ep" } });
+
+    // Should show both episodes
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+
+    // Search for "one" should match only first episode
+    fireEvent.change(searchInput, { target: { value: "one" } });
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no episodes match search", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for something that doesn't match
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "xyz" } });
+
+    // Should show empty state message
+    expect(screen.getByText("No episodes match your search")).toBeInTheDocument();
+    expect(screen.queryByText("Test Episode One")).not.toBeInTheDocument();
+  });
+
+  it("clear button resets search and shows all episodes", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search to filter
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Only first episode should be visible
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+
+    // Click clear button
+    const clearButton = screen.getByLabelText("Clear search");
+    fireEvent.click(clearButton);
+
+    // Both episodes should be visible again
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+  });
+
+  it("shows filtered count in stats bar", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Initially shows total count
+    expect(screen.getByText(/2 episodes/)).toBeInTheDocument();
+
+    // Search to filter
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Should show "Showing X of Y" format
+    expect(screen.getByText(/Showing 1 of 2 episodes/)).toBeInTheDocument();
+  });
+
+  it("shows all episodes when search query is empty", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Both episodes visible initially
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+
+    // Type and then clear
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+    fireEvent.change(searchInput, { target: { value: "" } });
+
+    // Both episodes should still be visible
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+  });
 });

--- a/docs/superpowers/plans/2026-04-12-episode-title-filter.md
+++ b/docs/superpowers/plans/2026-04-12-episode-title-filter.md
@@ -1,0 +1,650 @@
+# Episode Title Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add search input to filter episodes by title in EpisodesList component
+
+**Architecture:** Add search state and filter logic to EpisodesList, use existing Input component with Search/X icons, display filtered stats and empty state
+
+**Tech Stack:** Next.js, React, Tailwind CSS, Lucide icons, shadcn/ui Input component
+
+---
+
+### Task 1: Add search filter to EpisodesList
+
+**Files:**
+- Modify: `apps/web/src/components/EpisodesList.tsx:1-15` (imports)
+- Modify: `apps/web/src/components/EpisodesList.tsx:233-240` (add search state)
+- Modify: `apps/web/src/components/EpisodesList.tsx:255-290` (add filtered episodes memo)
+- Modify: `apps/web/src/components/EpisodesList.tsx:311-340` (add search input UI)
+
+- [ ] **Step 1: Update imports**
+
+Add Search and X icons to imports, add Input component import:
+
+```tsx
+import {
+  AlertTriangle,
+  ArrowUpDown,
+  ChevronDown,
+  ChevronUp,
+  Search,
+  X,
+} from "lucide-react";
+
+import ReprocessButton from "./ReprocessButton";
+import { Input } from "@/components/ui/input";
+```
+
+- [ ] **Step 2: Add search state**
+
+Add after existing useState declarations (around line 236):
+
+```tsx
+  const [searchQuery, setSearchQuery] = useState("");
+```
+
+- [ ] **Step 3: Add filtered episodes memo**
+
+Replace the sorted useMemo (lines 255-290) to work with filtered episodes. The filtered and sorted logic should be:
+
+```tsx
+  const filteredAndSorted = useMemo(() => {
+    // First filter by search query
+    const filtered = searchQuery
+      ? episodes.filter((ep) =>
+          ep.title?.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+      : episodes;
+
+    // Then sort
+    const arr = [...filtered];
+    arr.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "status":
+          cmp = (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99);
+          break;
+        case "duration_secs":
+          cmp = (a.duration_secs ?? 0) - (b.duration_secs ?? 0);
+          break;
+        case "processed_at": {
+          const ta = a.processed_at ? new Date(a.processed_at).getTime() : 0;
+          const tb = b.processed_at ? new Date(b.processed_at).getTime() : 0;
+          cmp = ta - tb;
+          break;
+        }
+        case "title":
+          cmp = (a.title ?? "").localeCompare(b.title ?? "");
+          break;
+        case "published_at":
+        default: {
+          const pa = a.published_at ? new Date(a.published_at).getTime() : 0;
+          const pb = b.published_at ? new Date(b.published_at).getTime() : 0;
+          cmp = pa - pb;
+          break;
+        }
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return arr;
+  }, [episodes, sortKey, sortDir, searchQuery]);
+```
+
+- [ ] **Step 4: Update StatsBar to show filtered count**
+
+Replace the StatsBar call (line 313) to pass filtered info:
+
+```tsx
+      <StatsBar episodes={episodes} filteredCount={filteredAndSorted.length} searchQuery={searchQuery} />
+```
+
+- [ ] **Step 5: Add search input UI**
+
+Add after StatsBar, before sort controls (after line 313, before line 315):
+
+```tsx
+      {/* Search input */}
+      <div className="relative">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder="Search episodes..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-10 pr-10"
+          aria-label="Search episodes by title"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => setSearchQuery("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+```
+
+- [ ] **Step 6: Replace sorted with filteredAndSorted in render**
+
+Change line 338 from `{sorted.map((ep) => {` to:
+
+```tsx
+      <div className="space-y-2">
+        {filteredAndSorted.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">
+            No episodes match your search
+          </p>
+        ) : (
+          filteredAndSorted.map((ep) => {
+```
+
+And close the conditional at the end (after line 489, before `</div>` closes):
+
+```tsx
+          })
+        )}
+      </div>
+```
+
+- [ ] **Step 7: Update StatsBar component**
+
+Modify the StatsBar component (around line 187) to accept and display filtered info:
+
+```tsx
+function StatsBar({ 
+  episodes, 
+  filteredCount, 
+  searchQuery 
+}: { 
+  episodes: EnrichedEpisode[]; 
+  filteredCount: number;
+  searchQuery: string;
+}) {
+  const counts = useMemo(() => {
+    const c = { total: episodes.length, done: 0, processing: 0, failed: 0, pending: 0 };
+    for (const ep of episodes) {
+      if (ep.status === "done") c.done++;
+      else if (ep.status === "failed") c.failed++;
+      else if (ep.status === "pending") c.pending++;
+      else c.processing++;
+    }
+    return c;
+  }, [episodes]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+      {searchQuery ? (
+        <span className="font-medium text-foreground">
+          Showing {filteredCount} of {counts.total} episodes
+        </span>
+      ) : (
+        <span className="font-medium text-foreground">{counts.total} episodes</span>
+      )}
+      <span className="text-muted-foreground/50">·</span>
+      <span>{counts.done} transcribed</span>
+      {counts.processing > 0 && (
+        <>
+          <span className="text-muted-foreground/50">·</span>
+          <span className="text-blue-600 dark:text-blue-400">{counts.processing} processing</span>
+        </>
+      )}
+      {counts.failed > 0 && (
+        <>
+          <span className="text-muted-foreground/50">·</span>
+          <span className="text-red-600 dark:text-red-400">{counts.failed} failed</span>
+        </>
+      )}
+      {counts.pending > 0 && (
+        <>
+          <span className="text-muted-foreground/50">·</span>
+          <span>{counts.pending} pending</span>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Run typecheck**
+
+```bash
+cd apps/web && npm run typecheck
+```
+
+Expected: No errors
+
+- [ ] **Step 9: Run linter**
+
+```bash
+cd apps/web && npm run lint
+```
+
+Expected: No new errors
+
+- [ ] **Step 10: Run tests**
+
+```bash
+cd apps/web && npm run test
+```
+
+Expected: All tests pass (currently 143)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/web/src/components/EpisodesList.tsx
+git commit -m "feat: add episode title search filter (#356)"
+```
+
+---
+
+### Task 2: Add unit tests for search filter
+
+**Files:**
+- Modify: `apps/web/tests/unit/EpisodesList.test.tsx`
+
+- [ ] **Step 1: Add test for case-insensitive filtering**
+
+Add after the existing tests (around line 156):
+
+```tsx
+  it("filters episodes by title case-insensitively", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for "test" should match "Test Episode One"
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Should show only "Test Episode One"
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+  });
+
+  it("filters episodes by partial title match", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for "ep" should match both episodes
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "ep" } });
+
+    // Should show both episodes
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+
+    // Search for "one" should match only first episode
+    fireEvent.change(searchInput, { target: { value: "one" } });
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no episodes match search", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search for something that doesn't match
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "xyz" } });
+
+    // Should show empty state message
+    expect(screen.getByText("No episodes match your search")).toBeInTheDocument();
+    expect(screen.queryByText("Test Episode One")).not.toBeInTheDocument();
+  });
+
+  it("clear button resets search and shows all episodes", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Search to filter
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Only first episode should be visible
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+
+    // Click clear button
+    const clearButton = screen.getByLabelText("Clear search");
+    fireEvent.click(clearButton);
+
+    // Both episodes should be visible again
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+  });
+
+  it("shows filtered count in stats bar", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Initially shows total count
+    expect(screen.getByText(/2 episodes/)).toBeInTheDocument();
+
+    // Search to filter
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+
+    // Should show "Showing X of Y" format
+    expect(screen.getByText(/Showing 1 of 2 episodes/)).toBeInTheDocument();
+  });
+
+  it("shows all episodes when search query is empty", () => {
+    const mockEpisodes: EnrichedEpisode[] = [
+      {
+        id: "ep-1",
+        title: "Test Episode One",
+        published_at: "2026-04-01T10:00:00.000Z",
+        processed_at: "2026-04-01T11:00:00.000Z",
+        duration_secs: 3600,
+        language: "en",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 120,
+        diarize_duration_secs: 60,
+        inference_provider_used: "fireworks",
+        fireworks_audio_minutes: 60,
+        fireworks_stt_cost_usd: 0.0123,
+        speaker_count: 2,
+        speaker_name_tags: [],
+      },
+      {
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        processed_at: null,
+        duration_secs: 1800,
+        language: "de",
+        status: "done",
+        has_diarization: true,
+        diarization_error: null,
+        error_class: null,
+        error_message: null,
+        retry_count: 0,
+        retry_max: 3,
+        transcribe_duration_secs: 90,
+        diarize_duration_secs: 45,
+        inference_provider_used: "local",
+        fireworks_audio_minutes: null,
+        fireworks_stt_cost_usd: null,
+        speaker_count: 3,
+        speaker_name_tags: [],
+      },
+    ];
+
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    // Both episodes visible initially
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+
+    // Type and then clear
+    const searchInput = screen.getByLabelText("Search episodes by title");
+    fireEvent.change(searchInput, { target: { value: "test" } });
+    fireEvent.change(searchInput, { target: { value: "" } });
+
+    // Both episodes should still be visible
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd apps/web && npm run test -- EpisodesList
+```
+
+Expected: All 11 tests pass (6 existing + 5 new)
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd apps/web && npm run test
+```
+
+Expected: All tests pass (143 existing + 5 new = 148)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/tests/unit/EpisodesList.test.tsx
+git commit -m "test: add episode search filter tests (#356)"
+```
+
+---
+
+## Spec Coverage Check
+
+- ✅ Search input with Search icon
+- ✅ Clear button (X) when text entered
+- ✅ Case-insensitive filtering
+- ✅ Partial title match
+- ✅ Real-time filtering
+- ✅ "Showing X of Y episodes" stats
+- ✅ Empty state message
+- ✅ Sort controls work on filtered results
+- ✅ All existing tests pass
+- ✅ New tests cover filtering behavior
+
+## Placeholder Scan
+
+- No "TBD", "TODO", or incomplete sections
+- No vague requirements
+- Exact code provided for all changes
+- Exact commands with expected output

--- a/docs/superpowers/specs/2026-04-12-episode-title-filter.md
+++ b/docs/superpowers/specs/2026-04-12-episode-title-filter.md
@@ -1,0 +1,105 @@
+# Episode Title Filter - Design Spec
+
+**Date:** 2026-04-12
+**Issue:** #356
+**Status:** Approved
+
+## Overview
+
+Add a search input field to the EpisodesList component to allow users to quickly filter episodes by title. This addresses the need to find specific episodes without scrolling through potentially long lists.
+
+## UI Changes
+
+### Search Input Placement
+
+- Location: Above the sort controls in EpisodesList component
+- Full-width input with search icon (lucide-react `Search` icon)
+- Uses existing `Input` component from `@/components/ui/input`
+- Clear button (×) appears when text is entered (lucide-react `X` icon)
+
+### Search Input Styling
+
+- Border style: `border-input` (matches existing form elements)
+- Background: `bg-background`
+- Placeholder text: "Search episodes..."
+- Left padding for search icon
+- Right padding for clear button
+- Focus ring: existing `focus-visible:ring-2 focus-visible:ring-ring`
+
+### Filter Behavior
+
+- Real-time filtering as user types (no debounce needed for client-side)
+- Case-insensitive partial title match
+- Filter applied to displayed episodes list
+- Sort order preserved on filtered results
+
+### Stats Display
+
+- When filtered: "Showing X of Y episodes" (where X = filtered count, Y = total)
+- When not filtered: Current stats display unchanged
+- Clear filter resets to full list
+
+### Empty State
+
+- When search returns no results: "No episodes match your search"
+- Displayed in place of episode list
+- Keep search input visible (allow user to modify query)
+
+## Technical Design
+
+### State Management
+
+- Add `searchQuery` state (string, initially empty)
+- Use `useMemo` to compute `filteredEpisodes` based on search query
+- Filtering logic: `episode.title?.toLowerCase().includes(query.toLowerCase())`
+
+### Component Changes
+
+**EpisodesList.tsx:**
+- Add `Search` and `X` imports from lucide-react
+- Add `Input` import from `@/components/ui/input`
+- Add search state and filter logic in `useMemo`
+- Render search input above sort controls
+- Update StatsBar or add inline stats showing "Showing X of Y"
+- Handle empty filtered state
+
+### Performance
+
+- `useMemo` for filtered results prevents unnecessary re-renders
+- Filtering happens on already-loaded data (no API calls)
+- Minimal impact on render performance
+
+### Accessibility
+
+- Input has proper `aria-label` or visible label
+- Clear button has `aria-label="Clear search"`
+- Keyboard navigation works (Tab to input, Escape to clear)
+
+## Testing
+
+### Unit Tests
+
+1. **Filter by title (case-insensitive):** Verify "test" matches "Test Episode"
+2. **Partial match:** Verify "ep" matches "My Episode"
+3. **No results state:** Verify "xyz" shows empty state message
+4. **Clear button:** Verify clicking × clears input and shows all episodes
+5. **Stats update:** Verify "Showing X of Y" updates correctly when filtering
+6. **Empty query:** Verify all episodes shown when query is empty
+
+## Acceptance Criteria
+
+1. Search input visible in EpisodesList
+2. Typing filters episodes in real-time (case-insensitive)
+3. Partial title matches work
+4. "Showing X of Y episodes" displayed when filtered
+5. Clear button (×) appears when text entered
+6. Clear button resets filter
+7. "No episodes match your search" shown when no results
+8. Sort controls continue to work on filtered results
+9. All existing tests pass
+10. New tests cover filtering behavior
+
+## Files to Modify
+
+- `apps/web/src/components/EpisodesList.tsx` - Main implementation
+- `apps/web/tests/unit/EpisodesList.test.tsx` - Add filter tests (or create new test file)


### PR DESCRIPTION
## Summary

- Added search input to filter episodes by title in the EpisodesList component
- Real-time case-insensitive filtering with partial title matching
- Search icon (Search) and clear button (X) for UX
- Stats bar shows "Showing X of Y episodes" when filtered
- Empty state message when no episodes match search
- Sort controls continue to work on filtered results

## Changes

- Modified `apps/web/src/components/EpisodesList.tsx`:
  - Added search state and filter logic using useMemo
  - Added search input with icons (Search from lucide-react, X for clear)
  - Updated StatsBar to display filtered count
  - Added empty state when no search results
  - Used existing `Input` component from `@/components/ui/input`

## Test Plan

- [x] All 149 tests pass (143 existing + 6 new)
- [x] Typecheck passes
- [x] Lint passes (only pre-existing warnings)
- [x] New tests verify:
  - Case-insensitive filtering
  - Partial title matching
  - Empty state display
  - Clear button functionality
  - Stats bar filtered count
  - Empty query shows all episodes

## Related Issue

Fixes #356