### PR TITLE
chore(web): remove orphan css declaration and redundant ui exports

### DIFF
--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -23,7 +23,7 @@ const badgeVariants = cva(
   }
 )
 
-export interface BadgeProps
+interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
   }
 )
 
-export interface ButtonProps
+interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean

--- a/apps/web/src/css.d.ts
+++ b/apps/web/src/css.d.ts
@@ -1,1 +1,0 @@
-declare module "*.css";


### PR DESCRIPTION
## Summary
- remove orphan ambient CSS declaration file `apps/web/src/css.d.ts`
- convert `ButtonProps` and `BadgeProps` from exported interfaces to file-local interfaces (they are only used internally)
- investigate pipeline dev dependencies from the audit finding: `pytest-cov` and `pytest-asyncio` are retained because coverage usage is documented and pytest async mode is configured (`asyncio_mode = \"auto\"`)

## Verification
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm test -- --runTestsByPath tests/unit/speaker-panel.test.tsx`

Closes #369
