### PR TITLE
Fix next-only episode navigation alignment (follow-up to #387)

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -166,7 +166,7 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
 
       {/* Episode navigation */}
       {(prev || next) && (
-        <div className="flex gap-2">
+        <div className={`flex gap-2 ${!prev && next ? "justify-end" : ""}`}>
           {prev && (
             <Link
               href={`/episodes/${prev.id}`}

--- a/apps/web/tests/unit/episode-page-navigation.test.tsx
+++ b/apps/web/tests/unit/episode-page-navigation.test.tsx
@@ -207,7 +207,7 @@ describe("Episode page navigation", () => {
     expect(firstElement?.tagName.toLowerCase()).toBe("svg");
   });
 
-  it("renders only next button as half-width and left-aligned when no previous episode", async () => {
+  it("renders only next button as half-width and right-aligned when no previous episode", async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [currentEpisode] })
       .mockResolvedValueOnce({ rows: [] })
@@ -221,6 +221,7 @@ describe("Episode page navigation", () => {
     expect(screen.queryByRole("link", { name: /previous episode/i })).not.toBeInTheDocument();
 
     expect(nextLink).toHaveClass("flex-1", "max-w-[50%]");
+    expect(nextLink.parentElement).toHaveClass("justify-end");
 
     const lastElement = nextLink.lastElementChild;
     expect(lastElement?.tagName.toLowerCase()).toBe("svg");


### PR DESCRIPTION
## Summary
- when only a next episode exists, right-align the navigation button within the row
- keep previous-only behavior left-aligned
- update navigation unit test expectation to assert right alignment in next-only state

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/episode-page-navigation.test.tsx

Related: #387