### PR TITLE
Implement in-app markdown docs navigation (issue #384)

### DIFF
--- a/apps/web/src/app/docs/DocsClient.tsx
+++ b/apps/web/src/app/docs/DocsClient.tsx
@@ -69,10 +69,27 @@ export default function DocsClient({ docs }: DocsClientProps) {
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const currentPage = searchParams.get("page") || "README";
+  const requestedPage = searchParams.get("page");
+  const defaultPage = docs.find((doc) => doc.name === "README")?.name ?? docs[0]?.name ?? null;
+  const currentPage = docs.some((doc) => doc.name === requestedPage)
+    ? requestedPage
+    : defaultPage;
+
+  useEffect(() => {
+    if (!docs.length) return;
+    if (requestedPage && docs.some((doc) => doc.name === requestedPage)) return;
+    if (!currentPage) return;
+    router.replace(`/docs?page=${encodeURIComponent(currentPage)}`);
+  }, [docs, requestedPage, currentPage, router]);
 
   // Fetch doc content when page changes
   useEffect(() => {
+    if (!currentPage) {
+      setContent(null);
+      setLoading(false);
+      return;
+    }
+
     const fetchContent = async () => {
       setLoading(true);
       try {
@@ -92,15 +109,35 @@ export default function DocsClient({ docs }: DocsClientProps) {
   }, [currentPage]);
 
   return (
-    <div className="flex gap-6 max-w-6xl mx-auto px-4 py-6">
-      {/* Sidebar */}
-      <aside className="w-52 shrink-0">
-        <h2 className="text-sm font-semibold text-muted-foreground mb-3 px-2">Guide</h2>
-        <nav className="space-y-1">
+    <div className="flex flex-col gap-4 md:flex-row md:gap-6 max-w-6xl mx-auto px-4 py-6">
+      {/* Sidebar / mobile navigator */}
+      <aside className="w-full md:w-52 md:shrink-0">
+        <h2 className="text-sm font-semibold text-muted-foreground mb-2 px-1">Guide</h2>
+        <div className="md:hidden">
+          <label htmlFor="docs-page-select" className="sr-only">Choose document</label>
+          <select
+            id="docs-page-select"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={currentPage ?? ""}
+            onChange={(e) => router.push(`/docs?page=${encodeURIComponent(e.target.value)}`)}
+            disabled={!docs.length}
+          >
+            {docs.length === 0 ? (
+              <option value="">No documents available</option>
+            ) : (
+              docs.map((doc) => (
+                <option key={doc.name} value={doc.name}>
+                  {doc.title}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+        <nav className="hidden md:block space-y-1">
           {docs.map((doc) => (
             <button
               key={doc.name}
-              onClick={() => router.push(`/docs?page=${doc.name}`)}
+              onClick={() => router.push(`/docs?page=${encodeURIComponent(doc.name)}`)}
               className={`w-full text-left px-2 py-1.5 rounded-md text-sm transition-colors ${
                 currentPage === doc.name
                   ? "bg-accent text-accent-foreground font-medium"
@@ -115,7 +152,16 @@ export default function DocsClient({ docs }: DocsClientProps) {
 
       {/* Content */}
       <main className="flex-1 min-w-0">
-        {loading ? (
+        {docs.length === 0 ? (
+          <div className="text-muted-foreground">
+            <h1 className="text-2xl font-bold mb-3">Documentation</h1>
+            <p className="mb-2">No markdown docs were found.</p>
+            <p>
+              Ensure `docs/guide` is available in this environment (for Docker web container,
+              mount it at <code>/docs/guide</code>).
+            </p>
+          </div>
+        ) : loading ? (
           <div className="text-muted-foreground">Loading...</div>
         ) : content ? (
           <article className="prose prose-sm max-w-none dark:prose-invert">
@@ -143,8 +189,17 @@ export default function DocsClient({ docs }: DocsClientProps) {
           </article>
         ) : (
           <div className="text-muted-foreground">
-            <h1 className="text-2xl font-bold mb-4">Documentation</h1>
-            <p>Could not load the requested page.</p>
+            <h1 className="text-2xl font-bold mb-3">Documentation</h1>
+            <p className="mb-3">Could not load the requested page.</p>
+            {defaultPage && (
+              <button
+                type="button"
+                onClick={() => router.push(`/docs?page=${encodeURIComponent(defaultPage)}`)}
+                className="text-sm px-3 py-1.5 rounded-md border border-input hover:bg-accent transition-colors"
+              >
+                Open default page
+              </button>
+            )}
           </div>
         )}
       </main>

--- a/apps/web/tests/unit/docs.test.tsx
+++ b/apps/web/tests/unit/docs.test.tsx
@@ -29,6 +29,8 @@ describe("DocsClient", () => {
     { name: "01-installation", title: "Installation" },
     { name: "02-first-run", title: "First Run" },
   ];
+  const mockPush = jest.fn();
+  const mockReplace = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,7 +38,8 @@ describe("DocsClient", () => {
       get: () => "README",
     });
     mockUseRouter.mockReturnValue({
-      push: jest.fn(),
+      push: mockPush,
+      replace: mockReplace,
     });
     global.fetch = jest.fn();
   });
@@ -49,9 +52,9 @@ describe("DocsClient", () => {
 
     render(<DocsClient docs={mockDocs} />);
 
-    expect(screen.getByText("README")).toBeInTheDocument();
-    expect(screen.getByText("Installation")).toBeInTheDocument();
-    expect(screen.getByText("First Run")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "README" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Installation" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "First Run" })).toBeInTheDocument();
   });
 
   it("renders markdown content", async () => {
@@ -87,6 +90,28 @@ describe("DocsClient", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Could not load the requested page.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when docs list is empty", async () => {
+    render(<DocsClient docs={[]} />);
+    expect(screen.getByText("No markdown docs were found.")).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("redirects invalid page query to default docs page", async () => {
+    mockUseSearchParams.mockReturnValue({
+      get: () => "not-a-doc",
+    });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("# README"),
+    });
+
+    render(<DocsClient docs={mockDocs} />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/docs?page=README");
     });
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       PIPELINE_API_URL: http://pipeline:8000
     volumes:
       - audio_data:/data/audio:ro
+      - ./docs/guide:/docs/guide:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- improve `/docs` navigation UX with responsive left navigation:
  - desktop sidebar buttons
  - mobile dropdown selector
- validate and normalize requested doc page selection to a safe default
- add better empty/error states when docs are missing or a page cannot be loaded
- keep markdown as source-of-truth and render via API-backed `.md` content
- mount `./docs/guide` into the web container at `/docs/guide` so docs are available in containerized runtime

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/docs.test.tsx tests/unit/docs-api-route.test.ts

## Notes
- Jest output includes existing console warnings (`act(...)` and expected `console.error` from missing-file route test), but all tests pass.

Closes #384