### PR TITLE
fix(web): load docs listing at runtime in /docs

### DIFF
--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -3,6 +3,8 @@ import { join } from "path";
 import { Suspense } from "react";
 import DocsClient from "./DocsClient";
 
+export const dynamic = "force-dynamic";
+
 function filenameToTitle(filename: string): string {
   return filename
     .replace(/^\d+-/, "")

--- a/apps/web/tests/unit/docs-page-runtime.test.ts
+++ b/apps/web/tests/unit/docs-page-runtime.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("Docs page runtime behavior", () => {
+  it("forces dynamic rendering so mounted docs are read at request time", () => {
+    const pageSource = readFileSync(resolve(__dirname, "../../src/app/docs/page.tsx"), "utf-8");
+    expect(pageSource).toContain('export const dynamic = "force-dynamic"');
+  });
+});


### PR DESCRIPTION
## Summary
- fix /docs being rendered with an empty docs list from build-time static generation
- force the docs page to render dynamically at request time so mounted docs guide files are visible
- add a regression test asserting the docs page remains force-dynamic

## Verification
- cd apps/web && npm test -- --runTestsByPath tests/unit/docs-page-runtime.test.ts tests/unit/docs.test.tsx tests/unit/docs-api-route.test.ts
- rebuilt and restarted web container
- Playwright check on http://localhost:3000/docs now shows guide entries and content (no empty-docs message)

Refs #394