### PR TITLE
feat(settings): convert to two tabs with per-tab save buttons (fixes #378)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.96.2",
         "class-variance-authority": "^0.7.0",
@@ -3514,6 +3515,36 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.96.2",
     "class-variance-authority": "^0.7.0",

--- a/apps/web/src/components/NotificationSettings.tsx
+++ b/apps/web/src/components/NotificationSettings.tsx
@@ -1,20 +1,37 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Settings, Toast } from "./NotificationSettingsSections";
 import NotificationSection from "./NotificationSection";
 import RemoteInferenceSection from "./RemoteInferenceSection";
 
+const INFERENCE_FIELDS = new Set<keyof Settings>([
+  "inference_provider",
+  "fireworks_api_key",
+  "fireworks_audio_base_url",
+  "fireworks_stt_model",
+  "fireworks_stt_diarize",
+  "fireworks_chat_base_url",
+  "fireworks_chat_model",
+  "fireworks_stt_cost_per_minute_usd",
+  "embedding_provider",
+  "embedding_model",
+  "fireworks_embedding_base_url",
+  "fireworks_embedding_model",
+]);
+
 export default function NotificationSettings() {
   const [settings, setSettings] = useState<Settings | null>(null);
-  const [saving, setSaving] = useState(false);
+  const [savingNotifications, setSavingNotifications] = useState(false);
+  const [savingInference, setSavingInference] = useState(false);
   const [testing, setTesting] = useState(false);
   const [toast, setToast] = useState<{
     message: string;
     type: "success" | "error";
   } | null>(null);
-  const [dirty, setDirty] = useState<Partial<Settings>>({});
+  const [dirtyNotifications, setDirtyNotifications] = useState<Partial<Settings>>({});
+  const [dirtyInference, setDirtyInference] = useState<Partial<Settings>>({});
 
   useEffect(() => {
     fetch("/api/notifications/settings")
@@ -40,27 +57,53 @@ export default function NotificationSettings() {
     value: string | number | boolean | null
   ) {
     setSettings((prev) => (prev ? { ...prev, [field]: value } : prev));
-    setDirty((prev) => ({ ...prev, [field]: value }));
+    if (INFERENCE_FIELDS.has(field)) {
+      setDirtyInference((prev) => ({ ...prev, [field]: value }));
+    } else {
+      setDirtyNotifications((prev) => ({ ...prev, [field]: value }));
+    }
   }
 
-  async function handleSave() {
-    if (Object.keys(dirty).length === 0) return;
-    setSaving(true);
+  async function handleSaveNotifications() {
+    if (Object.keys(dirtyNotifications).length === 0) return;
+    setSavingNotifications(true);
     try {
       const resp = await fetch("/api/notifications/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(dirty),
+        body: JSON.stringify(dirtyNotifications),
       });
       if (resp.ok) {
         const updated = await resp.json();
         setSettings(updated);
-        setDirty({});
+        setDirtyNotifications({});
+        setToast({ message: "Settings saved", type: "success" });
+      } else {
+        const err = await resp.json();
+        setToast({ message: err.error || "Failed to save", type: "error" });
+      }
+    } catch {
+      setToast({ message: "Network error", type: "error" });
+    } finally {
+      setSavingNotifications(false);
+    }
+  }
+
+  async function handleSaveInference() {
+    if (Object.keys(dirtyInference).length === 0) return;
+    setSavingInference(true);
+    try {
+      const resp = await fetch("/api/notifications/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(dirtyInference),
+      });
+      if (resp.ok) {
+        const updated = await resp.json();
+        setSettings(updated);
+        setDirtyInference({});
         if (updated.fireworks_key_warning) {
-          setToast({
-            message: updated.fireworks_key_warning,
-            type: "error",
-          });
+          setToast({ message: updated.fireworks_key_warning, type: "error" });
           return;
         }
         setToast({ message: "Settings saved", type: "success" });
@@ -71,7 +114,7 @@ export default function NotificationSettings() {
     } catch {
       setToast({ message: "Network error", type: "error" });
     } finally {
-      setSaving(false);
+      setSavingInference(false);
     }
   }
 
@@ -108,43 +151,43 @@ export default function NotificationSettings() {
         </p>
       </div>
 
-      {/* Section 1: Notifications */}
-      <section>
-        <h2 className="text-lg font-semibold mb-1">Notifications</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Configure how and when Podlog sends you notifications about processed
-          episodes and system health.
-        </p>
-        <NotificationSection
-          settings={settings}
-          onChange={handleChange}
-          onTest={handleTest}
-          testing={testing}
-        />
-      </section>
+      <Tabs defaultValue="notifications">
+        <TabsList className="mb-6">
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="inference">Remote Inference</TabsTrigger>
+        </TabsList>
 
-      <Separator className="my-8" />
+        <TabsContent value="notifications">
+          <NotificationSection
+            settings={settings}
+            onChange={handleChange}
+            onTest={handleTest}
+            testing={testing}
+          />
+          <div className="flex gap-3 mt-8 mb-4">
+            <button
+              className={actionButtonClass}
+              onClick={handleSaveNotifications}
+              disabled={savingNotifications || Object.keys(dirtyNotifications).length === 0}
+            >
+              {savingNotifications ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </TabsContent>
 
-      {/* Section 2: Remote Inference */}
-      <section>
-        <h2 className="text-lg font-semibold mb-1">Remote Inference</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Configure which pipeline steps run locally and which use a remote
-          provider for faster processing.
-        </p>
-        <RemoteInferenceSection settings={settings} onChange={handleChange} />
-      </section>
-
-      {/* Single Save button */}
-      <div className="flex gap-3 mt-8 mb-4">
-        <button
-          className={actionButtonClass}
-          onClick={handleSave}
-          disabled={saving || Object.keys(dirty).length === 0}
-        >
-          {saving ? "Saving..." : "Save"}
-        </button>
-      </div>
+        <TabsContent value="inference">
+          <RemoteInferenceSection settings={settings} onChange={handleChange} />
+          <div className="flex gap-3 mt-8 mb-4">
+            <button
+              className={actionButtonClass}
+              onClick={handleSaveInference}
+              disabled={savingInference || Object.keys(dirtyInference).length === 0}
+            >
+              {savingInference ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </TabsContent>
+      </Tabs>
 
       {toast && <Toast message={toast.message} type={toast.type} />}
     </div>

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/apps/web/tests/unit/notification-settings.test.tsx
+++ b/apps/web/tests/unit/notification-settings.test.tsx
@@ -114,6 +114,7 @@ describe("NotificationSettings", () => {
   });
 
   it("calls PUT on save in Notifications tab", async () => {
+    const user = userEvent.setup();
     mockFetch.mockImplementation((url: string) => {
       if (url === "/api/hardware") {
         return Promise.resolve({
@@ -128,15 +129,14 @@ describe("NotificationSettings", () => {
     });
 
     render(<NotificationSettings />);
-    await waitFor(() => screen.getByLabelText(/bot token/i));
+    const tokenInput = await screen.findByLabelText(/bot token/i);
 
-    fireEvent.change(screen.getByLabelText(/bot token/i), {
-      target: { value: "123:ABC" },
-    });
+    await user.clear(tokenInput);
+    await user.type(tokenInput, "123:ABC");
 
     // Click the Save button in the active (Notifications) tab
     const saveButtons = screen.getAllByRole("button", { name: /save/i });
-    fireEvent.click(saveButtons[0]);
+    await user.click(saveButtons[0]);
 
     await waitFor(() => {
       const putCall = mockFetch.mock.calls.find(

--- a/apps/web/tests/unit/notification-settings.test.tsx
+++ b/apps/web/tests/unit/notification-settings.test.tsx
@@ -3,6 +3,7 @@
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import NotificationSettings from "@/components/NotificationSettings";
 
 // Mock fetch globally
@@ -66,15 +67,15 @@ beforeEach(() => {
 });
 
 describe("NotificationSettings", () => {
-  it("renders both sections", async () => {
+  it("renders both tab triggers", async () => {
     render(<NotificationSettings />);
     await waitFor(() => {
-      expect(screen.getByText("Notifications")).toBeInTheDocument();
-      expect(screen.getByText("Remote Inference")).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Notifications" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Remote Inference" })).toBeInTheDocument();
     });
   });
 
-  it("shows telegram fields", async () => {
+  it("shows telegram fields in Notifications tab (default)", async () => {
     render(<NotificationSettings />);
     await waitFor(() => {
       expect(screen.getByLabelText(/bot token/i)).toBeInTheDocument();
@@ -82,7 +83,7 @@ describe("NotificationSettings", () => {
     });
   });
 
-  it("shows email fields", async () => {
+  it("shows email fields in Notifications tab (default)", async () => {
     render(<NotificationSettings />);
     await waitFor(() => {
       expect(screen.getByText(/send to/i)).toBeInTheDocument();
@@ -90,25 +91,29 @@ describe("NotificationSettings", () => {
     });
   });
 
-  it("shows general settings", async () => {
+  it("shows general settings in Notifications tab (default)", async () => {
     render(<NotificationSettings />);
     await waitFor(() => {
       expect(screen.getByLabelText(/notification frequency/i)).toBeInTheDocument();
     });
   });
 
-  it("shows pipeline step cards", async () => {
+  it("shows pipeline step cards in Remote Inference tab", async () => {
+    const user = userEvent.setup();
     render(<NotificationSettings />);
-    await waitFor(() => {
-      expect(screen.getByText("Transcription")).toBeInTheDocument();
-      expect(screen.getByText("Diarization")).toBeInTheDocument();
-      expect(screen.getByText("Speaker Inference")).toBeInTheDocument();
-      expect(screen.getByText("Embedding")).toBeInTheDocument();
-      expect(screen.getByText("RAG / Ask")).toBeInTheDocument();
-    });
+    // Wait for tabs to be available
+    const inferenceTab = await screen.findByRole("tab", { name: "Remote Inference" });
+    await user.click(inferenceTab);
+    // Wait for the Remote Inference section to load with pipeline steps
+    const transcription = await screen.findByText("Transcription");
+    expect(transcription).toBeInTheDocument();
+    expect(screen.getByText("Diarization")).toBeInTheDocument();
+    expect(screen.getByText("Speaker Inference")).toBeInTheDocument();
+    expect(screen.getByText("Embedding")).toBeInTheDocument();
+    expect(screen.getByText("RAG / Ask")).toBeInTheDocument();
   });
 
-  it("calls PUT on save", async () => {
+  it("calls PUT on save in Notifications tab", async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url === "/api/hardware") {
         return Promise.resolve({
@@ -128,7 +133,10 @@ describe("NotificationSettings", () => {
     fireEvent.change(screen.getByLabelText(/bot token/i), {
       target: { value: "123:ABC" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    // Click the Save button in the active (Notifications) tab
+    const saveButtons = screen.getAllByRole("button", { name: /save/i });
+    fireEvent.click(saveButtons[0]);
 
     await waitFor(() => {
       const putCall = mockFetch.mock.calls.find(
@@ -146,15 +154,29 @@ describe("NotificationSettings", () => {
     });
   });
 
-  it("shows fireworks API key field", async () => {
+  it("shows fireworks API key field in Remote Inference tab", async () => {
+    const user = userEvent.setup();
     render(<NotificationSettings />);
-    await waitFor(() => {
-      expect(screen.getByText(/fireworks api key/i)).toBeInTheDocument();
-    });
+    const inferenceTab = await screen.findByRole("tab", { name: "Remote Inference" });
+    await user.click(inferenceTab);
+    // The API key field should be available after the tab content is rendered
+    const apiKeyLabel = await screen.findByText(/fireworks api key/i);
+    expect(apiKeyLabel).toBeInTheDocument();
   });
 
-  it("save button is disabled when no changes", async () => {
+  it("Notifications Save button is disabled when no changes", async () => {
     render(<NotificationSettings />);
+    await waitFor(() => screen.getByLabelText(/bot token/i));
+    const saveButtons = screen.getAllByRole("button", { name: /save/i });
+    expect(saveButtons[0]).toBeDisabled();
+  });
+
+  it("Remote Inference Save button is disabled when no changes", async () => {
+    const user = userEvent.setup();
+    render(<NotificationSettings />);
+    const inferenceTab = await screen.findByRole("tab", { name: "Remote Inference" });
+    await user.click(inferenceTab);
+    // After clicking Remote Inference tab, the Save button should be visible and disabled (no changes made)
     await waitFor(() => {
       const saveBtn = screen.getByRole("button", { name: /save/i });
       expect(saveBtn).toBeDisabled();

--- a/apps/web/tests/unit/podcast-page-speakers.test.tsx
+++ b/apps/web/tests/unit/podcast-page-speakers.test.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 
 const mockQuery = jest.fn();
-const mockEpisodesList = jest.fn(() => <div data-testid="episodes-list" />);
+const mockEpisodesList = jest.fn((_props?: unknown) => <div data-testid="episodes-list" />);
 
 jest.mock("@/lib/db", () => ({
   __esModule: true,

--- a/docs/superpowers/plans/2026-04-13-settings-tabs.md
+++ b/docs/superpowers/plans/2026-04-13-settings-tabs.md
@@ -1,0 +1,565 @@
+# Settings Page Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the settings page from a single-scroll layout into two tabs ("Notifications" and "Remote Inference"), each with its own Save button.
+
+**Architecture:** Install shadcn/ui Tabs component, then refactor `NotificationSettings.tsx` to split `dirty` state into `dirtyNotifications` + `dirtyInference`, route `handleChange` to the correct tracker by field key, and wrap each section in a `<TabsContent>` with its own Save button. No changes to `NotificationSection`, `RemoteInferenceSection`, or API routes.
+
+**Tech Stack:** shadcn/ui Tabs (Radix UI), React `useState`, existing `/api/notifications/settings` PUT endpoint
+
+---
+
+### Task 1: Install shadcn Tabs component
+
+**Files:**
+- Create: `apps/web/src/components/ui/tabs.tsx`
+
+- [ ] **Step 1: Install the component**
+
+```bash
+cd /home/brlauuu/repos/podlog/apps/web && npx shadcn@latest add tabs
+```
+
+Expected output: `✔ Done` and new file `src/components/ui/tabs.tsx` created.
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls /home/brlauuu/repos/podlog/apps/web/src/components/ui/tabs.tsx
+```
+
+Expected: file path printed (no error).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/brlauuu/repos/podlog
+git add apps/web/src/components/ui/tabs.tsx apps/web/package.json apps/web/package-lock.json
+git commit -m "chore(web): install shadcn Tabs component"
+```
+
+---
+
+### Task 2: Refactor `NotificationSettings.tsx` to tabbed layout
+
+**Files:**
+- Modify: `apps/web/src/components/NotificationSettings.tsx`
+
+- [ ] **Step 1: Replace the component with the tabbed version**
+
+Replace the entire contents of `apps/web/src/components/NotificationSettings.tsx` with:
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Settings, Toast } from "./NotificationSettingsSections";
+import NotificationSection from "./NotificationSection";
+import RemoteInferenceSection from "./RemoteInferenceSection";
+
+const INFERENCE_FIELDS = new Set<keyof Settings>([
+  "inference_provider",
+  "fireworks_api_key",
+  "fireworks_audio_base_url",
+  "fireworks_stt_model",
+  "fireworks_stt_diarize",
+  "fireworks_chat_base_url",
+  "fireworks_chat_model",
+  "fireworks_stt_cost_per_minute_usd",
+  "embedding_provider",
+  "embedding_model",
+  "fireworks_embedding_base_url",
+  "fireworks_embedding_model",
+]);
+
+export default function NotificationSettings() {
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [savingNotifications, setSavingNotifications] = useState(false);
+  const [savingInference, setSavingInference] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [dirtyNotifications, setDirtyNotifications] = useState<Partial<Settings>>({});
+  const [dirtyInference, setDirtyInference] = useState<Partial<Settings>>({});
+
+  useEffect(() => {
+    fetch("/api/notifications/settings")
+      .then((r) => r.json())
+      .then((data) => setSettings(data))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(id);
+  }, [toast]);
+
+  if (!settings) {
+    return (
+      <div className="text-muted-foreground text-sm">Loading settings...</div>
+    );
+  }
+
+  function handleChange(
+    field: keyof Settings,
+    value: string | number | boolean | null
+  ) {
+    setSettings((prev) => (prev ? { ...prev, [field]: value } : prev));
+    if (INFERENCE_FIELDS.has(field)) {
+      setDirtyInference((prev) => ({ ...prev, [field]: value }));
+    } else {
+      setDirtyNotifications((prev) => ({ ...prev, [field]: value }));
+    }
+  }
+
+  async function handleSaveNotifications() {
+    if (Object.keys(dirtyNotifications).length === 0) return;
+    setSavingNotifications(true);
+    try {
+      const resp = await fetch("/api/notifications/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(dirtyNotifications),
+      });
+      if (resp.ok) {
+        const updated = await resp.json();
+        setSettings(updated);
+        setDirtyNotifications({});
+        setToast({ message: "Settings saved", type: "success" });
+      } else {
+        const err = await resp.json();
+        setToast({ message: err.error || "Failed to save", type: "error" });
+      }
+    } catch {
+      setToast({ message: "Network error", type: "error" });
+    } finally {
+      setSavingNotifications(false);
+    }
+  }
+
+  async function handleSaveInference() {
+    if (Object.keys(dirtyInference).length === 0) return;
+    setSavingInference(true);
+    try {
+      const resp = await fetch("/api/notifications/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(dirtyInference),
+      });
+      if (resp.ok) {
+        const updated = await resp.json();
+        setSettings(updated);
+        setDirtyInference({});
+        if (updated.fireworks_key_warning) {
+          setToast({ message: updated.fireworks_key_warning, type: "error" });
+          return;
+        }
+        setToast({ message: "Settings saved", type: "success" });
+      } else {
+        const err = await resp.json();
+        setToast({ message: err.error || "Failed to save", type: "error" });
+      }
+    } catch {
+      setToast({ message: "Network error", type: "error" });
+    } finally {
+      setSavingInference(false);
+    }
+  }
+
+  async function handleTest(channel: "telegram" | "email") {
+    setTesting(true);
+    try {
+      const resp = await fetch("/api/notifications/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channel }),
+      });
+      if (resp.ok) {
+        setToast({ message: "Test message sent", type: "success" });
+      } else {
+        const err = await resp.json();
+        setToast({ message: err.error || "Test failed", type: "error" });
+      }
+    } catch {
+      setToast({ message: "Network error", type: "error" });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  const actionButtonClass =
+    "px-5 py-2 rounded-md bg-action text-action-foreground text-sm font-medium hover:bg-action/90 disabled:opacity-50";
+
+  return (
+    <div>
+      <div className="mb-5">
+        <h1 className="text-xl font-semibold">Settings</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure notifications and remote inference providers.
+        </p>
+      </div>
+
+      <Tabs defaultValue="notifications">
+        <TabsList className="mb-6">
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="inference">Remote Inference</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="notifications">
+          <NotificationSection
+            settings={settings}
+            onChange={handleChange}
+            onTest={handleTest}
+            testing={testing}
+          />
+          <div className="flex gap-3 mt-8 mb-4">
+            <button
+              className={actionButtonClass}
+              onClick={handleSaveNotifications}
+              disabled={savingNotifications || Object.keys(dirtyNotifications).length === 0}
+            >
+              {savingNotifications ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="inference">
+          <RemoteInferenceSection settings={settings} onChange={handleChange} />
+          <div className="flex gap-3 mt-8 mb-4">
+            <button
+              className={actionButtonClass}
+              onClick={handleSaveInference}
+              disabled={savingInference || Object.keys(dirtyInference).length === 0}
+            >
+              {savingInference ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      {toast && <Toast message={toast.message} type={toast.type} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+```bash
+cd /home/brlauuu/repos/podlog/apps/web && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/brlauuu/repos/podlog
+git add apps/web/src/components/NotificationSettings.tsx
+git commit -m "feat(settings): convert to tabbed layout with per-tab save buttons (fixes #378)"
+```
+
+---
+
+### Task 3: Update tests for tabbed layout
+
+**Files:**
+- Modify: `apps/web/tests/unit/notification-settings.test.tsx`
+
+The following tests need updates because:
+- `shows pipeline step cards` and `shows fireworks API key field` check content in the Remote Inference tab, which is not active by default — they need to click the "Remote Inference" tab first.
+- `save button is disabled when no changes` uses `getByRole("button", { name: /save/i })` which now matches two buttons — needs `getAllByRole` or a more specific query.
+- `calls PUT on save` fires the Save button after changing a Notifications field — still works but needs the specific Notifications tab Save button.
+
+- [ ] **Step 1: Update the test file**
+
+Replace the entire contents of `apps/web/tests/unit/notification-settings.test.tsx` with:
+
+```tsx
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NotificationSettings from "@/components/NotificationSettings";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const defaultSettings = {
+  telegram_bot_token: null,
+  telegram_chat_id: null,
+  notification_email_to: null,
+  notification_email_from: "podlog@localhost",
+  smtp_host: "host.docker.internal",
+  smtp_port: 25,
+  smtp_user: null,
+  smtp_password: null,
+  smtp_use_tls: false,
+  notification_frequency: "immediate",
+  health_check_notifications_enabled: true,
+  inference_provider: "local",
+  fireworks_api_key: null,
+  fireworks_audio_base_url: "https://audio-turbo.api.fireworks.ai",
+  fireworks_stt_model: "whisper-v3-turbo",
+  fireworks_stt_diarize: true,
+  fireworks_stt_cost_per_minute_usd: 0.006,
+  fireworks_chat_base_url: "https://api.fireworks.ai/inference/v1",
+  fireworks_chat_model: "accounts/fireworks/models/llama-v3p1-8b-instruct",
+  embedding_provider: "local",
+  embedding_model: "all-MiniLM-L6-v2",
+  fireworks_embedding_base_url: "https://api.fireworks.ai/inference/v1",
+  fireworks_embedding_model: "BAAI/bge-small-en-v1.5",
+  telegram_configured: false,
+  email_configured: false,
+  fireworks_configured: false,
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockImplementation((url: string) => {
+    if (url === "/api/hardware") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          hardware: null,
+          profile: null,
+          profile_label: null,
+          estimates: {
+            transcription_minutes_per_hour: null,
+            embedding_seconds_per_hour: null,
+            remote_transcription_minutes_per_hour: 3,
+            remote_embedding_seconds_per_hour: 5,
+            remote_cost_per_hour_usd: 0.36,
+          },
+        }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ ...defaultSettings }),
+    });
+  });
+});
+
+describe("NotificationSettings", () => {
+  it("renders both tab triggers", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Notifications" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Remote Inference" })).toBeInTheDocument();
+    });
+  });
+
+  it("shows telegram fields in Notifications tab (default)", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/bot token/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/chat id/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows email fields in Notifications tab (default)", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(screen.getByText(/send to/i)).toBeInTheDocument();
+      expect(screen.getByText(/from address/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows general settings in Notifications tab (default)", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(screen.getByLabelText(/notification frequency/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows pipeline step cards in Remote Inference tab", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByRole("tab", { name: "Remote Inference" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Remote Inference" }));
+    await waitFor(() => {
+      expect(screen.getByText("Transcription")).toBeInTheDocument();
+      expect(screen.getByText("Diarization")).toBeInTheDocument();
+      expect(screen.getByText("Speaker Inference")).toBeInTheDocument();
+      expect(screen.getByText("Embedding")).toBeInTheDocument();
+      expect(screen.getByText("RAG / Ask")).toBeInTheDocument();
+    });
+  });
+
+  it("calls PUT on save in Notifications tab", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/api/hardware") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ hardware: null, profile: null, profile_label: null, estimates: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ ...defaultSettings }),
+      });
+    });
+
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByLabelText(/bot token/i));
+
+    fireEvent.change(screen.getByLabelText(/bot token/i), {
+      target: { value: "123:ABC" },
+    });
+
+    // Click the Save button in the active (Notifications) tab
+    const saveButtons = screen.getAllByRole("button", { name: /save/i });
+    fireEvent.click(saveButtons[0]);
+
+    await waitFor(() => {
+      const putCall = mockFetch.mock.calls.find(
+        (c: [string, RequestInit?]) => c[1]?.method === "PUT"
+      );
+      expect(putCall).toBeTruthy();
+    });
+  });
+
+  it("disables test button when telegram not configured", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      const testBtn = screen.getByRole("button", { name: /send test message/i });
+      expect(testBtn).toBeDisabled();
+    });
+  });
+
+  it("shows fireworks API key field in Remote Inference tab", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByRole("tab", { name: "Remote Inference" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Remote Inference" }));
+    await waitFor(() => {
+      expect(screen.getByText(/fireworks api key/i)).toBeInTheDocument();
+    });
+  });
+
+  it("Notifications Save button is disabled when no changes", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByLabelText(/bot token/i));
+    const saveButtons = screen.getAllByRole("button", { name: /save/i });
+    expect(saveButtons[0]).toBeDisabled();
+  });
+
+  it("Remote Inference Save button is disabled when no changes", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByRole("tab", { name: "Remote Inference" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Remote Inference" }));
+    await waitFor(() => {
+      const saveButtons = screen.getAllByRole("button", { name: /save/i });
+      expect(saveButtons[0]).toBeDisabled();
+    });
+  });
+});
+
+describe("Email tag input", () => {
+  beforeEach(() => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/api/hardware") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ hardware: null, profile: null, profile_label: null, estimates: {} }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          ...defaultSettings,
+          notification_email_to: "existing@example.com",
+          email_configured: true,
+        }),
+      });
+    });
+  });
+
+  it("displays existing emails as tags", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("existing@example.com")).toBeInTheDocument();
+    });
+  });
+
+  it("adds a valid email on Enter", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByText("existing@example.com"));
+
+    const input = screen.getByPlaceholderText(/add email/i);
+    fireEvent.change(input, { target: { value: "new@example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("new@example.com")).toBeInTheDocument();
+  });
+
+  it("rejects an invalid email with error message", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByText("existing@example.com"));
+
+    const input = screen.getByPlaceholderText(/add email/i);
+    fireEvent.change(input, { target: { value: "not-an-email" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText(/invalid email/i)).toBeInTheDocument();
+  });
+
+  it("removes an email when X is clicked", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByText("existing@example.com"));
+
+    const removeBtn = screen.getByRole("button", { name: /remove existing@example.com/i });
+    fireEvent.click(removeBtn);
+
+    expect(screen.queryByText("existing@example.com")).not.toBeInTheDocument();
+  });
+
+  it("prevents duplicate emails", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => screen.getByText("existing@example.com"));
+
+    const input = screen.getByPlaceholderText(/add email/i);
+    fireEvent.change(input, { target: { value: "existing@example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText(/already added/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cd /home/brlauuu/repos/podlog/apps/web && npx jest --no-coverage 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/brlauuu/repos/podlog
+git add apps/web/tests/unit/notification-settings.test.tsx
+git commit -m "test(settings): update tests for tabbed layout"
+```
+
+---
+
+### Task 4: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Run full test suite and typecheck**
+
+```bash
+cd /home/brlauuu/repos/podlog/apps/web && npx tsc --noEmit && npx jest --no-coverage 2>&1 | tail -10
+```
+
+Expected: typecheck clean, all tests pass.

--- a/docs/superpowers/specs/2026-04-13-settings-tabs-design.md
+++ b/docs/superpowers/specs/2026-04-13-settings-tabs-design.md
@@ -1,0 +1,90 @@
+# Settings Page Tabs Design
+
+## Problem
+
+The settings page (`/settings`) displays notifications and remote inference configuration as two stacked sections separated by a divider. Issue #378 asks for two tabs instead, making it immediately obvious both setting categories exist.
+
+## Goal
+
+Convert `NotificationSettings.tsx` from a single-scroll layout to a two-tab layout using shadcn/ui Tabs. Each tab gets its own Save button that only saves that tab's dirty fields.
+
+## Design
+
+### Tab Structure
+
+| Tab | Label | Content |
+|-----|-------|---------|
+| 1 | Notifications | `NotificationSection` + its Save button |
+| 2 | Remote Inference | `RemoteInferenceSection` + its Save button |
+
+The page title ("Settings") and subtitle remain above the tabs. The `Toast` component remains shared (one toast for the whole page).
+
+### State Management
+
+`NotificationSettings.tsx` currently has one `dirty: Partial<Settings>` object. This splits into two:
+
+```ts
+const [dirtyNotifications, setDirtyNotifications] = useState<Partial<Settings>>({});
+const [dirtyInference, setDirtyInference] = useState<Partial<Settings>>({});
+```
+
+`handleChange` routes to the correct dirty tracker based on the field key:
+
+```ts
+const INFERENCE_FIELDS: Set<keyof Settings> = new Set([
+  "inference_provider", "fireworks_api_key", "fireworks_audio_base_url",
+  "fireworks_stt_model", "fireworks_stt_diarize", "fireworks_chat_base_url",
+  "fireworks_chat_model", "fireworks_stt_cost_per_minute_usd",
+  "embedding_provider", "embedding_model", "fireworks_embedding_base_url",
+  "fireworks_embedding_model",
+]);
+
+function handleChange(field: keyof Settings, value: ...) {
+  setSettings(prev => prev ? { ...prev, [field]: value } : prev);
+  if (INFERENCE_FIELDS.has(field)) {
+    setDirtyInference(prev => ({ ...prev, [field]: value }));
+  } else {
+    setDirtyNotifications(prev => ({ ...prev, [field]: value }));
+  }
+}
+```
+
+Two save handlers:
+
+```ts
+async function handleSaveNotifications() { /* sends dirtyNotifications */ }
+async function handleSaveInference() { /* sends dirtyInference */ }
+```
+
+Each save handler follows the same pattern as the current `handleSave`: PUT to `/api/notifications/settings`, update `settings`, clear its own dirty tracker, show toast.
+
+### Tab Component
+
+Install shadcn Tabs:
+```bash
+npx shadcn@latest add tabs
+```
+
+Use `<Tabs defaultValue="notifications">` with the two tabs. The active tab is not persisted (default is always Notifications on page load).
+
+### Save Button Placement
+
+Each tab's Save button sits at the bottom of its `<TabsContent>`, above the shared `<Toast>`.
+
+### Test (Notification Tab Only)
+
+The "Send Test" button for notifications stays in the Notifications tab, behavior unchanged.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/src/components/ui/tabs.tsx` | Create — shadcn install |
+| `apps/web/src/components/NotificationSettings.tsx` | Modify — split dirty state, add tabs layout |
+| `apps/web/tests/unit/notification-settings.test.tsx` | Modify — update tests for tab structure |
+
+## Out of Scope
+
+- URL-based or localStorage tab persistence
+- Changes to `NotificationSection`, `RemoteInferenceSection`, or API routes
+- Any new settings fields


### PR DESCRIPTION
## Summary

- Converted settings page from single-scroll layout to two tabs: **Notifications** and **Remote Inference**
- Each tab has its own Save button, disabled until that tab has unsaved changes
- Split dirty state tracking into `dirtyNotifications` / `dirtyInference` routed by a `INFERENCE_FIELDS` set in `handleChange`
- Installed shadcn/ui Tabs component; no changes to `NotificationSection`, `RemoteInferenceSection`, or API routes

## Test Plan

- [ ] 15 updated unit tests covering tab rendering, per-tab save behavior, and disabled states
- [ ] Remote Inference tab content verified by clicking the tab in tests
- [ ] All 180 tests pass, typecheck clean

Fixes #378