### PR TITLE
Fix speaker tags on podcast episode list (issue #374)

### DIFF
--- a/apps/web/src/app/podcasts/[id]/page.tsx
+++ b/apps/web/src/app/podcasts/[id]/page.tsx
@@ -50,6 +50,12 @@ async function getEpisodes(feedId: string): Promise<EnrichedEpisode[]> {
        ) FILTER (WHERE sn.id IS NOT NULL) AS speaker_name_tags
        FROM speaker_names sn
        WHERE sn.episode_id = e.id
+         AND EXISTS (
+           SELECT 1
+           FROM segments s2
+           WHERE s2.episode_id = e.id
+             AND s2.speaker_label = sn.speaker_label
+         )
      ) sn_agg ON true
      WHERE e.feed_id = $1
      ORDER BY e.published_at DESC NULLS LAST`,

--- a/apps/web/tests/unit/podcast-page-speakers.test.tsx
+++ b/apps/web/tests/unit/podcast-page-speakers.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+
+const mockQuery = jest.fn();
+const mockEpisodesList = jest.fn(() => <div data-testid="episodes-list" />);
+
+jest.mock("@/lib/db", () => ({
+  __esModule: true,
+  default: { query: (...args: unknown[]) => mockQuery(...args) },
+}));
+
+jest.mock("next/link", () => {
+  return ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("notFound");
+  }),
+}));
+
+jest.mock("@/components/EpisodesList", () => ({
+  __esModule: true,
+  default: (props: unknown) => mockEpisodesList(props),
+}));
+
+import PodcastPage from "@/app/podcasts/[id]/page";
+
+describe("Podcast page speaker metadata", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockEpisodesList.mockClear();
+  });
+
+  it("filters speaker_name_tags to labels that still exist in episode segments", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: "feed-1", title: "Feed One", image_url: null, website_url: null, mode: "live" }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await PodcastPage({ params: Promise.resolve({ id: "feed-1" }) });
+
+    expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining("FROM speaker_names sn"), ["feed-1"]);
+    expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining("EXISTS ("), ["feed-1"]);
+    expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining("s2.speaker_label = sn.speaker_label"), ["feed-1"]);
+  });
+});


### PR DESCRIPTION
## Summary
- filter podcast-page `speaker_name_tags` to only speaker labels that currently exist in episode segments
- prevent stale `speaker_names` rows from showing extra/incorrect speaker chips
- add a regression unit test for podcast page speaker metadata SQL

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/podcast-page-speakers.test.tsx

Closes #374