### PR TITLE
fix(web): ensure inference tags render with requested colors

### DIFF
--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -108,14 +108,14 @@ function StatusTag({ status }: { status: string }) {
   return <Tag className={colors[status] ?? colors.pending}>{label}</Tag>;
 }
 
-function ProviderTag({ provider }: { provider: string }) {
+function ProviderTag({ provider }: { provider: string | null }) {
   const isRemote = provider === "fireworks";
   return (
     <Tag
       className={
         isRemote
-          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-          : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+          ? "bg-[#dcfce7] text-[#166534]"
+          : "bg-[#dbeafe] text-[#1e3a8a]"
       }
     >
       {isRemote ? "Remote inference" : "Local inference"}
@@ -450,9 +450,7 @@ export default function EpisodesList({ episodes, feedId }: Props) {
                   </Tag>
                 )}
 
-                {ep.inference_provider_used && (
-                  <ProviderTag provider={ep.inference_provider_used} />
-                )}
+                <ProviderTag provider={ep.inference_provider_used} />
 
                 {ep.status === "done" && ep.transcribe_duration_secs != null && ep.transcribe_duration_secs > 0 && (
                   <Tag className="bg-muted text-muted-foreground">

--- a/apps/web/tests/unit/EpisodesList.test.tsx
+++ b/apps/web/tests/unit/EpisodesList.test.tsx
@@ -104,8 +104,27 @@ describe("EpisodesList", () => {
   it("renders local/remote inference tags with updated labels", () => {
     render(<EpisodesList episodes={mockEpisodes} feedId="feed-1" />);
 
-    expect(screen.getByText("Remote inference")).toBeInTheDocument();
+    const remote = screen.getByText("Remote inference");
+    const local = screen.getByText("Local inference");
+
+    expect(remote).toBeInTheDocument();
+    expect(local).toBeInTheDocument();
+    expect(remote).toHaveClass("bg-[#dcfce7]", "text-[#166534]");
+    expect(local).toHaveClass("bg-[#dbeafe]", "text-[#1e3a8a]");
+  });
+
+  it("renders local inference tag when provider is missing", () => {
+    const episodesWithoutProvider: EnrichedEpisode[] = [
+      {
+        ...mockEpisodes[0],
+        id: "ep-no-provider",
+        inference_provider_used: null,
+      },
+    ];
+
+    render(<EpisodesList episodes={episodesWithoutProvider} feedId="feed-1" />);
     expect(screen.getByText("Local inference")).toBeInTheDocument();
+    expect(screen.queryByText("Remote inference")).not.toBeInTheDocument();
   });
 
   it("renders confirmed speakers in blue and non-confirmed speakers in orange", () => {


### PR DESCRIPTION
## Summary
- always render the inference provider tag in episode cards
- show Local inference when provider is null/empty
- update provider chip colors to requested palette (Remote inference green, Local inference blue)
- add unit coverage for both class names and null-provider behavior

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/EpisodesList.test.tsx

Refs #386