### PR TITLE
fix(web): float back-to-search link on episode page

### DIFF
--- a/apps/web/src/components/BackToSearchLink.tsx
+++ b/apps/web/src/components/BackToSearchLink.tsx
@@ -17,7 +17,7 @@ export default function BackToSearchLink() {
   return (
     <Link
       href={`/search?q=${encodeURIComponent(query)}`}
-      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      className="fixed left-3 sm:left-4 top-20 z-40 inline-flex items-center gap-1 rounded-full border border-input bg-background/95 px-3 py-1.5 text-sm font-medium text-muted-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80 hover:bg-accent hover:text-foreground transition-colors"
     >
       <ArrowLeft size={14} />
       Back to search results

--- a/apps/web/tests/unit/back-to-search-link.test.tsx
+++ b/apps/web/tests/unit/back-to-search-link.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockUseSearchParams = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+jest.mock("next/link", () => {
+  return ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+import BackToSearchLink from "@/components/BackToSearchLink";
+
+describe("BackToSearchLink", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not render when there is no search query", () => {
+    mockUseSearchParams.mockReturnValue({
+      get: () => null,
+    });
+
+    render(<BackToSearchLink />);
+
+    expect(screen.queryByRole("link", { name: /back to search results/i })).not.toBeInTheDocument();
+  });
+
+  it("renders a fixed floating link with encoded query when search query exists", () => {
+    mockUseSearchParams.mockReturnValue({
+      get: () => "john doe & jane",
+    });
+
+    render(<BackToSearchLink />);
+
+    const link = screen.getByRole("link", { name: /back to search results/i });
+    expect(link).toHaveAttribute("href", "/search?q=john%20doe%20%26%20jane");
+    expect(link).toHaveClass("fixed", "left-3", "sm:left-4", "top-20", "z-40");
+  });
+});


### PR DESCRIPTION
## Summary
- make the episode-page back-to-search control float in the upper-left
- keep it visible while scrolling with fixed positioning
- add unit coverage for query-gated rendering, encoded href, and floating classes

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/back-to-search-link.test.tsx
- cd apps/web && npm test -- --runTestsByPath tests/unit/episode-page-navigation.test.tsx

Refs #392