### PR TITLE
fix(search): stabilize filter loading and confirmed speaker sourcing

### DIFF
--- a/apps/web/src/app/api/search/speakers/route.ts
+++ b/apps/web/src/app/api/search/speakers/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import pool from "@/lib/db";
 
 /**
- * GET /api/search/speakers — list distinct speakers across selected feeds.
+ * GET /api/search/speakers — list distinct confirmed speaker names across selected feeds.
  * Used to populate the speaker filter dropdown on the search page.
  *
  * Query params:
@@ -10,6 +10,7 @@ import pool from "@/lib/db";
  *   uploads — "true" to include manual uploads
  *
  * Returns: [{ speaker_label, display_name }] ordered by display_name.
+ * `speaker_label` is intentionally set to display_name for compatibility with existing clients.
  */
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
@@ -32,21 +33,25 @@ export async function GET(req: NextRequest) {
 
   try {
     const result = await pool.query(
-      `SELECT DISTINCT ON (s.speaker_label)
-        s.speaker_label,
-        COALESCE(sn.display_name, s.speaker_label) AS display_name
-      FROM segments s
-      JOIN episodes e ON s.episode_id = e.id
+      `SELECT DISTINCT
+        BTRIM(sn.display_name) AS display_name
+      FROM speaker_names sn
+      JOIN episodes e ON sn.episode_id = e.id
       LEFT JOIN feeds f ON e.feed_id = f.id
-      LEFT JOIN speaker_names sn ON sn.episode_id = s.episode_id AND sn.speaker_label = s.speaker_label
-      WHERE s.speaker_label IS NOT NULL
+      WHERE sn.confirmed_by_user = true
+        AND NULLIF(BTRIM(sn.display_name), '') IS NOT NULL
         AND e.status = 'done'
         AND ${feedClause}
-      ORDER BY s.speaker_label, display_name`,
+      ORDER BY display_name`,
       params
     );
 
-    return NextResponse.json(result.rows);
+    return NextResponse.json(
+      result.rows.map((row: { display_name: string }) => ({
+        speaker_label: row.display_name,
+        display_name: row.display_name,
+      }))
+    );
   } catch (err) {
     console.error("Speakers fetch error:", err);
     return NextResponse.json({ error: "Failed to fetch speakers" }, { status: 500 });

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -50,6 +50,7 @@ export default function AskPage() {
   const [errorMsg, setErrorMsg] = useState(initialSnapshot?.errorMsg || "");
   const [model, setModel] = useState(initialSnapshot?.model || getStoredModel);
   const [feeds, setFeeds] = useState<Feed[]>([]);
+  const [feedsLoading, setFeedsLoading] = useState(true);
   const [selectedFeedIds, setSelectedFeedIds] = useState<Set<string>>(
     new Set(initialSnapshot?.selectedFeedIds || [])
   );
@@ -84,12 +85,14 @@ export default function AskPage() {
 
   // Fetch feeds and coverage stats
   useEffect(() => {
+    setFeedsLoading(true);
     fetch("/api/feeds")
       .then((r) => r.json())
       .then((data) => {
         if (Array.isArray(data)) setFeeds(data);
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setFeedsLoading(false));
 
     fetch("/api/ask/coverage")
       .then((r) => r.json())
@@ -294,6 +297,7 @@ export default function AskPage() {
               selectedFeedIds={selectedFeedIds}
               onSelectionChange={setSelectedFeedIds}
               hasManualUploads={hasManualUploads}
+              loading={feedsLoading && feeds.length === 0 && !hasManualUploads}
             />
           </div>
 

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -86,26 +86,41 @@ function SearchPageContent() {
     totalMentions: number;
   } | null>(null);
 
-  // Fetch stats for the info line below search — uses coverage endpoint
-  // to include manual uploads (episodes with no feed_id)
-  const statsQuery = useQuery<{ feedCount: number; episodeCount: number; processing: number }>({
-    queryKey: ["search-stats"],
+  // Load feeds independently so Source filter can show even if coverage endpoint is slower.
+  const feedsQuery = useQuery<Feed[]>({
+    queryKey: ["search-feeds"],
     queryFn: async () => {
-      const [feedsResp, coverageResp] = await Promise.all([
-        fetch("/api/feeds"),
-        fetch("/api/ask/coverage"),
-      ]);
-      const feedsData = feedsResp.ok ? await feedsResp.json() : [];
-      const feedCount = Array.isArray(feedsData) ? feedsData.length : 0;
-      if (Array.isArray(feedsData)) setFeeds(feedsData);
-      const covData = coverageResp.ok ? await coverageResp.json() : {};
-      const episodeCount = covData.processed ?? 0;
-      const processing = Math.max(0, (covData.total ?? 0) - (covData.processed ?? 0));
-      setHasManualUploads(covData.has_manual_uploads ?? false);
-      return { feedCount, episodeCount, processing };
+      const resp = await fetch("/api/feeds");
+      if (!resp.ok) return [];
+      const data = await resp.json();
+      return Array.isArray(data) ? data : [];
     },
     staleTime: 60_000,
   });
+
+  // Coverage powers the processed/total info line and manual-upload marker.
+  const coverageQuery = useQuery<{ processed: number; total: number; has_manual_uploads: boolean }>({
+    queryKey: ["search-coverage"],
+    queryFn: async () => {
+      const resp = await fetch("/api/ask/coverage");
+      if (!resp.ok) return { processed: 0, total: 0, has_manual_uploads: false };
+      const data = await resp.json();
+      return {
+        processed: data.processed ?? 0,
+        total: data.total ?? 0,
+        has_manual_uploads: data.has_manual_uploads ?? false,
+      };
+    },
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (feedsQuery.data) setFeeds(feedsQuery.data);
+  }, [feedsQuery.data]);
+
+  useEffect(() => {
+    if (coverageQuery.data) setHasManualUploads(coverageQuery.data.has_manual_uploads);
+  }, [coverageQuery.data]);
 
   // Sync state when URL ?q= param changes (e.g. browser back/forward)
   useEffect(() => {
@@ -281,14 +296,14 @@ function SearchPageContent() {
           />
 
           {/* Stats below search bar */}
-          {!submittedQuery && statsQuery.data && (
+          {!submittedQuery && coverageQuery.data && (
             <p className="text-center text-xs text-muted-foreground">
-              Searching across {statsQuery.data.feedCount} podcast
-              {statsQuery.data.feedCount !== 1 ? "s" : ""} and{" "}
-              {statsQuery.data.episodeCount} episode
-              {statsQuery.data.episodeCount !== 1 ? "s" : ""}
-              {statsQuery.data.processing > 0 && (
-                <> ({statsQuery.data.processing} still processing)</>
+              Searching across {feeds.length} podcast
+              {feeds.length !== 1 ? "s" : ""} and{" "}
+              {coverageQuery.data.processed} episode
+              {coverageQuery.data.processed !== 1 ? "s" : ""}
+              {coverageQuery.data.total > coverageQuery.data.processed && (
+                <> ({coverageQuery.data.total - coverageQuery.data.processed} still processing)</>
               )}
             </p>
           )}
@@ -300,6 +315,7 @@ function SearchPageContent() {
               selectedFeedIds={selectedFeedIds}
               onSelectionChange={(next) => { setSelectedFeedIds(next); setSelectedSpeaker(null); setPage(1); }}
               hasManualUploads={hasManualUploads}
+              loading={feedsQuery.isLoading && feeds.length === 0 && !hasManualUploads}
             />
             <SpeakerFilter
               feedIds={Array.from(selectedFeedIds)}

--- a/apps/web/src/components/PodcastFilter.tsx
+++ b/apps/web/src/components/PodcastFilter.tsx
@@ -14,6 +14,7 @@ interface PodcastFilterProps {
   selectedFeedIds: Set<string>;
   onSelectionChange: (next: Set<string>) => void;
   hasManualUploads?: boolean;
+  loading?: boolean;
 }
 
 export default function PodcastFilter({
@@ -21,6 +22,7 @@ export default function PodcastFilter({
   selectedFeedIds,
   onSelectionChange,
   hasManualUploads = false,
+  loading = false,
 }: PodcastFilterProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -35,7 +37,7 @@ export default function PodcastFilter({
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  if (feeds.length === 0 && !hasManualUploads) return null;
+  const hasAnyOptions = feeds.length > 0 || hasManualUploads;
 
   function toggle(id: string) {
     const next = new Set(selectedFeedIds);
@@ -49,12 +51,15 @@ export default function PodcastFilter({
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
+        disabled={loading && !hasAnyOptions}
         className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
       >
         <span className="text-muted-foreground">Source:</span>
-        {selectedFeedIds.size === 0
-          ? "All"
-          : `${selectedFeedIds.size} selected`}
+        {loading && !hasAnyOptions
+          ? "Loading..."
+          : selectedFeedIds.size === 0
+            ? "All"
+            : `${selectedFeedIds.size} selected`}
         <ChevronDown size={14} className="text-muted-foreground" />
       </button>
       {open && (
@@ -69,20 +74,24 @@ export default function PodcastFilter({
             All sources
           </button>
           <div className="border-t border-border my-1" />
-          {feeds.map((f) => (
-            <label
-              key={f.id}
-              className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors cursor-pointer"
-            >
-              <input
-                type="checkbox"
-                checked={selectedFeedIds.has(f.id)}
-                onChange={() => toggle(f.id)}
-                className="rounded"
-              />
-              <span className="truncate">{f.title || "Untitled"}</span>
-            </label>
-          ))}
+          {loading && !hasAnyOptions ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">Loading sources...</div>
+          ) : (
+            feeds.map((f) => (
+              <label
+                key={f.id}
+                className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedFeedIds.has(f.id)}
+                  onChange={() => toggle(f.id)}
+                  className="rounded"
+                />
+                <span className="truncate">{f.title || "Untitled"}</span>
+              </label>
+            ))
+          )}
           {hasManualUploads && (
             <>
               <div className="border-t border-border my-1" />
@@ -96,6 +105,11 @@ export default function PodcastFilter({
                 <span>Manual uploads</span>
               </label>
             </>
+          )}
+          {!loading && !hasAnyOptions && (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              No sources available.
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/components/SpeakerFilter.tsx
+++ b/apps/web/src/components/SpeakerFilter.tsx
@@ -24,23 +24,37 @@ export default function SpeakerFilter({
   const [open, setOpen] = useState(false);
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setLoading(true);
+    setError(false);
     const params = new URLSearchParams();
     const realIds = feedIds.filter((id) => id !== "__uploads__");
     if (realIds.length > 0) params.set("feedId", realIds.join(","));
     if (includeManualUploads) params.set("uploads", "true");
 
-    fetch(`/api/search/speakers?${params}`)
-      .then((r) => r.json())
+    const controller = new AbortController();
+    fetch(`/api/search/speakers?${params}`, { signal: controller.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed");
+        return r.json();
+      })
       .then((data) => {
         if (Array.isArray(data)) setSpeakers(data);
+        else setSpeakers([]);
       })
-      .catch(() => {})
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setSpeakers([]);
+        setError(true);
+      })
       .finally(() => setLoading(false));
-  }, [feedIds, includeManualUploads]);
+
+    return () => controller.abort();
+  }, [feedIds, includeManualUploads, reloadToken]);
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -52,8 +66,6 @@ export default function SpeakerFilter({
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  if (loading || speakers.length === 0) return null;
-
   const selectedDisplay = selectedSpeaker
     ? (speakers.find((s) => s.speaker_label === selectedSpeaker)?.display_name ?? selectedSpeaker)
     : null;
@@ -63,12 +75,13 @@ export default function SpeakerFilter({
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
+        disabled={loading && speakers.length === 0}
         className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
       >
         <User size={13} className="text-muted-foreground shrink-0" />
         <span className="text-muted-foreground">Speaker:</span>
         <span className={selectedDisplay ? "max-w-[120px] truncate" : ""}>
-          {selectedDisplay ?? "All"}
+          {selectedDisplay ?? (loading ? "Loading..." : "All")}
         </span>
         <ChevronDown size={14} className="text-muted-foreground shrink-0" />
       </button>
@@ -84,18 +97,37 @@ export default function SpeakerFilter({
             All speakers
           </button>
           <div className="border-t border-border my-1" />
-          {speakers.map((s) => (
-            <button
-              key={s.speaker_label}
-              type="button"
-              onClick={() => { onSelectionChange(s.speaker_label); setOpen(false); }}
-              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors truncate ${
-                selectedSpeaker === s.speaker_label ? "font-medium" : ""
-              }`}
-            >
-              {s.display_name}
-            </button>
-          ))}
+          {loading ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">Loading speakers...</div>
+          ) : error ? (
+            <div className="px-3 py-2 space-y-1.5">
+              <p className="text-xs text-muted-foreground">Could not load speakers.</p>
+              <button
+                type="button"
+                onClick={() => setReloadToken((v) => v + 1)}
+                className="text-xs px-2 py-1 rounded border border-input hover:bg-accent/30 transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          ) : speakers.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              No confirmed speakers for selected sources.
+            </div>
+          ) : (
+            speakers.map((s) => (
+              <button
+                key={s.speaker_label}
+                type="button"
+                onClick={() => { onSelectionChange(s.speaker_label); setOpen(false); }}
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent/30 transition-colors truncate ${
+                  selectedSpeaker === s.speaker_label ? "font-medium" : ""
+                }`}
+              >
+                {s.display_name}
+              </button>
+            ))
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -141,7 +141,8 @@ export async function searchSegments(
           SELECT 1
           FROM speaker_names sn
           WHERE sn.episode_id = e.id
-            AND sn.speaker_label = $${idx}
+            AND sn.confirmed_by_user = true
+            AND sn.display_name = $${idx}
         )`
       );
       params.push(speakerLabel);
@@ -224,7 +225,7 @@ export async function searchSegments(
   let ftsIdx = feedFilter.nextIdx;
 
   if (speakerLabel) {
-    ftsExtraClauses.push(`t.speaker_label = $${ftsIdx}`);
+    ftsExtraClauses.push(`sn.confirmed_by_user = true AND sn.display_name = $${ftsIdx}`);
     ftsParams.push(speakerLabel);
     ftsIdx++;
   }
@@ -285,7 +286,7 @@ export async function searchSegments(
   let vecIdx = vecFeedFilter.nextIdx;
 
   if (speakerLabel) {
-    vecExtraClauses.push(`s.speaker_label = $${vecIdx}`);
+    vecExtraClauses.push(`sn.confirmed_by_user = true AND sn.display_name = $${vecIdx}`);
     vecParams.push(speakerLabel);
     vecIdx++;
   }
@@ -345,7 +346,7 @@ export async function searchSegments(
   let countIdx = countFeedFilter.nextIdx;
 
   if (speakerLabel) {
-    countExtraClauses.push(`t.speaker_label = $${countIdx}`);
+    countExtraClauses.push(`sn.confirmed_by_user = true AND sn.display_name = $${countIdx}`);
     countParams.push(speakerLabel);
     countIdx++;
   }
@@ -452,7 +453,8 @@ export async function searchGrouped(
           SELECT 1
           FROM speaker_names sn
           WHERE sn.episode_id = e.id
-            AND sn.speaker_label = $${idx}
+            AND sn.confirmed_by_user = true
+            AND sn.display_name = $${idx}
         )`
       );
       params.push(speakerLabel);
@@ -517,7 +519,7 @@ export async function searchGrouped(
   let rowsIdx = feedFilter.nextIdx;
 
   if (speakerLabel) {
-    rowsExtraClauses.push(`t.speaker_label = $${rowsIdx}`);
+    rowsExtraClauses.push(`sn.confirmed_by_user = true AND sn.display_name = $${rowsIdx}`);
     rowsParams.push(speakerLabel);
     rowsIdx++;
   }
@@ -571,7 +573,7 @@ export async function searchGrouped(
   let countIdx = grpCountFilter.nextIdx;
 
   if (speakerLabel) {
-    countExtraClauses.push(`t.speaker_label = $${countIdx}`);
+    countExtraClauses.push(`sn.confirmed_by_user = true AND sn.display_name = $${countIdx}`);
     countParams.push(speakerLabel);
     countIdx++;
   }

--- a/apps/web/tests/unit/speaker-filter.test.tsx
+++ b/apps/web/tests/unit/speaker-filter.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SpeakerFilter from "@/components/SpeakerFilter";
+
+describe("SpeakerFilter", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it("shows loading label instead of disappearing while speakers are loading", () => {
+    (global.fetch as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <SpeakerFilter
+        feedIds={[]}
+        includeManualUploads={false}
+        selectedSpeaker={null}
+        onSelectionChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /speaker:/i })).toHaveTextContent("Loading...");
+  });
+
+  it("renders confirmed speakers and applies selection", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { speaker_label: "Alice", display_name: "Alice" },
+        { speaker_label: "Bob", display_name: "Bob" },
+      ],
+    });
+    const onSelectionChange = jest.fn();
+
+    render(
+      <SpeakerFilter
+        feedIds={["feed-1"]}
+        includeManualUploads={false}
+        selectedSpeaker={null}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /speaker:/i })).toHaveTextContent("All");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /speaker:/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Alice" }));
+    expect(onSelectionChange).toHaveBeenCalledWith("Alice");
+  });
+
+  it("shows no-confirmed-speakers message for empty results", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    render(
+      <SpeakerFilter
+        feedIds={["feed-1"]}
+        includeManualUploads={false}
+        selectedSpeaker={null}
+        onSelectionChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /speaker:/i })).toHaveTextContent("All");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /speaker:/i }));
+    expect(screen.getByText(/No confirmed speakers for selected sources/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/speakers-route.test.ts
+++ b/apps/web/tests/unit/speakers-route.test.ts
@@ -11,10 +11,7 @@ jest.mock("@/lib/db", () => ({ query: mockQuery }));
 
 import { NextRequest } from "next/server";
 
-const mockRows = [
-  { speaker_label: "SPEAKER_00", display_name: "Alice" },
-  { speaker_label: "SPEAKER_01", display_name: "Bob" },
-];
+const mockRows = [{ display_name: "Alice" }, { display_name: "Bob" }];
 
 describe("GET /api/search/speakers", () => {
   let GET: (req: NextRequest) => Promise<Response>;
@@ -32,10 +29,15 @@ describe("GET /api/search/speakers", () => {
     const resp = await GET(req);
     expect(resp.status).toBe(200);
     const data = await resp.json();
-    expect(data).toEqual(mockRows);
+    expect(data).toEqual([
+      { speaker_label: "Alice", display_name: "Alice" },
+      { speaker_label: "Bob", display_name: "Bob" },
+    ]);
     // No feed params — WHERE clause should use TRUE
     const sql: string = mockQuery.mock.calls[0][0];
     expect(sql).toContain("TRUE");
+    expect(sql).toContain("sn.confirmed_by_user = true");
+    expect(sql).toContain("NULLIF(BTRIM(sn.display_name), '') IS NOT NULL");
     expect(mockQuery.mock.calls[0][1]).toEqual([]);
   });
 

--- a/docs/guide/04-search.md
+++ b/docs/guide/04-search.md
@@ -35,6 +35,25 @@ Toggle between views using the buttons above the results.
 
 Use the feed filter dropdown to narrow results to a specific podcast. Useful when you remember which show discussed a topic but not which episode.
 
+## Filtering by Speaker
+
+The **Speaker** filter is populated from **user-confirmed speaker names** only (not raw `SPEAKER_00` labels, and not unconfirmed AI guesses).
+
+How it works:
+
+- The list is scoped to the currently selected **Source** filter.
+- If no source is selected, speaker options come from all processed episodes.
+- If one or more sources are selected, speaker options are limited to those sources.
+- If manual uploads are included in Source, confirmed speakers from uploads are included too.
+
+Why a name may not appear:
+
+- The speaker has not been confirmed yet on any matching episode.
+- The episode is not in `Done` status yet.
+- The currently selected source filter excludes that episode.
+
+Tip: if you confirm a speaker name on an episode page, return to `/search` and the name will become available in speaker filtering for relevant sources.
+
 ## Exporting Results
 
 Click the download button to export search results:

--- a/docs/guide/06-speakers.md
+++ b/docs/guide/06-speakers.md
@@ -20,6 +20,8 @@ Inferred names show an "AI" badge to distinguish them from user-confirmed names.
 
 User-confirmed names take priority over AI-inferred names and won't be overwritten by future inference runs.
 
+Confirmed names are also what populate the **Speaker** filter on the `/search` page.
+
 ## Merging Speakers
 
 Sometimes pyannote splits one real speaker into multiple labels (e.g., SPEAKER_00 and SPEAKER_02 are both the host). To fix this:


### PR DESCRIPTION
## Summary
- make source/speaker filters resilient instead of disappearing during loading/fetch issues
- split search page feeds and coverage loading so Source options appear as soon as feeds load (no longer blocked by coverage request)
- update speaker filter API to source options from confirmed speaker names only
- align search SQL speaker filter handling with confirmed display names used by the dropdown
- add unit coverage for speaker filter loading/empty behavior and updated speakers API response

## Testing
- cd apps/web && npm test -- --runTestsByPath tests/unit/speakers-route.test.ts tests/unit/speaker-filter.test.tsx
- cd apps/web && npm test -- --runTestsByPath tests/unit/search-lib.test.ts tests/unit/grouped-search.test.ts tests/unit/flat-search.test.ts
- cd apps/web && npm test -- --runTestsByPath tests/unit/search-spinner.test.tsx tests/unit/search-url-priority.test.tsx tests/unit/page-state-persistence.test.ts
- cd apps/web && npm test -- --runTestsByPath tests/unit/ask-page-helpbox.test.tsx tests/unit/ask-page-play.test.tsx

Refs #399