### PR TITLE
Change provider tag colors to Violet/Teal (issue #402)

### DIFF
--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -114,8 +114,8 @@ function ProviderTag({ provider }: { provider: string | null }) {
     <Tag
       className={
         isRemote
-          ? "bg-[#dcfce7] text-[#166534]"
-          : "bg-[#dbeafe] text-[#1e3a8a]"
+          ? "bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200"
+          : "bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200"
       }
     >
       {isRemote ? "Remote inference" : "Local inference"}

--- a/apps/web/tests/unit/EpisodesList.test.tsx
+++ b/apps/web/tests/unit/EpisodesList.test.tsx
@@ -109,8 +109,8 @@ describe("EpisodesList", () => {
 
     expect(remote).toBeInTheDocument();
     expect(local).toBeInTheDocument();
-    expect(remote).toHaveClass("bg-[#dcfce7]", "text-[#166534]");
-    expect(local).toHaveClass("bg-[#dbeafe]", "text-[#1e3a8a]");
+    expect(remote).toHaveClass("bg-violet-100", "text-violet-800");
+    expect(local).toHaveClass("bg-teal-100", "text-teal-800");
   });
 
   it("renders local inference tag when provider is missing", () => {


### PR DESCRIPTION
## Summary
Change the Remote and Local inference tag colors - user chose Violet/Teal scheme.

- Remote inference: Violet (bg-violet-100/text-violet-800)  
- Local inference: Teal (bg-teal-100/text-teal-800)
- Both work in light and dark themes

## Testing
- All 15 EpisodesList tests pass

Closes #402