### PR TITLE
fix(web): align episode metadata tag chip heights

### DIFF
--- a/apps/web/src/components/EpisodeMetaTags.tsx
+++ b/apps/web/src/components/EpisodeMetaTags.tsx
@@ -21,6 +21,7 @@ interface EpisodeMetaTagsProps {
 const STEP_ABBREVIATIONS: Record<string, string> = {
   io: "I/O", api: "API", stt: "STT", url: "URL",
 };
+const CHIP_BASE_CLASS = "inline-flex h-5 items-center rounded px-1.5 text-xs font-medium leading-none";
 
 function formatDiarizeStepLabel(key: string): string {
   const words = key.replace(/_secs$/, "").split("_").filter(Boolean);
@@ -32,7 +33,7 @@ function formatDiarizeStepLabel(key: string): string {
 
 function Tag({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${className ?? "bg-muted text-muted-foreground"}`}>
+    <span className={`${CHIP_BASE_CLASS} ${className ?? "bg-muted text-muted-foreground"}`}>
       {children}
     </span>
   );
@@ -43,7 +44,7 @@ function StatusTag({ status }: { status: string }) {
   const label = isFailed ? "Failed" : status.charAt(0).toUpperCase() + status.slice(1);
   return (
     <span
-      className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded font-medium border ${
+      className={`${CHIP_BASE_CLASS} gap-1 border ${
         isFailed
           ? "text-red-700 border-red-300 dark:text-red-300 dark:border-red-700"
           : "text-blue-700 border-blue-300 dark:text-blue-300 dark:border-blue-700"
@@ -66,7 +67,7 @@ function FireworksCostTag({
 
   return (
     <div
-      className="relative inline-block"
+      className="relative inline-flex items-center"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
     >
@@ -125,7 +126,7 @@ export default function EpisodeMetaTags({
         {diarizeDurationSecs != null && (
           <button
             onClick={() => setStepsExpanded(v => !v)}
-            className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded font-medium bg-muted text-muted-foreground hover:bg-muted/80 transition-colors"
+            className={`${CHIP_BASE_CLASS} gap-0.5 bg-muted text-muted-foreground hover:bg-muted/80 transition-colors`}
             aria-label={`Diarized: ${formatTimestamp(diarizeDurationSecs)}`}
           >
             Diarized: {formatTimestamp(diarizeDurationSecs)}

--- a/apps/web/tests/unit/EpisodeMetaTags.test.tsx
+++ b/apps/web/tests/unit/EpisodeMetaTags.test.tsx
@@ -93,6 +93,25 @@ describe("EpisodeMetaTags", () => {
     expect(screen.getByText(/Fireworks STT: \$0\.03/)).toBeInTheDocument();
   });
 
+  it("uses consistent chip sizing classes for standard, diarized, and Fireworks tags", () => {
+    render(
+      <EpisodeMetaTags
+        {...baseProps}
+        inferenceProviderUsed="fireworks"
+        fireworksSttCostUsd={0.0312}
+        fireworksAudioMinutes={6.2}
+      />
+    );
+
+    const dateTag = screen.getByText(/2024/);
+    const diarizedTag = screen.getByRole("button", { name: /Diarized:/ });
+    const fireworksTag = screen.getByText(/Fireworks STT: \$0\.03/);
+
+    expect(dateTag).toHaveClass("inline-flex", "h-5", "items-center", "leading-none");
+    expect(diarizedTag).toHaveClass("inline-flex", "h-5", "items-center", "leading-none");
+    expect(fireworksTag).toHaveClass("inline-flex", "h-5", "items-center", "leading-none");
+  });
+
   it("shows diarization step tags when Diarized tag is clicked", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary
- standardize episode metadata chips to a shared base class with consistent height and vertical alignment
- apply the same chip sizing/line-height to status, regular tags, diarized button, and Fireworks STT tag
- keep existing colors and behavior while fixing visual misalignment
- add unit coverage asserting consistent sizing classes across representative chips

## Testing
- cd /tmp/podlog-403/apps/web && npm test -- --runTestsByPath tests/unit/EpisodeMetaTags.test.tsx

Refs #403