### PR TITLE
Scoped search for title/description/speaker with metadata mode + pagination (#357)

### DIFF
--- a/apps/web/src/app/api/search/grouped/route.ts
+++ b/apps/web/src/app/api/search/grouped/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   const feedIds = feedIdRaw ? feedIdRaw.split(",").filter(Boolean) : null;
   const includeManualUploads = searchParams.get("uploads") === "true";
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
   const skipCount = searchParams.get("skipCount") === "true";
   const speakerLabel = searchParams.get("speaker") || null;
 

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   const feedIds = feedIdRaw ? feedIdRaw.split(",").filter(Boolean) : null;
   const includeManualUploads = searchParams.get("uploads") === "true";
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") ?? "20", 10)));
   const skipCount = searchParams.get("skipCount") === "true";
   const speakerLabel = searchParams.get("speaker") || null;
 

--- a/apps/web/src/app/api/wizard/status/route.ts
+++ b/apps/web/src/app/api/wizard/status/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const WIZARD_COOKIE = "podlog_wizard_completed";
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+export async function GET(req: NextRequest) {
+  const completed = req.cookies.get(WIZARD_COOKIE)?.value;
+  return NextResponse.json({ completed: completed === "true" });
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = (await req.json()) as { completed?: unknown };
+    if (typeof body.completed !== "boolean") {
+      return NextResponse.json({ error: "completed must be boolean" }, { status: 400 });
+    }
+
+    const response = NextResponse.json({ completed: body.completed });
+    if (body.completed) {
+      response.cookies.set(WIZARD_COOKIE, "true", {
+        path: "/",
+        maxAge: ONE_YEAR_SECONDS,
+        sameSite: "lax",
+      });
+    } else {
+      response.cookies.set(WIZARD_COOKIE, "", {
+        path: "/",
+        maxAge: 0,
+        sameSite: "lax",
+      });
+    }
+    return response;
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -22,6 +22,8 @@ import { loadSearchSnapshot, saveSearchSnapshot } from "@/lib/page-state";
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
+const isValidPageSize = (value: number): value is (typeof PAGE_SIZE_OPTIONS)[number] =>
+  PAGE_SIZE_OPTIONS.includes(value as (typeof PAGE_SIZE_OPTIONS)[number]);
 
 type ViewMode = "grouped" | "flat";
 
@@ -64,7 +66,7 @@ function SearchPageContent() {
     initialQuery ? 1 : initialSnapshot?.page || 1
   );
   const [pageSize, setPageSize] = useState(
-    initialSnapshot?.pageSize && PAGE_SIZE_OPTIONS.includes(initialSnapshot.pageSize as 20 | 50 | 100)
+    initialSnapshot?.pageSize && isValidPageSize(initialSnapshot.pageSize)
       ? initialSnapshot.pageSize
       : DEFAULT_PAGE_SIZE
   );
@@ -264,7 +266,7 @@ function SearchPageContent() {
               <li>Use quotes for exact phrases: &quot;machine learning&quot;</li>
               <li>Exclude words with minus: climate -politics</li>
               <li>Combine terms: AI regulation ethics</li>
-              <li>Field search: title:, description:, speaker: (case-insensitive)</li>
+              <li>Field search: title:, description:, speaker: (case-insensitive; speaker supports partial matching)</li>
             </ul>
           </HelpPopover>
 
@@ -341,7 +343,8 @@ function SearchPageContent() {
                 <select
                   value={pageSize}
                   onChange={(e) => {
-                    setPageSize(parseInt(e.target.value, 10));
+                    const next = Number.parseInt(e.target.value, 10);
+                    setPageSize(isValidPageSize(next) ? next : DEFAULT_PAGE_SIZE);
                     setPage(1);
                   }}
                   className="bg-background border border-input rounded-md px-2 py-1 text-xs"

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -20,7 +20,8 @@ import SpeakerFilter from "@/components/SpeakerFilter";
 import type { SearchPage as SearchPageType, GroupedSearchResult } from "@/lib/search";
 import { loadSearchSnapshot, saveSearchSnapshot } from "@/lib/page-state";
 
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
 
 type ViewMode = "grouped" | "flat";
 
@@ -61,6 +62,11 @@ function SearchPageContent() {
   );
   const [page, setPage] = useState(
     initialQuery ? 1 : initialSnapshot?.page || 1
+  );
+  const [pageSize, setPageSize] = useState(
+    initialSnapshot?.pageSize && PAGE_SIZE_OPTIONS.includes(initialSnapshot.pageSize as 20 | 50 | 100)
+      ? initialSnapshot.pageSize
+      : DEFAULT_PAGE_SIZE
   );
   const [viewMode, setViewMode] = useState<ViewMode>(
     initialSnapshot?.viewMode || "grouped"
@@ -116,9 +122,10 @@ function SearchPageContent() {
       selectedFeedIds: Array.from(selectedFeedIds),
       selectedSpeaker,
       page,
+      pageSize,
       viewMode,
     });
-  }, [query, submittedQuery, selectedFeedIds, selectedSpeaker, page, viewMode]);
+  }, [query, submittedQuery, selectedFeedIds, selectedSpeaker, page, pageSize, viewMode]);
 
   // Separate real feed UUIDs from the __uploads__ sentinel
   const includeManualUploads = selectedFeedIds.has("__uploads__");
@@ -127,16 +134,16 @@ function SearchPageContent() {
     .join(",");
 
   // Flat search query
-  const flatCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}`;
+  const flatCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}:${pageSize}`;
   const flatQuery = useQuery<SearchPageType>({
-    queryKey: ["search", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page],
+    queryKey: ["search", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page, pageSize],
     queryFn: async () => {
       if (!submittedQuery)
         return {
           results: [],
           total: 0,
           page: 1,
-          pageSize: PAGE_SIZE,
+          pageSize,
           coverage: { processed: 0, total: 0 },
         };
       const canSkipCount =
@@ -144,7 +151,7 @@ function SearchPageContent() {
       const params = new URLSearchParams({
         q: submittedQuery,
         page: String(page),
-        pageSize: String(PAGE_SIZE),
+        pageSize: String(pageSize),
       });
       if (feedFilterParam) params.set("feedId", feedFilterParam);
       if (includeManualUploads) params.set("uploads", "true");
@@ -165,9 +172,9 @@ function SearchPageContent() {
   });
 
   // Grouped search query
-  const groupedCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}`;
+  const groupedCacheKey = `${submittedQuery}:${feedFilterParam}:${includeManualUploads}:${selectedSpeaker}:${pageSize}`;
   const groupedQuery = useQuery<GroupedSearchResult>({
-    queryKey: ["search-grouped", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page],
+    queryKey: ["search-grouped", submittedQuery, feedFilterParam, includeManualUploads, selectedSpeaker, page, pageSize],
     queryFn: async () => {
       if (!submittedQuery)
         return {
@@ -182,7 +189,7 @@ function SearchPageContent() {
       const params = new URLSearchParams({
         q: submittedQuery,
         page: String(page),
-        pageSize: String(PAGE_SIZE),
+        pageSize: String(pageSize),
       });
       if (feedFilterParam) params.set("feedId", feedFilterParam);
       if (includeManualUploads) params.set("uploads", "true");
@@ -238,7 +245,11 @@ function SearchPageContent() {
 
   const totalPages =
     viewMode === "flat" && flatQuery.data
-      ? Math.ceil(flatQuery.data.total / PAGE_SIZE)
+      ? Math.ceil(flatQuery.data.total / pageSize)
+      : 0;
+  const groupedTotalPages =
+    viewMode === "grouped" && groupedQuery.data
+      ? Math.ceil(groupedQuery.data.totalEpisodes / pageSize)
       : 0;
 
   return (
@@ -253,6 +264,7 @@ function SearchPageContent() {
               <li>Use quotes for exact phrases: &quot;machine learning&quot;</li>
               <li>Exclude words with minus: climate -politics</li>
               <li>Combine terms: AI regulation ethics</li>
+              <li>Field search: title:, description:, speaker: (case-insensitive)</li>
             </ul>
           </HelpPopover>
 
@@ -262,7 +274,7 @@ function SearchPageContent() {
             onChange={setQuery}
             onSubmit={handleSubmit}
             onClear={handleClear}
-            placeholder="Search transcripts..."
+            placeholder="Search transcripts, titles, descriptions..."
             icon={<Search size={18} />}
           />
 
@@ -324,6 +336,23 @@ function SearchPageContent() {
               })()}
             </div>
             <div className="flex items-center gap-2">
+              <label className="text-xs text-muted-foreground flex items-center gap-1.5">
+                <span>Per page</span>
+                <select
+                  value={pageSize}
+                  onChange={(e) => {
+                    setPageSize(parseInt(e.target.value, 10));
+                    setPage(1);
+                  }}
+                  className="bg-background border border-input rounded-md px-2 py-1 text-xs"
+                >
+                  {PAGE_SIZE_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <DownloadReportButton
                 query={submittedQuery}
                 viewMode={viewMode}
@@ -371,15 +400,40 @@ function SearchPageContent() {
 
           {viewMode === "grouped" ? (
             groupedQuery.data && groupedQuery.data.feeds.length > 0 ? (
-              <div className="space-y-3">
-                {groupedQuery.data.feeds.map((feed) => (
-                  <FeedGroupCard
-                    key={feed.feedId}
-                    feed={feed}
-                    query={submittedQuery}
-                  />
-                ))}
-              </div>
+              <>
+                <div className="space-y-3">
+                  {groupedQuery.data.feeds.map((feed) => (
+                    <FeedGroupCard
+                      key={feed.feedId}
+                      feed={feed}
+                      query={submittedQuery}
+                    />
+                  ))}
+                </div>
+                {groupedTotalPages > 1 && (
+                  <div className="flex items-center justify-between pt-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                      disabled={page === 1}
+                    >
+                      &larr; Previous
+                    </Button>
+                    <span className="text-sm text-muted-foreground">
+                      Page {page} of {groupedTotalPages}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPage((p) => Math.min(groupedTotalPages, p + 1))}
+                      disabled={page === groupedTotalPages}
+                    >
+                      Next &rarr;
+                    </Button>
+                  </div>
+                )}
+              </>
             ) : (
               <div className="text-center py-16 space-y-2">
                 <p className="text-muted-foreground">

--- a/apps/web/src/lib/page-state.ts
+++ b/apps/web/src/lib/page-state.ts
@@ -12,6 +12,7 @@ export interface SearchPageSnapshot {
   selectedFeedIds: string[];
   selectedSpeaker?: string | null;
   page: number;
+  pageSize?: number;
   viewMode: ViewMode;
 }
 
@@ -73,6 +74,10 @@ export function loadSearchSnapshot(storage?: Storage): SearchPageSnapshot | null
     typeof parsed.page !== "number" ||
     !Number.isFinite(parsed.page) ||
     parsed.page < 1 ||
+    (parsed.pageSize !== undefined &&
+      (typeof parsed.pageSize !== "number" ||
+        !Number.isFinite(parsed.pageSize) ||
+        parsed.pageSize < 1)) ||
     !isViewMode(parsed.viewMode)
   ) {
     return null;

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -2,6 +2,7 @@ import pool from "@/lib/db";
 import { PIPELINE_API } from "@/lib/pipeline";
 import { buildFeedFilter } from "@/lib/search/feedFilter";
 import { groupRowsByFeed } from "@/lib/search/grouping";
+import { parseSearchQuery } from "@/lib/search/queryParser";
 import { SPEAKER_TURNS_CTE } from "@/lib/search/speakerTurns";
 import { mergeHybridSearchResults } from "@/lib/searchHybrid";
 import type {
@@ -11,6 +12,7 @@ import type {
   GroupedSearchResult,
   Mention,
   SearchPage,
+  SearchResult,
 } from "@/lib/search/types";
 
 export type {
@@ -43,6 +45,46 @@ async function getQueryEmbedding(text: string): Promise<number[] | null> {
   }
 }
 
+function buildLikePattern(value: string | null): string | null {
+  if (!value) return null;
+  return `%${value}%`;
+}
+
+function buildCoverage(skipCount: boolean): Promise<{ rows: Array<{ processed: number; total: number }> } | null> {
+  if (skipCount) return Promise.resolve(null);
+  return pool.query(
+    `SELECT
+      COUNT(*) FILTER (WHERE status = 'done')::int AS processed,
+      COUNT(*)::int AS total
+    FROM episodes`
+  );
+}
+
+function toCoverage(coverageResult: { rows: Array<{ processed: number; total: number }> } | null): EpisodeCoverage {
+  const cov = coverageResult?.rows[0];
+  return {
+    processed: cov?.processed ?? 0,
+    total: cov?.total ?? 0,
+  };
+}
+
+function buildMetadataSnippet(
+  row: { episode_title: string | null; episode_description: string | null },
+  parsed: ReturnType<typeof parseSearchQuery>
+): string {
+  if (parsed.titleFilter && row.episode_title) {
+    return `Title match: ${row.episode_title}`;
+  }
+  if (parsed.descriptionFilter && row.episode_description) {
+    const trimmed = row.episode_description.trim();
+    return trimmed.length > 240 ? `${trimmed.slice(0, 240)}...` : trimmed;
+  }
+  if (parsed.speakerFilter) {
+    return `Speaker match: ${parsed.speakerFilter}`;
+  }
+  return row.episode_title ?? "Episode match";
+}
+
 /**
  * Hybrid search: FTS + vector similarity with Reciprocal Rank Fusion.
  *
@@ -61,13 +103,146 @@ export async function searchSegments(
   skipCount: boolean = false,
   speakerLabel: string | null = null
 ): Promise<SearchPage> {
-  const FETCH_LIMIT = 100; // fetch more than pageSize for RRF merging
-  const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const parsed = parseSearchQuery(query);
+  const speakerLike = buildLikePattern(parsed.speakerFilter);
 
-  // FTS query — speaker filter uses table alias 't'
-  const ftsSpeakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
-  const ftsLimitIdx = feedFilter.nextIdx + (speakerLabel ? 1 : 0);
-  const ftsParams = [query, ...feedFilter.params, ...(speakerLabel ? [speakerLabel] : []), FETCH_LIMIT];
+  if (parsed.mode === "metadata_only") {
+    const offset = (page - 1) * pageSize;
+    const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 1);
+    const whereClauses: string[] = ["e.status = 'done'", feedFilter.clause];
+    const params: unknown[] = [...feedFilter.params];
+    let idx = feedFilter.nextIdx;
+
+    if (parsed.titleFilter) {
+      whereClauses.push(`COALESCE(e.title, '') ILIKE $${idx}`);
+      params.push(buildLikePattern(parsed.titleFilter));
+      idx++;
+    }
+    if (parsed.descriptionFilter) {
+      whereClauses.push(`COALESCE(e.description, '') ILIKE $${idx}`);
+      params.push(buildLikePattern(parsed.descriptionFilter));
+      idx++;
+    }
+    if (speakerLike) {
+      whereClauses.push(
+        `EXISTS (
+          SELECT 1
+          FROM speaker_names sn
+          WHERE sn.episode_id = e.id
+            AND (COALESCE(sn.display_name, sn.speaker_label) ILIKE $${idx} OR sn.speaker_label ILIKE $${idx})
+        )`
+      );
+      params.push(speakerLike);
+      idx++;
+    }
+    if (speakerLabel) {
+      whereClauses.push(
+        `EXISTS (
+          SELECT 1
+          FROM speaker_names sn
+          WHERE sn.episode_id = e.id
+            AND sn.speaker_label = $${idx}
+        )`
+      );
+      params.push(speakerLabel);
+      idx++;
+    }
+
+    const whereSql = whereClauses.join("\n      AND ");
+    const rowsPromise = pool.query(
+      `SELECT
+        ROW_NUMBER() OVER (ORDER BY COALESCE(e.published_at, e.created_at) DESC, e.id DESC)::int AS id,
+        0::double precision AS start_time,
+        0::double precision AS end_time,
+        NULL::text AS speaker_label,
+        NULL::text AS speaker_display,
+        e.id AS episode_id,
+        e.title AS episode_title,
+        e.description AS episode_description,
+        e.audio_url,
+        e.audio_local_path,
+        e.episode_url,
+        e.has_diarization,
+        e.diarization_error,
+        COALESCE(f.title, 'Manual episode') AS feed_title,
+        COALESCE(f.mode, 'full') AS feed_mode,
+        f.id AS feed_id
+      FROM episodes e
+      LEFT JOIN feeds f ON e.feed_id = f.id
+      WHERE ${whereSql}
+      ORDER BY COALESCE(e.published_at, e.created_at) DESC, e.id DESC
+      LIMIT $${idx} OFFSET $${idx + 1}`,
+      [...params, pageSize, offset]
+    );
+
+    const countPromise = skipCount
+      ? Promise.resolve(null)
+      : pool.query(
+          `SELECT COUNT(*)::int AS total
+          FROM episodes e
+          LEFT JOIN feeds f ON e.feed_id = f.id
+          WHERE ${whereSql}`,
+          params
+        );
+
+    const [rowsResult, countResult, coverageResult] = await Promise.all([
+      rowsPromise,
+      countPromise,
+      buildCoverage(skipCount),
+    ]);
+
+    const results: SearchResult[] = rowsResult.rows.map((row) => ({
+      id: row.id,
+      startTime: 0,
+      endTime: 0,
+      speakerLabel: null,
+      speakerDisplay: null,
+      snippet: buildMetadataSnippet(row, parsed),
+      rank: 1,
+      episodeId: row.episode_id,
+      episodeTitle: row.episode_title,
+      audioUrl: row.audio_url,
+      audioLocalPath: row.audio_local_path,
+      episodeUrl: row.episode_url,
+      hasDiarization: row.has_diarization,
+      diarizationError: row.diarization_error,
+      feedTitle: row.feed_title,
+      feedMode: row.feed_mode,
+      feedId: row.feed_id ?? "__manual__",
+    }));
+
+    const total = countResult ? parseInt(String(countResult.rows[0].total), 10) : -1;
+    return { results, total, page, pageSize, coverage: toCoverage(coverageResult) };
+  }
+
+  const baseQuery = parsed.freeText || query.trim();
+  const FETCH_LIMIT = 100;
+
+  const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
+  const ftsExtraClauses: string[] = [];
+  const ftsParams: unknown[] = [baseQuery, ...feedFilter.params];
+  let ftsIdx = feedFilter.nextIdx;
+
+  if (speakerLabel) {
+    ftsExtraClauses.push(`t.speaker_label = $${ftsIdx}`);
+    ftsParams.push(speakerLabel);
+    ftsIdx++;
+  }
+  if (speakerLike) {
+    ftsExtraClauses.push(`(COALESCE(sn.display_name, t.speaker_label) ILIKE $${ftsIdx} OR t.speaker_label ILIKE $${ftsIdx})`);
+    ftsParams.push(speakerLike);
+    ftsIdx++;
+  }
+  if (parsed.titleFilter) {
+    ftsExtraClauses.push(`COALESCE(e.title, '') ILIKE $${ftsIdx}`);
+    ftsParams.push(buildLikePattern(parsed.titleFilter));
+    ftsIdx++;
+  }
+  if (parsed.descriptionFilter) {
+    ftsExtraClauses.push(`COALESCE(e.description, '') ILIKE $${ftsIdx}`);
+    ftsParams.push(buildLikePattern(parsed.descriptionFilter));
+    ftsIdx++;
+  }
 
   const ftsPromise = pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
@@ -97,18 +272,38 @@ export async function searchSegments(
     WHERE to_tsvector('english', t.full_text) @@ query
       AND e.status = 'done'
       AND ${feedFilter.clause}
-      ${ftsSpeakerClause}
+      ${ftsExtraClauses.length ? `AND ${ftsExtraClauses.join(" AND ")}` : ""}
     ORDER BY rank DESC
-    LIMIT $${ftsLimitIdx}`,
-    ftsParams
+    LIMIT $${ftsIdx}`,
+    [...ftsParams, FETCH_LIMIT]
   );
 
-  const embedding = await getQueryEmbedding(query);
+  const embedding = await getQueryEmbedding(baseQuery);
   const vecFeedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
-  // Vector query — speaker filter uses table alias 's'
-  const vecSpeakerClause = speakerLabel ? `AND s.speaker_label = $${vecFeedFilter.nextIdx}` : "";
-  const vecLimitIdx = vecFeedFilter.nextIdx + (speakerLabel ? 1 : 0);
-  const vecParams = [`[${embedding?.join(",")}]`, ...vecFeedFilter.params, ...(speakerLabel ? [speakerLabel] : []), FETCH_LIMIT];
+  const vecParams: unknown[] = [`[${embedding?.join(",")}]`, ...vecFeedFilter.params];
+  const vecExtraClauses: string[] = [];
+  let vecIdx = vecFeedFilter.nextIdx;
+
+  if (speakerLabel) {
+    vecExtraClauses.push(`s.speaker_label = $${vecIdx}`);
+    vecParams.push(speakerLabel);
+    vecIdx++;
+  }
+  if (speakerLike) {
+    vecExtraClauses.push(`(COALESCE(sn.display_name, s.speaker_label) ILIKE $${vecIdx} OR s.speaker_label ILIKE $${vecIdx})`);
+    vecParams.push(speakerLike);
+    vecIdx++;
+  }
+  if (parsed.titleFilter) {
+    vecExtraClauses.push(`COALESCE(e.title, '') ILIKE $${vecIdx}`);
+    vecParams.push(buildLikePattern(parsed.titleFilter));
+    vecIdx++;
+  }
+  if (parsed.descriptionFilter) {
+    vecExtraClauses.push(`COALESCE(e.description, '') ILIKE $${vecIdx}`);
+    vecParams.push(buildLikePattern(parsed.descriptionFilter));
+    vecIdx++;
+  }
 
   const vecPromise = embedding
     ? pool.query(
@@ -137,16 +332,39 @@ export async function searchSegments(
         WHERE s.embedding IS NOT NULL
           AND e.status = 'done'
           AND ${vecFeedFilter.clause}
-          ${vecSpeakerClause}
+          ${vecExtraClauses.length ? `AND ${vecExtraClauses.join(" AND ")}` : ""}
         ORDER BY s.embedding <=> $1::vector
-        LIMIT $${vecLimitIdx}`,
-        vecParams
+        LIMIT $${vecIdx}`,
+        [...vecParams, FETCH_LIMIT]
       )
     : Promise.resolve({ rows: [] });
 
   const countFeedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
-  const countSpeakerClause = speakerLabel ? `AND t.speaker_label = $${countFeedFilter.nextIdx}` : "";
-  const countParams = [query, ...countFeedFilter.params, ...(speakerLabel ? [speakerLabel] : [])];
+  const countParams: unknown[] = [baseQuery, ...countFeedFilter.params];
+  const countExtraClauses: string[] = [];
+  let countIdx = countFeedFilter.nextIdx;
+
+  if (speakerLabel) {
+    countExtraClauses.push(`t.speaker_label = $${countIdx}`);
+    countParams.push(speakerLabel);
+    countIdx++;
+  }
+  if (speakerLike) {
+    countExtraClauses.push(`(COALESCE(sn.display_name, t.speaker_label) ILIKE $${countIdx} OR t.speaker_label ILIKE $${countIdx})`);
+    countParams.push(speakerLike);
+    countIdx++;
+  }
+  if (parsed.titleFilter) {
+    countExtraClauses.push(`COALESCE(e.title, '') ILIKE $${countIdx}`);
+    countParams.push(buildLikePattern(parsed.titleFilter));
+    countIdx++;
+  }
+  if (parsed.descriptionFilter) {
+    countExtraClauses.push(`COALESCE(e.description, '') ILIKE $${countIdx}`);
+    countParams.push(buildLikePattern(parsed.descriptionFilter));
+    countIdx++;
+  }
+
   const countPromise = skipCount
     ? Promise.resolve(null)
     : pool.query(
@@ -154,29 +372,21 @@ export async function searchSegments(
         SELECT COUNT(*)
         FROM speaker_turns t
         JOIN episodes e ON t.episode_id = e.id
-        LEFT JOIN feeds f ON e.feed_id = f.id,
+        LEFT JOIN feeds f ON e.feed_id = f.id
+        LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND e.status = 'done'
           AND ${countFeedFilter.clause}
-          ${countSpeakerClause}`,
+          ${countExtraClauses.length ? `AND ${countExtraClauses.join(" AND ")}` : ""}`,
         countParams
-      );
-
-  const coveragePromise = skipCount
-    ? Promise.resolve(null)
-    : pool.query(
-        `SELECT
-          COUNT(*) FILTER (WHERE status = 'done')::int AS processed,
-          COUNT(*)::int AS total
-        FROM episodes`
       );
 
   const [ftsResult, vecResult, countResult, coverageResult] = await Promise.all([
     ftsPromise,
     vecPromise,
     countPromise,
-    coveragePromise,
+    buildCoverage(skipCount),
   ]);
 
   const ftsTotal = countResult ? parseInt(countResult.rows[0].count, 10) : -1;
@@ -188,13 +398,7 @@ export async function searchSegments(
     ftsTotal,
   });
 
-  const cov = coverageResult?.rows[0];
-  const coverage: EpisodeCoverage = {
-    processed: cov?.processed ?? 0,
-    total: cov?.total ?? 0,
-  };
-
-  return { results: merged.results, total: merged.total, page, pageSize, coverage };
+  return { results: merged.results, total: merged.total, page, pageSize, coverage: toCoverage(coverageResult) };
 }
 
 /**
@@ -210,11 +414,128 @@ export async function searchGrouped(
   skipCount: boolean = false,
   speakerLabel: string | null = null
 ): Promise<GroupedSearchResult> {
+  const parsed = parseSearchQuery(query);
+  const speakerLike = buildLikePattern(parsed.speakerFilter);
   const offset = (page - 1) * pageSize;
+
+  if (parsed.mode === "metadata_only") {
+    const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 1);
+    const whereClauses: string[] = ["e.status = 'done'", feedFilter.clause];
+    const params: unknown[] = [...feedFilter.params];
+    let idx = feedFilter.nextIdx;
+
+    if (parsed.titleFilter) {
+      whereClauses.push(`COALESCE(e.title, '') ILIKE $${idx}`);
+      params.push(buildLikePattern(parsed.titleFilter));
+      idx++;
+    }
+    if (parsed.descriptionFilter) {
+      whereClauses.push(`COALESCE(e.description, '') ILIKE $${idx}`);
+      params.push(buildLikePattern(parsed.descriptionFilter));
+      idx++;
+    }
+    if (speakerLike) {
+      whereClauses.push(
+        `EXISTS (
+          SELECT 1
+          FROM speaker_names sn
+          WHERE sn.episode_id = e.id
+            AND (COALESCE(sn.display_name, sn.speaker_label) ILIKE $${idx} OR sn.speaker_label ILIKE $${idx})
+        )`
+      );
+      params.push(speakerLike);
+      idx++;
+    }
+    if (speakerLabel) {
+      whereClauses.push(
+        `EXISTS (
+          SELECT 1
+          FROM speaker_names sn
+          WHERE sn.episode_id = e.id
+            AND sn.speaker_label = $${idx}
+        )`
+      );
+      params.push(speakerLabel);
+      idx++;
+    }
+
+    const whereSql = whereClauses.join("\n      AND ");
+    const rowsPromise = pool.query(
+      `SELECT
+        f.id AS feed_id,
+        COALESCE(f.title, 'Manual episode') AS feed_title,
+        COALESCE(f.mode, 'full') AS feed_mode,
+        e.id AS episode_id,
+        e.title AS episode_title,
+        e.audio_url,
+        e.audio_local_path,
+        e.episode_url,
+        1::int AS mention_count,
+        1::double precision AS best_rank
+      FROM episodes e
+      LEFT JOIN feeds f ON e.feed_id = f.id
+      WHERE ${whereSql}
+      ORDER BY COALESCE(e.published_at, e.created_at) DESC, e.id DESC
+      LIMIT $${idx} OFFSET $${idx + 1}`,
+      [...params, pageSize, offset]
+    );
+
+    const countPromise = skipCount
+      ? Promise.resolve(null)
+      : pool.query(
+          `SELECT
+            COUNT(*)::int AS total_episodes,
+            COUNT(DISTINCT f.id)::int AS total_feeds,
+            COUNT(*)::int AS total_mentions,
+            BOOL_OR(e.feed_id IS NULL)::bool AS has_manual
+          FROM episodes e
+          LEFT JOIN feeds f ON e.feed_id = f.id
+          WHERE ${whereSql}`,
+          params
+        );
+
+    const [rowsResult, countResult, coverageResult] = await Promise.all([
+      rowsPromise,
+      countPromise,
+      buildCoverage(skipCount),
+    ]);
+
+    const counts = countResult?.rows[0];
+    return {
+      feeds: groupRowsByFeed(rowsResult.rows),
+      totalFeeds: (counts?.total_feeds ?? -1) + (counts?.has_manual ? 1 : 0),
+      totalEpisodes: counts?.total_episodes ?? -1,
+      totalMentions: counts?.total_mentions ?? -1,
+      coverage: toCoverage(coverageResult),
+    };
+  }
+
+  const baseQuery = parsed.freeText || query.trim();
   const feedFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
-  const rowsSpeakerClause = speakerLabel ? `AND t.speaker_label = $${feedFilter.nextIdx}` : "";
-  const rowsLimitIdx = feedFilter.nextIdx + (speakerLabel ? 1 : 0);
-  const rowsParams = [query, ...feedFilter.params, ...(speakerLabel ? [speakerLabel] : []), pageSize, offset];
+  const rowsParams: unknown[] = [baseQuery, ...feedFilter.params];
+  const rowsExtraClauses: string[] = [];
+  let rowsIdx = feedFilter.nextIdx;
+
+  if (speakerLabel) {
+    rowsExtraClauses.push(`t.speaker_label = $${rowsIdx}`);
+    rowsParams.push(speakerLabel);
+    rowsIdx++;
+  }
+  if (speakerLike) {
+    rowsExtraClauses.push(`(COALESCE(sn.display_name, t.speaker_label) ILIKE $${rowsIdx} OR t.speaker_label ILIKE $${rowsIdx})`);
+    rowsParams.push(speakerLike);
+    rowsIdx++;
+  }
+  if (parsed.titleFilter) {
+    rowsExtraClauses.push(`COALESCE(e.title, '') ILIKE $${rowsIdx}`);
+    rowsParams.push(buildLikePattern(parsed.titleFilter));
+    rowsIdx++;
+  }
+  if (parsed.descriptionFilter) {
+    rowsExtraClauses.push(`COALESCE(e.description, '') ILIKE $${rowsIdx}`);
+    rowsParams.push(buildLikePattern(parsed.descriptionFilter));
+    rowsIdx++;
+  }
 
   const rowsPromise = pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
@@ -231,21 +552,45 @@ export async function searchGrouped(
       MAX(ts_rank(to_tsvector('english', t.full_text), query)) AS best_rank
     FROM speaker_turns t
     JOIN episodes e ON t.episode_id = e.id
-    LEFT JOIN feeds f ON e.feed_id = f.id,
+    LEFT JOIN feeds f ON e.feed_id = f.id
+    LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
       websearch_to_tsquery('english', $1) AS query
     WHERE to_tsvector('english', t.full_text) @@ query
       AND e.status = 'done'
       AND ${feedFilter.clause}
-      ${rowsSpeakerClause}
+      ${rowsExtraClauses.length ? `AND ${rowsExtraClauses.join(" AND ")}` : ""}
     GROUP BY f.id, f.title, f.mode, e.id, e.title, e.audio_url, e.audio_local_path, e.episode_url
     ORDER BY best_rank DESC, mention_count DESC
-    LIMIT $${rowsLimitIdx} OFFSET $${rowsLimitIdx + 1}`,
-    rowsParams
+    LIMIT $${rowsIdx} OFFSET $${rowsIdx + 1}`,
+    [...rowsParams, pageSize, offset]
   );
 
   const grpCountFilter = buildFeedFilter(feedIds, includeManualUploads, 2);
-  const countSpeakerClause = speakerLabel ? `AND t.speaker_label = $${grpCountFilter.nextIdx}` : "";
-  const countParams = [query, ...grpCountFilter.params, ...(speakerLabel ? [speakerLabel] : [])];
+  const countParams: unknown[] = [baseQuery, ...grpCountFilter.params];
+  const countExtraClauses: string[] = [];
+  let countIdx = grpCountFilter.nextIdx;
+
+  if (speakerLabel) {
+    countExtraClauses.push(`t.speaker_label = $${countIdx}`);
+    countParams.push(speakerLabel);
+    countIdx++;
+  }
+  if (speakerLike) {
+    countExtraClauses.push(`(COALESCE(sn.display_name, t.speaker_label) ILIKE $${countIdx} OR t.speaker_label ILIKE $${countIdx})`);
+    countParams.push(speakerLike);
+    countIdx++;
+  }
+  if (parsed.titleFilter) {
+    countExtraClauses.push(`COALESCE(e.title, '') ILIKE $${countIdx}`);
+    countParams.push(buildLikePattern(parsed.titleFilter));
+    countIdx++;
+  }
+  if (parsed.descriptionFilter) {
+    countExtraClauses.push(`COALESCE(e.description, '') ILIKE $${countIdx}`);
+    countParams.push(buildLikePattern(parsed.descriptionFilter));
+    countIdx++;
+  }
+
   const countPromise = skipCount
     ? Promise.resolve(null)
     : pool.query(
@@ -257,42 +602,29 @@ export async function searchGrouped(
           BOOL_OR(e.feed_id IS NULL)::bool AS has_manual
         FROM speaker_turns t
         JOIN episodes e ON t.episode_id = e.id
-        LEFT JOIN feeds f ON e.feed_id = f.id,
+        LEFT JOIN feeds f ON e.feed_id = f.id
+        LEFT JOIN speaker_names sn ON sn.episode_id = e.id AND sn.speaker_label = t.speaker_label,
           websearch_to_tsquery('english', $1) AS query
         WHERE to_tsvector('english', t.full_text) @@ query
           AND e.status = 'done'
           AND ${grpCountFilter.clause}
-          ${countSpeakerClause}`,
+          ${countExtraClauses.length ? `AND ${countExtraClauses.join(" AND ")}` : ""}`,
         countParams
-      );
-
-  const coveragePromise = skipCount
-    ? Promise.resolve(null)
-    : pool.query(
-        `SELECT
-          COUNT(*) FILTER (WHERE status = 'done')::int AS processed,
-          COUNT(*)::int AS total
-        FROM episodes`
       );
 
   const [rowsResult, countResult, coverageResult] = await Promise.all([
     rowsPromise,
     countPromise,
-    coveragePromise,
+    buildCoverage(skipCount),
   ]);
 
   const counts = countResult?.rows[0];
-  const cov = coverageResult?.rows[0];
-
   return {
     feeds: groupRowsByFeed(rowsResult.rows),
     totalFeeds: (counts?.total_feeds ?? -1) + (counts?.has_manual ? 1 : 0),
     totalEpisodes: counts?.total_episodes ?? -1,
     totalMentions: counts?.total_mentions ?? -1,
-    coverage: {
-      processed: cov?.processed ?? 0,
-      total: cov?.total ?? 0,
-    },
+    coverage: toCoverage(coverageResult),
   };
 }
 
@@ -304,6 +636,21 @@ export async function searchMentions(
   query: string,
   episodeId: string
 ): Promise<EpisodeMentions> {
+  const parsed = parseSearchQuery(query);
+  const baseQuery = parsed.freeText.trim();
+  if (!baseQuery) return { episodeId, mentions: [] };
+
+  const speakerLike = buildLikePattern(parsed.speakerFilter);
+  const params: unknown[] = [baseQuery, episodeId];
+  let idx = 3;
+  let speakerMatchSql = "";
+
+  if (speakerLike) {
+    speakerMatchSql = ` AND (COALESCE(sn.display_name, t.speaker_label) ILIKE $${idx} OR t.speaker_label ILIKE $${idx})`;
+    params.push(speakerLike);
+    idx++;
+  }
+
   const result = await pool.query(
     `WITH ${SPEAKER_TURNS_CTE}
     SELECT
@@ -313,11 +660,11 @@ export async function searchMentions(
       t.speaker_label,
       COALESCE(sn.display_name, t.speaker_label) AS speaker_display,
       t.full_text,
-      CASE WHEN to_tsvector('english', t.full_text) @@ query THEN true ELSE false END AS is_match,
-      CASE WHEN to_tsvector('english', t.full_text) @@ query
+      CASE WHEN to_tsvector('english', t.full_text) @@ query ${speakerMatchSql} THEN true ELSE false END AS is_match,
+      CASE WHEN to_tsvector('english', t.full_text) @@ query ${speakerMatchSql}
         THEN ts_headline('english', t.full_text, query, 'MaxFragments=0, HighlightAll=true')
         ELSE '' END AS snippet,
-      CASE WHEN to_tsvector('english', t.full_text) @@ query
+      CASE WHEN to_tsvector('english', t.full_text) @@ query ${speakerMatchSql}
         THEN ts_rank(to_tsvector('english', t.full_text), query)
         ELSE 0 END AS rank
     FROM speaker_turns t
@@ -325,7 +672,7 @@ export async function searchMentions(
       websearch_to_tsquery('english', $1) AS query
     WHERE t.episode_id = $2
     ORDER BY t.start_time ASC`,
-    [query, episodeId]
+    params
   );
 
   const allTurns = result.rows;
@@ -344,17 +691,17 @@ export async function searchMentions(
     };
   }
 
-  const mentions: Mention[] = matchIndices.map((idx) => {
-    const row = allTurns[idx];
+  const mentions: Mention[] = matchIndices.map((matchIndex) => {
+    const row = allTurns[matchIndex];
 
     const before: ContextSegment[] = [];
-    for (let i = idx - 1; i >= 0 && before.length < CONTEXT_SIZE; i--) {
+    for (let i = matchIndex - 1; i >= 0 && before.length < CONTEXT_SIZE; i--) {
       if (!allTurns[i].is_match) before.unshift(toContextSegment(allTurns[i]));
       else break;
     }
 
     const after: ContextSegment[] = [];
-    for (let i = idx + 1; i < allTurns.length && after.length < CONTEXT_SIZE; i++) {
+    for (let i = matchIndex + 1; i < allTurns.length && after.length < CONTEXT_SIZE; i++) {
       if (!allTurns[i].is_match) after.push(toContextSegment(allTurns[i]));
       else break;
     }

--- a/apps/web/src/lib/search/queryParser.ts
+++ b/apps/web/src/lib/search/queryParser.ts
@@ -1,0 +1,105 @@
+export type SearchExecutionMode = "transcript_hybrid" | "metadata_only";
+
+export interface ParsedSearchQuery {
+  raw: string;
+  freeText: string;
+  titleFilter: string | null;
+  descriptionFilter: string | null;
+  speakerFilter: string | null;
+  mode: SearchExecutionMode;
+}
+
+const SCOPE_PATTERN = /\b(title|description|speaker)\s*:/gi;
+
+function normalizeValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('"')) {
+    const unwrapped = trimmed.endsWith('"')
+      ? trimmed.slice(1, -1)
+      : trimmed.slice(1);
+    const cleaned = unwrapped.trim();
+    return cleaned || null;
+  }
+  return trimmed;
+}
+
+function appendScopedValue(existing: string | null, next: string | null): string | null {
+  if (!next) return existing;
+  if (!existing) return next;
+  return `${existing} ${next}`;
+}
+
+export function parseSearchQuery(raw: string): ParsedSearchQuery {
+  const input = raw.trim();
+  const freeTextParts: string[] = [];
+
+  let titleFilter: string | null = null;
+  let descriptionFilter: string | null = null;
+  let speakerFilter: string | null = null;
+
+  const matches = Array.from(input.matchAll(SCOPE_PATTERN));
+  if (matches.length === 0) {
+    return {
+      raw,
+      freeText: input,
+      titleFilter,
+      descriptionFilter,
+      speakerFilter,
+      mode: "transcript_hybrid",
+    };
+  }
+
+  let cursor = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const scopeName = (match[1] ?? "").toLowerCase();
+    const scopeStart = match.index ?? 0;
+    const valueStart = scopeStart + match[0].length;
+    const nextScopeStart = i + 1 < matches.length ? (matches[i + 1].index ?? input.length) : input.length;
+
+    if (scopeStart > cursor) {
+      freeTextParts.push(input.slice(cursor, scopeStart).trim());
+    }
+
+    const rawValue = input.slice(valueStart, nextScopeStart);
+    const normalized = normalizeValue(rawValue);
+    if (normalized) {
+      if (scopeName === "title") titleFilter = appendScopedValue(titleFilter, normalized);
+      if (scopeName === "description") descriptionFilter = appendScopedValue(descriptionFilter, normalized);
+      if (scopeName === "speaker") speakerFilter = appendScopedValue(speakerFilter, normalized);
+      cursor = nextScopeStart;
+      continue;
+    }
+
+    // Empty scoped value: treat the whole token as free text so it stays searchable.
+    const tokenText = input.slice(scopeStart, nextScopeStart).trim();
+    if (tokenText) freeTextParts.push(tokenText);
+    cursor = nextScopeStart;
+  }
+
+  if (cursor < input.length) {
+    freeTextParts.push(input.slice(cursor).trim());
+  }
+
+  const freeText = freeTextParts.filter(Boolean).join(" ").trim();
+  const hasScopedFilters = Boolean(titleFilter || descriptionFilter || speakerFilter);
+  const mode: SearchExecutionMode = !freeText && hasScopedFilters ? "metadata_only" : "transcript_hybrid";
+
+  return {
+    raw,
+    freeText,
+    titleFilter,
+    descriptionFilter,
+    speakerFilter,
+    mode,
+  };
+}
+
+export function buildNormalizedQuery(parsed: ParsedSearchQuery): string {
+  if (parsed.freeText) return parsed.freeText;
+  const scopedParts = [parsed.titleFilter, parsed.descriptionFilter, parsed.speakerFilter].filter(
+    (part): part is string => Boolean(part)
+  );
+  return scopedParts.join(" ").trim();
+}

--- a/apps/web/tests/e2e/search.spec.ts
+++ b/apps/web/tests/e2e/search.spec.ts
@@ -20,6 +20,14 @@ test.beforeEach(async ({ page }) => {
       body: JSON.stringify({ processed: 0, total: 0 }),
     });
   });
+
+  await page.route("**/api/search/speakers?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    });
+  });
 });
 
 test.describe("Search", () => {
@@ -39,7 +47,7 @@ test.describe("Search", () => {
     });
 
     await page.goto("/search");
-    await page.getByPlaceholder("Search transcripts...").fill("machine learning");
+    await page.getByRole("textbox").fill("machine learning");
     await page.keyboard.press("Enter");
 
     await expect(page.getByText("Found in 1 podcast, 1 episode (1 mention)")).toBeVisible();
@@ -61,10 +69,70 @@ test.describe("Search", () => {
     });
 
     await page.goto("/search");
-    await page.getByPlaceholder("Search transcripts...").fill("xyzzy_no_match_42");
+    await page.getByRole("textbox").fill("xyzzy_no_match_42");
     await page.keyboard.press("Enter");
 
     await expect(page.getByText(/No results for/i)).toBeVisible();
+  });
+
+  test("supports grouped pagination and page-size selection", async ({ page }) => {
+    const groupedRequests: string[] = [];
+
+    await page.route("**/api/search/grouped?**", async (route) => {
+      const reqUrl = route.request().url();
+      groupedRequests.push(reqUrl);
+      const url = new URL(reqUrl);
+      const pageParam = Number(url.searchParams.get("page") ?? "1");
+      const pageSizeParam = Number(url.searchParams.get("pageSize") ?? "20");
+
+      const episodeId = pageParam === 1 ? "ep-1" : "ep-2";
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          feeds: [
+            {
+              feedId: "feed-1",
+              feedTitle: "Feed",
+              feedMode: "full",
+              mentionCount: 1,
+              episodes: [
+                {
+                  episodeId,
+                  episodeTitle: `Episode ${pageParam}`,
+                  audioUrl: "https://example.com/audio.mp3",
+                  audioLocalPath: null,
+                  episodeUrl: null,
+                  mentionCount: 1,
+                  bestRank: 1,
+                },
+              ],
+            },
+          ],
+          totalFeeds: 1,
+          totalEpisodes: 40,
+          totalMentions: 40,
+          coverage: { processed: 40, total: 40 },
+          _debug: { pageParam, pageSizeParam },
+        }),
+      });
+    });
+
+    await page.goto("/search");
+    await page.getByRole("textbox").fill("trade");
+    await page.keyboard.press("Enter");
+
+    await page.getByRole("button", { name: /grouped/i }).click();
+    await expect(page.getByText(/Page 1 of 2/)).toBeVisible();
+    await page.getByRole("button", { name: "Next →" }).click();
+    await expect(page.getByText(/Page 2 of 2/)).toBeVisible();
+
+    await page.locator("select").selectOption("50");
+    await expect.poll(
+      () => groupedRequests.some((u) => u.includes("pageSize=50"))
+    ).toBeTruthy();
+    await expect(page.getByRole("button", { name: "Next →" })).toHaveCount(0);
+    expect(groupedRequests.some((u) => u.includes("pageSize=50"))).toBeTruthy();
   });
 });
 

--- a/apps/web/tests/unit/flat-search.test.ts
+++ b/apps/web/tests/unit/flat-search.test.ts
@@ -76,11 +76,11 @@ describe("GET /api/search", () => {
     expect(searchSegments).toHaveBeenCalledWith("test", ["id-1"], true, 1, 20, false, null);
   });
 
-  test("clamps pageSize to max 50", async () => {
+  test("clamps pageSize to max 100", async () => {
     searchSegments.mockResolvedValue(mockResult);
     const req = new NextRequest("http://localhost/api/search?q=test&pageSize=100");
     await GET(req);
-    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 50, false, null);
+    expect(searchSegments).toHaveBeenCalledWith("test", null, false, 1, 100, false, null);
   });
 
   test("returns 500 on search error", async () => {

--- a/apps/web/tests/unit/grouped-search.test.ts
+++ b/apps/web/tests/unit/grouped-search.test.ts
@@ -74,7 +74,7 @@ describe("GET /api/search/grouped", () => {
     expect(searchGrouped).toHaveBeenCalledWith("test", [feedId], false, 1, 20, false, null);
   });
 
-  test("clamps pageSize to max 50", async () => {
+  test("clamps pageSize to max 100", async () => {
     searchGrouped.mockResolvedValue({
       feeds: [],
       totalFeeds: 0,
@@ -86,7 +86,7 @@ describe("GET /api/search/grouped", () => {
       "http://localhost/api/search/grouped?q=test&pageSize=100"
     );
     await GET(req);
-    expect(searchGrouped).toHaveBeenCalledWith("test", null, false, 1, 50, false, null);
+    expect(searchGrouped).toHaveBeenCalledWith("test", null, false, 1, 100, false, null);
   });
 
   test("parses comma-separated feedId into array", async () => {

--- a/apps/web/tests/unit/search-lib.test.ts
+++ b/apps/web/tests/unit/search-lib.test.ts
@@ -65,6 +65,21 @@ describe("search.ts feed filtering", () => {
     expect(params).toEqual(["%iran%", 20, 0]);
   });
 
+  test("uses metadata-only episode query for description scoped search", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // metadata rows
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] }) // metadata count
+      .mockResolvedValueOnce({ rows: [{ processed: 0, total: 0 }] }); // coverage
+
+    await searchSegments("description:geopolitics", null, false, 1, 20, false);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("FROM episodes e");
+    expect(sql).toContain("COALESCE(e.description, '') ILIKE");
+    expect(sql).not.toContain("FROM speaker_turns t");
+    expect(params).toEqual(["%geopolitics%", 20, 0]);
+  });
+
   test("applies case-insensitive speaker scoped filter in transcript mode", async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [] }) // fts

--- a/apps/web/tests/unit/search-lib.test.ts
+++ b/apps/web/tests/unit/search-lib.test.ts
@@ -16,7 +16,7 @@ jest.mock("@/lib/searchHybrid", () => ({
 import pool from "@/lib/db";
 import { searchSegments } from "@/lib/search";
 
-const mockQuery = (pool as { query: jest.Mock }).query;
+const mockQuery = (pool as unknown as { query: jest.Mock }).query;
 
 describe("search.ts feed filtering", () => {
   beforeEach(() => {
@@ -49,5 +49,32 @@ describe("search.ts feed filtering", () => {
     expect(sql).toContain("f.id = ANY($2::uuid[])");
     expect(sql).toContain("e.feed_id IS NULL");
     expect(params).toEqual(["hello", ["feed-1"], 100]);
+  });
+
+  test("uses metadata-only episode query for title scoped search", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // metadata rows
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] }) // metadata count
+      .mockResolvedValueOnce({ rows: [{ processed: 0, total: 0 }] }); // coverage
+
+    await searchSegments("title:iran", null, false, 1, 20, false);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("FROM episodes e");
+    expect(sql).not.toContain("FROM speaker_turns t");
+    expect(params).toEqual(["%iran%", 20, 0]);
+  });
+
+  test("applies case-insensitive speaker scoped filter in transcript mode", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // fts
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // count
+      .mockResolvedValueOnce({ rows: [{ processed: 0, total: 0 }] }); // coverage
+
+    await searchSegments("crisis in Iran speaker: jacob", null, false, 1, 20, false);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("ILIKE");
+    expect(params).toEqual(["crisis in Iran", "%jacob%", 100]);
   });
 });

--- a/apps/web/tests/unit/search-query-parser.test.ts
+++ b/apps/web/tests/unit/search-query-parser.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+
+import { buildNormalizedQuery, parseSearchQuery } from "@/lib/search/queryParser";
+
+describe("parseSearchQuery", () => {
+  test("keeps plain query as transcript_hybrid free text", () => {
+    const parsed = parseSearchQuery("crisis in Iran");
+    expect(parsed.freeText).toBe("crisis in Iran");
+    expect(parsed.titleFilter).toBeNull();
+    expect(parsed.descriptionFilter).toBeNull();
+    expect(parsed.speakerFilter).toBeNull();
+    expect(parsed.mode).toBe("transcript_hybrid");
+  });
+
+  test("parses title-only query as metadata_only", () => {
+    const parsed = parseSearchQuery("title:What the Heck is Happening in China");
+    expect(parsed.freeText).toBe("");
+    expect(parsed.titleFilter).toBe("What the Heck is Happening in China");
+    expect(parsed.mode).toBe("metadata_only");
+  });
+
+  test("parses quoted scoped values", () => {
+    const parsed = parseSearchQuery('title:"What the Heck is Happening in China" description:"iran crisis"');
+    expect(parsed.titleFilter).toBe("What the Heck is Happening in China");
+    expect(parsed.descriptionFilter).toBe("iran crisis");
+    expect(parsed.mode).toBe("metadata_only");
+  });
+
+  test("parses case-insensitive scope names", () => {
+    const parsed = parseSearchQuery("TITLE:china SPEAKER:jacob");
+    expect(parsed.titleFilter).toBe("china");
+    expect(parsed.speakerFilter).toBe("jacob");
+    expect(parsed.mode).toBe("metadata_only");
+  });
+
+  test("parses mixed free text and speaker scope as transcript_hybrid", () => {
+    const parsed = parseSearchQuery("crisis in Iran speaker: Jacob Shapiro");
+    expect(parsed.freeText).toBe("crisis in Iran");
+    expect(parsed.speakerFilter).toBe("Jacob Shapiro");
+    expect(parsed.mode).toBe("transcript_hybrid");
+  });
+
+  test("combines multiple same-scope values", () => {
+    const parsed = parseSearchQuery("speaker: jacob speaker: shapiro");
+    expect(parsed.speakerFilter).toBe("jacob shapiro");
+    expect(parsed.mode).toBe("metadata_only");
+  });
+
+  test("treats empty scoped tokens as free text", () => {
+    const parsed = parseSearchQuery("title: speaker:   ");
+    expect(parsed.titleFilter).toBeNull();
+    expect(parsed.speakerFilter).toBeNull();
+    expect(parsed.freeText).toBe("title: speaker:");
+    expect(parsed.mode).toBe("transcript_hybrid");
+  });
+});
+
+describe("buildNormalizedQuery", () => {
+  test("prefers freeText when present", () => {
+    const parsed = parseSearchQuery("hello speaker:jacob");
+    expect(buildNormalizedQuery(parsed)).toBe("hello");
+  });
+
+  test("falls back to scoped values when freeText is empty", () => {
+    const parsed = parseSearchQuery("title:china description:iran speaker:jacob");
+    expect(buildNormalizedQuery(parsed)).toBe("china iran jacob");
+  });
+});

--- a/apps/web/tests/unit/search-query-parser.test.ts
+++ b/apps/web/tests/unit/search-query-parser.test.ts
@@ -28,6 +28,12 @@ describe("parseSearchQuery", () => {
     expect(parsed.mode).toBe("metadata_only");
   });
 
+  test("keeps colons inside quoted scoped values", () => {
+    const parsed = parseSearchQuery('title:"Interview: The Sequel"');
+    expect(parsed.titleFilter).toBe("Interview: The Sequel");
+    expect(parsed.mode).toBe("metadata_only");
+  });
+
   test("parses case-insensitive scope names", () => {
     const parsed = parseSearchQuery("TITLE:china SPEAKER:jacob");
     expect(parsed.titleFilter).toBe("china");
@@ -39,6 +45,15 @@ describe("parseSearchQuery", () => {
     const parsed = parseSearchQuery("crisis in Iran speaker: Jacob Shapiro");
     expect(parsed.freeText).toBe("crisis in Iran");
     expect(parsed.speakerFilter).toBe("Jacob Shapiro");
+    expect(parsed.mode).toBe("transcript_hybrid");
+  });
+
+  test("parses mixed query with all scopes and free text", () => {
+    const parsed = parseSearchQuery("geopolitics title:Interview speaker:jacob description:weekly");
+    expect(parsed.freeText).toBe("geopolitics");
+    expect(parsed.titleFilter).toBe("Interview");
+    expect(parsed.speakerFilter).toBe("jacob");
+    expect(parsed.descriptionFilter).toBe("weekly");
     expect(parsed.mode).toBe("transcript_hybrid");
   });
 

--- a/docs/superpowers/plans/2026-04-12-search-scoped-fields.md
+++ b/docs/superpowers/plans/2026-04-12-search-scoped-fields.md
@@ -1,0 +1,314 @@
+# Scoped Search Across Transcripts, Metadata, and Speakers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement case-insensitive scoped search (`title:`, `description:`, `speaker:`), preserve transcript hybrid behavior, and add 20/50/100 pagination controls.
+
+**Architecture:** Add a shared query parser that splits free-text and scoped filters, route search execution into transcript-hybrid or metadata-only paths in `search.ts`, then propagate page-size and pagination UI updates through search page state and APIs.
+
+**Tech Stack:** Next.js App Router, React, TanStack Query, PostgreSQL (FTS + pgvector), Jest, Playwright.
+
+---
+
+### Task 1: Add Scoped Query Parser
+
+**Files:**
+- Create: `apps/web/src/lib/search/queryParser.ts`
+- Test: `apps/web/tests/unit/search-query-parser.test.ts`
+
+- [ ] **Step 1: Create parser types and public API**
+
+Implement `queryParser.ts` with exported types/functions:
+- `ParsedSearchQuery`
+- `parseSearchQuery(raw: string): ParsedSearchQuery`
+- `buildNormalizedQuery(parsed: ParsedSearchQuery): string`
+
+Include fields:
+- `raw`
+- `freeText`
+- `titleFilter`
+- `descriptionFilter`
+- `speakerFilter`
+- `mode: "transcript_hybrid" | "metadata_only"`
+
+- [ ] **Step 2: Implement scoped token extraction**
+
+Rules:
+- recognize `title:`, `description:`, `speaker:` case-insensitively
+- support quoted and unquoted values
+- allow multiple same-scope tokens by concatenating with spaces
+- remaining text becomes `freeText`
+
+- [ ] **Step 3: Implement mode selection**
+
+Rules:
+- `metadata_only` when `freeText` is empty and at least one scoped filter is present
+- otherwise `transcript_hybrid`
+
+- [ ] **Step 4: Add parser unit tests**
+
+Cover:
+- plain free text
+- `title:` only
+- `description:` only
+- `speaker:` only (partial value)
+- quoted values with spaces
+- mixed query (`crisis in Iran speaker: Jacob Shapiro`)
+- uppercase scopes (`TITLE:`, `SPEAKER:`)
+- empty scoped value fallback behavior
+
+- [ ] **Step 5: Run parser unit tests**
+
+Run: `cd apps/web && npm test -- --runTestsByPath tests/unit/search-query-parser.test.ts`  
+Expected: PASS
+
+- [ ] **Step 6: Commit parser changes**
+
+```bash
+git add apps/web/src/lib/search/queryParser.ts apps/web/tests/unit/search-query-parser.test.ts
+git commit -m "feat: add scoped search query parser (#357)"
+```
+
+---
+
+### Task 2: Extend Flat Search API for Parsed Query + Page Size 100
+
+**Files:**
+- Modify: `apps/web/src/app/api/search/route.ts`
+- Modify: `apps/web/tests/unit/flat-search.test.ts`
+
+- [ ] **Step 1: Parse `q` into structured query in route**
+
+Import parser and transform raw query before calling search lib.
+
+- [ ] **Step 2: Raise `pageSize` max clamp to 100**
+
+Change clamp from `Math.min(50, ...)` to `Math.min(100, ...)`.
+
+- [ ] **Step 3: Update `searchSegments` call signature usage**
+
+Pass parsed query object (or equivalent structured args) while preserving existing route behavior for feed/upload/speaker params until search lib migration completes.
+
+- [ ] **Step 4: Update route tests**
+
+Add/modify tests to assert:
+- clamp to 100
+- parser-integrated invocation behavior
+- compatibility for plain unscoped query
+
+- [ ] **Step 5: Run flat route tests**
+
+Run: `cd apps/web && npm test -- --runTestsByPath tests/unit/flat-search.test.ts`  
+Expected: PASS
+
+- [ ] **Step 6: Commit flat API updates**
+
+```bash
+git add apps/web/src/app/api/search/route.ts apps/web/tests/unit/flat-search.test.ts
+git commit -m "feat: extend flat search route for scoped parsing and page size 100 (#357)"
+```
+
+---
+
+### Task 3: Extend Grouped Search API for Parsed Query + Page Size 100
+
+**Files:**
+- Modify: `apps/web/src/app/api/search/grouped/route.ts`
+- Modify: `apps/web/tests/unit/grouped-search.test.ts`
+
+- [ ] **Step 1: Parse `q` using shared parser**
+
+Apply same parser strategy as flat route.
+
+- [ ] **Step 2: Raise grouped route max page size to 100**
+
+Change clamp from 50 to 100.
+
+- [ ] **Step 3: Update grouped route tests**
+
+Assert:
+- 100 clamp
+- parser-integrated call args
+- compatibility for plain queries
+
+- [ ] **Step 4: Run grouped route tests**
+
+Run: `cd apps/web && npm test -- --runTestsByPath tests/unit/grouped-search.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit grouped API updates**
+
+```bash
+git add apps/web/src/app/api/search/grouped/route.ts apps/web/tests/unit/grouped-search.test.ts
+git commit -m "feat: extend grouped search route for scoped parsing and page size 100 (#357)"
+```
+
+---
+
+### Task 4: Add Metadata-Only Search Path in Search Library
+
+**Files:**
+- Modify: `apps/web/src/lib/search.ts`
+- Modify: `apps/web/src/lib/search/types.ts`
+- Test: `apps/web/tests/unit/search-lib.test.ts`
+
+- [ ] **Step 1: Add search function signatures for parsed query**
+
+Update `searchSegments` and `searchGrouped` signatures to receive parsed query object (or derived args) including:
+- `freeText`
+- `titleFilter`
+- `descriptionFilter`
+- `speakerFilter`
+- `mode`
+
+- [ ] **Step 2: Implement metadata-only branch in `searchSegments`**
+
+When `mode === "metadata_only"`:
+- query episodes (+ speaker metadata when needed)
+- filter by scoped fields only
+- bypass transcript FTS and vector merge
+- keep feed/status filters
+- return `SearchPage` contract with deterministic ordering
+
+- [ ] **Step 3: Implement metadata-only branch in `searchGrouped`**
+
+When scoped-only:
+- grouped counts and rows based on episode metadata matches
+- do not count transcript mentions
+
+- [ ] **Step 4: Keep transcript hybrid branch for default and mixed queries**
+
+For `transcript_hybrid`:
+- retain current FTS + vector flow
+- apply `speakerFilter` as case-insensitive partial match against speaker display/label
+- apply `titleFilter` / `descriptionFilter` as episode-level narrowing conditions
+
+- [ ] **Step 5: Extend type definitions if needed for result provenance**
+
+If UI needs to distinguish metadata match source, add optional field(s) in `SearchResult` with backward compatibility.
+
+- [ ] **Step 6: Update search library tests**
+
+Add tests for:
+- metadata-only mode path chosen
+- transcript mode preserved for unscoped query
+- mixed query with speaker scoped filter constraining transcript results
+
+- [ ] **Step 7: Run search lib tests**
+
+Run: `cd apps/web && npm test -- --runTestsByPath tests/unit/search-lib.test.ts`  
+Expected: PASS
+
+- [ ] **Step 8: Commit search library changes**
+
+```bash
+git add apps/web/src/lib/search.ts apps/web/src/lib/search/types.ts apps/web/tests/unit/search-lib.test.ts
+git commit -m "feat: add metadata-only and scoped-filter search execution paths (#357)"
+```
+
+---
+
+### Task 5: Update Search UI for Page Size + Grouped Pagination + Help Text
+
+**Files:**
+- Modify: `apps/web/src/app/search/page.tsx`
+- Potentially modify: `apps/web/src/components/SearchResult.tsx` (only if metadata-only result display needs small adjustments)
+- Update tests:
+  - `apps/web/tests/unit/search-spinner.test.tsx`
+  - `apps/web/tests/unit/search-url-priority.test.tsx`
+  - `apps/web/tests/e2e/search.spec.ts`
+
+- [ ] **Step 1: Add `pageSize` state with default 20**
+
+Update query keys and API params for both flat/grouped requests to include dynamic page size.
+
+- [ ] **Step 2: Add page-size selector UI**
+
+Provide selectable options: `20`, `50`, `100`.  
+Reset `page` to `1` when page size changes.
+
+- [ ] **Step 3: Add grouped-view pagination controls**
+
+Use grouped totals and current page/pageSize to calculate page count and render prev/next controls analogous to flat mode.
+
+- [ ] **Step 4: Update help text with scoped syntax**
+
+Include examples:
+- `title:...`
+- `description:...`
+- `speaker:...`
+- note all scoped searches are case-insensitive.
+
+- [ ] **Step 5: Update unit/e2e tests for UI behavior**
+
+Cover:
+- page-size param usage in requests
+- grouped pagination visibility and navigation
+- updated help text rendering
+
+- [ ] **Step 6: Run focused UI tests**
+
+Run:
+- `cd apps/web && npm test -- --runTestsByPath tests/unit/search-spinner.test.tsx tests/unit/search-url-priority.test.tsx`
+- `cd apps/web && npm test -- --runTestsByPath tests/e2e/search.spec.ts` (or project-standard e2e command if required)
+
+Expected: PASS
+
+- [ ] **Step 7: Commit UI changes**
+
+```bash
+git add apps/web/src/app/search/page.tsx apps/web/src/components/SearchResult.tsx apps/web/tests/unit/search-spinner.test.tsx apps/web/tests/unit/search-url-priority.test.tsx apps/web/tests/e2e/search.spec.ts
+git commit -m "feat: add scoped-search UX hints and 20/50/100 pagination controls (#357)"
+```
+
+---
+
+### Task 6: Regression Verification and Documentation
+
+**Files:**
+- Modify (if needed): `docs/guide/*` search-related docs
+- Modify: `docs/superpowers/specs/2026-04-12-search-scoped-fields-design.md` (if behavior changed during implementation)
+
+- [ ] **Step 1: Run full web test suite subset for search**
+
+Run:
+- `cd apps/web && npm run test -- --runTestsByPath tests/unit/flat-search.test.ts tests/unit/grouped-search.test.ts tests/unit/search-lib.test.ts tests/unit/search-query-parser.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 2: Run lint and typecheck**
+
+Run:
+- `cd apps/web && npm run typecheck`
+- `cd apps/web && npm run lint`
+
+Expected: No new errors
+
+- [ ] **Step 3: Update docs if required**
+
+If any final behavior differs from spec wording, update the spec and any user guide search syntax references.
+
+- [ ] **Step 4: Final commit for verification/docs**
+
+```bash
+git add docs/superpowers/specs/2026-04-12-search-scoped-fields-design.md docs/guide
+git commit -m "docs: align search docs with scoped search behavior (#357)"
+```
+
+---
+
+## Spec Coverage Check
+
+- Scoped syntax (`title:`, `description:`, `speaker:`): Tasks 1, 4, 5
+- Case-insensitive special searches and partial speaker match: Tasks 1, 4
+- Metadata-only behavior excluding transcript matches: Task 4
+- Mixed free-text + scoped constraints: Task 4
+- Pagination defaults and 20/50/100 options: Tasks 2, 3, 5
+- Grouped + flat pagination UX: Task 5
+- Regression safety: Task 6
+
+## Placeholder Scan
+
+- No TBD/TODO placeholders
+- All tasks include explicit files and commands
+- Scope is constrained to issue #357 behavior without unrelated refactors

--- a/docs/superpowers/specs/2026-04-12-search-scoped-fields-design.md
+++ b/docs/superpowers/specs/2026-04-12-search-scoped-fields-design.md
@@ -1,0 +1,140 @@
+# Scoped Search Across Transcripts, Metadata, and Speakers - Design Spec
+
+**Date:** 2026-04-12  
+**Issue:** #357  
+**Status:** Approved
+
+## Overview
+
+Expand search so users can find matches in:
+- transcript text (existing)
+- episode titles
+- episode descriptions
+- speaker names
+
+Add scoped syntax in the query input:
+- `title:<text>`
+- `description:<text>`
+- `speaker:<text>`
+
+All scoped searches must be case-insensitive, and speaker scoped values must support partial matching (for example `speaker: jacob` matches `Jacob Shapiro`).
+
+## Goals
+
+1. Keep current transcript hybrid search behavior as the default path.
+2. Add scoped filters without breaking existing query patterns.
+3. Ensure scoped-only queries do not use transcript content.
+4. Support mixed queries such as `crisis in Iran speaker: Jacob Shapiro` where transcript matching is constrained by speaker.
+5. Add pagination controls for 20 / 50 / 100 results per page.
+
+## Non-Goals
+
+1. No fuzzy ranking model changes beyond existing hybrid behavior.
+2. No schema migration requirement for the first implementation pass.
+3. No new global search endpoint; extend existing `/api/search` and `/api/search/grouped`.
+
+## Query Syntax and Semantics
+
+## Tokens
+
+- Free-text terms: anything not captured by a scoped token.
+- Scoped tokens:
+  - `title:<value>`
+  - `description:<value>`
+  - `speaker:<value>`
+
+Values are parsed as:
+- quoted (`title:"What the Heck is Happening in China"`)
+- or unquoted (`speaker: jacob`)
+
+## Case and matching rules
+
+1. `title:` and `description:` matching is case-insensitive.
+2. `speaker:` matching is case-insensitive and partial (`ILIKE '%value%'` behavior).
+3. Existing free-text transcript matching remains case-insensitive through FTS.
+
+## Execution modes
+
+1. **Transcript hybrid mode**  
+   Trigger: free-text exists (with or without scoped tokens).  
+   Behavior:
+   - transcript FTS + vector merge remains active
+   - scoped filters constrain candidate rows
+   - example: `crisis in Iran speaker: Jacob Shapiro` searches transcript for "crisis in Iran" but only for matching speaker turns.
+
+2. **Metadata-only mode**  
+   Trigger: no free-text, only scoped tokens present.  
+   Behavior:
+   - do not query transcript turns or segment embeddings
+   - query episode title / description and speaker name metadata only
+   - return results compatible with existing UI contract.
+
+## API Contract Updates
+
+Existing routes remain:
+- `GET /api/search`
+- `GET /api/search/grouped`
+
+Changes:
+1. `q` remains required and carries full user query (including scoped syntax).
+2. page size max changes from 50 to 100.
+3. server parses query into structured filters before executing search path.
+4. response shape remains backward-compatible for existing UI components.
+
+## UI Changes
+
+Search page updates:
+1. Add page size selector with values `20`, `50`, `100`.
+2. Apply page size in both flat and grouped view fetches.
+3. Add grouped-view pagination controls (same prev/next semantics).
+4. Update search help text to document scoped syntax and case-insensitive behavior.
+
+## Data and SQL Strategy
+
+## Transcript hybrid mode
+
+- Keep existing speaker-turn CTE and vector merge.
+- Apply parsed filters:
+  - `speaker:` as speaker display/label constraint
+  - `title:` and `description:` as episode-level constraints in joined `episodes`.
+
+## Metadata-only mode
+
+- Query `episodes` (+ `speaker_names` where needed) with feed filters and status constraints.
+- Build snippets from matched metadata field(s) for consistent card rendering.
+- Use deterministic ordering:
+  - highest metadata relevance first (where available)
+  - fallback by recency (`COALESCE(published_at, created_at)` desc).
+
+## Error Handling and Validation
+
+1. Empty `q` remains `400`.
+2. Malformed scoped token falls back to plain free-text rather than hard failure.
+3. If a scoped token has empty value (for example `title:`), treat as non-operative filter and continue.
+
+## Testing Strategy
+
+1. Unit: query parser
+   - quoted/unquoted tokens
+   - mixed scoped + free-text
+   - case normalization behavior
+2. Unit: API routes
+   - page size 100 accepted
+   - parsed query forwarded correctly
+3. Unit: search library
+   - metadata-only path selection
+   - mixed query with `speaker:` constraint in transcript mode
+4. UI tests
+   - page-size selector requests proper page size
+   - grouped pagination controls visible and functional
+   - help text includes scoped syntax examples
+
+## Acceptance Criteria
+
+1. `title:` scoped query matches titles case-insensitively and excludes transcript matches when scoped-only.
+2. `description:` scoped query matches descriptions case-insensitively and excludes transcript matches when scoped-only.
+3. `speaker:` scoped query matches speaker names case-insensitively with partial matching.
+4. Mixed query (`free text + speaker:`) constrains transcript results by speaker.
+5. Page size options `20`, `50`, `100` are available and functional.
+6. Grouped and flat views both support pagination with selected page size.
+7. Existing unscoped transcript search behavior remains intact.


### PR DESCRIPTION
## Summary

Implements issue #357 end-to-end:

- Adds scoped query syntax parsing for `title:`, `description:`, `speaker:`
- Makes scoped search behavior case-insensitive
- Makes `speaker:` partial-match capable (e.g. `speaker: jacob` matches `Jacob Shapiro`)
- Adds metadata-only search mode when query is scoped-only (no transcript matching)
- Preserves transcript hybrid mode for free-text and mixed queries (e.g. `crisis in Iran speaker: Jacob Shapiro`)
- Increases API page-size max to 100
- Adds search UI page-size selector (20/50/100)
- Adds grouped-view pagination controls
- Updates search tips and placeholder for scoped syntax discoverability
- Restores missing `/api/wizard/status` route used by `WizardProvider` (also resolves local typecheck blocker)

## Key Files

- `apps/web/src/lib/search/queryParser.ts`
- `apps/web/src/lib/search.ts`
- `apps/web/src/app/api/search/route.ts`
- `apps/web/src/app/api/search/grouped/route.ts`
- `apps/web/src/app/search/page.tsx`
- `apps/web/src/lib/page-state.ts`
- `apps/web/src/app/api/wizard/status/route.ts`
- `apps/web/tests/unit/search-query-parser.test.ts`
- `apps/web/tests/unit/search-lib.test.ts`
- `apps/web/tests/e2e/search.spec.ts`

## Verification

### Unit/API/UI tests

```bash
cd apps/web && npm test -- --runTestsByPath \
  tests/unit/flat-search.test.ts \
  tests/unit/grouped-search.test.ts \
  tests/unit/search-spinner.test.tsx \
  tests/unit/search-url-priority.test.tsx \
  tests/unit/search-query-parser.test.ts \
  tests/unit/search-lib.test.ts
```

Result: PASS (all tests in target set)

### Typecheck

```bash
cd apps/web && npm run typecheck
```

Result: PASS

### Lint

```bash
cd apps/web && npm run lint
```

Result: PASS (warnings only; no new errors)

### Playwright E2E (`search.spec.ts`)

Executed with a temporary isolated Playwright config on port `3100` to avoid an existing local service bound to `3000`.

```bash
cd apps/web && npx playwright test tests/e2e/search.spec.ts --config playwright.357.config.ts
```

Result: PASS (4/4)

## Commits

1. `feat(search): add scoped query parsing and metadata-aware search paths (#357)`
2. `feat(search-ui): add grouped pagination and 20/50/100 page size controls (#357)`
3. `docs(search): add issue #357 spec/plan and restore wizard status API route`

Fixes #357