### PR TITLE
Update README credits with linked agents and platforms (issue #373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,18 @@ make help            # List all available commands
 
 ## Credits
 
-Built by [@brlauuu](https://github.com/brlauuu) and [Claude](https://claude.ai) (Anthropic).
+Built by [@brlauuu](https://github.com/brlauuu) with support from:
+
+Agents:
+
+- [Claude](https://claude.ai)
+- [Gemini](https://gemini.google.com)
+- [OpenCode](https://opencode.ai) (running [Kimi K2.5](https://platform.kimi.com/docs/guide/kimi-k2-5-quickstart) and [Big Pickle](https://opencode.ai))
+
+Platforms:
+
+- [Omnara](https://omnara.cc)
+- [Fireworks AI](https://fireworks.ai) (optional remote inference for Podlog)
 
 ## License
 


### PR DESCRIPTION
## Summary
- update README credits to include explicit Agents and Platforms sections
- add links for Gemini, OpenCode, Kimi K2.5, Big Pickle, and Omnara
- add Fireworks AI as a platform that can be used with Podlog remote inference

## Scope
- README only

Closes #373