### PR TITLE
UI tag and inference label adjustments on podcast episodes (issue #386)

### DIFF
--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -114,11 +114,11 @@ function ProviderTag({ provider }: { provider: string }) {
     <Tag
       className={
         isRemote
-          ? "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
-          : "bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200"
+          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+          : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
       }
     >
-      {isRemote ? "Remote" : "Local"}
+      {isRemote ? "Remote inference" : "Local inference"}
     </Tag>
   );
 }
@@ -487,7 +487,7 @@ export default function EpisodesList({ episodes, feedId }: Props) {
                       key={sn.display_name}
                       className={
                         sn.confirmed_by_user
-                          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                          ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
                           : "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200"
                       }
                     >

--- a/apps/web/src/components/ReprocessButton.tsx
+++ b/apps/web/src/components/ReprocessButton.tsx
@@ -37,9 +37,9 @@ export default function ReprocessButton({ episodeId, status }: ReprocessButtonPr
     <button
       onClick={handleReprocess}
       disabled={loading}
-      className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-50"
+      className="inline-flex items-center gap-1 rounded border border-input bg-background px-1.5 py-0.5 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
     >
-      <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+      <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
       {loading ? "Reprocessing..." : "Reprocess"}
     </button>
   );

--- a/apps/web/tests/unit/EpisodesList.test.tsx
+++ b/apps/web/tests/unit/EpisodesList.test.tsx
@@ -101,6 +101,30 @@ describe("EpisodesList", () => {
     expect(fireworksTags.length).toBe(1);
   });
 
+  it("renders local/remote inference tags with updated labels", () => {
+    render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
+
+    expect(screen.getByText("Remote inference")).toBeInTheDocument();
+    expect(screen.getByText("Local inference")).toBeInTheDocument();
+  });
+
+  it("renders confirmed speakers in blue and non-confirmed speakers in orange", () => {
+    const episodesWithSpeakerTags: EnrichedEpisode[] = [
+      {
+        ...mockEpisodes[0],
+        speaker_name_tags: [
+          { display_name: "Alice", inferred: false, confirmed_by_user: true },
+          { display_name: "Bob", inferred: true, confirmed_by_user: false },
+        ],
+      },
+    ];
+
+    render(<EpisodesList episodes={episodesWithSpeakerTags} feedId="feed-1" />);
+
+    expect(screen.getByText("Alice")).toHaveClass("bg-blue-100", "text-blue-800");
+    expect(screen.getByText("Bob")).toHaveClass("bg-orange-100", "text-orange-800");
+  });
+
   it("renders ReprocessButton in list rows for all episodes", () => {
     render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
 

--- a/apps/web/tests/unit/reprocess-button.test.tsx
+++ b/apps/web/tests/unit/reprocess-button.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockRefresh = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+  }),
+}));
+
+import ReprocessButton from "@/components/ReprocessButton";
+
+describe("ReprocessButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses compact tag-like sizing classes", () => {
+    render(<ReprocessButton episodeId="ep-1" status="done" />);
+
+    const button = screen.getByRole("button", { name: /reprocess/i });
+    expect(button).toHaveClass(
+      "px-1.5",
+      "py-0.5",
+      "text-xs",
+      "rounded",
+      "font-medium",
+      "border"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make provider labels explicit: `Remote inference` and `Local inference`
- update provider tag colors:
  - remote inference -> light green
  - local inference -> light blue/navy
- update speaker tag colors:
  - confirmed speakers -> light blue
  - non-confirmed speakers -> light orange
- shrink Reprocess button styling to match tag sizing on episode cards
- add regression tests for tag labels/colors and compact reprocess button classes

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/EpisodesList.test.tsx tests/unit/reprocess-button.test.tsx

Closes #386