### PR TITLE
Remove episode count from Ask page help hover (issue #393)

### DIFF
--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -216,12 +216,6 @@ export default function AskPage() {
   }
 
   const isProcessing = status === "connecting" || status === "streaming";
-  const helpSummary = useMemo(() => {
-    if (!helpCoverageSnapshot) return null;
-    const remaining = Math.max(0, helpCoverageSnapshot.total - helpCoverageSnapshot.processed);
-    return `Analyzing ${helpCoverageSnapshot.processed} processed episodes (${remaining} still processing)`;
-  }, [helpCoverageSnapshot]);
-
   const processingCount = coverage
     ? Math.max(0, coverage.total - coverage.processed)
     : 0;
@@ -236,9 +230,6 @@ export default function AskPage() {
             <p>
               Retrieval-augmented analysis across your transcripts. Finds the 8 most relevant transcript excerpts and generates an answer grounded in their content.
             </p>
-            {helpSummary && (
-              <p className="mt-2 text-muted-foreground">{helpSummary}</p>
-            )}
           </HelpPopover>
 
           {/* Ask input */}

--- a/apps/web/tests/unit/ask-page-helpbox.test.tsx
+++ b/apps/web/tests/unit/ask-page-helpbox.test.tsx
@@ -44,9 +44,6 @@ describe("Ask page helpbox behavior", () => {
     expect(
       await screen.findByText(/Retrieval-augmented analysis across your transcripts/i)
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Analyzing 195 processed episodes \(197 still processing\)/i)
-    ).toBeInTheDocument();
 
     fireEvent.click(helpTrigger);
     fireEvent.mouseLeave(helpTrigger);


### PR DESCRIPTION
## Summary
Remove the episode and podcast count information from the help hover on the Ask page, as requested in issue #393.

## Changes
- Removed the `helpSummary` text generation that displayed "Analyzing X processed episodes (Y still processing)" from the HelpPopover
- Removed the related test assertion in `ask-page-helpbox.test.tsx`

## Testing
- All 189 tests pass
- Specifically verified: `tests/unit/ask-page-helpbox.test.tsx`

Closes #393