### PR TITLE
docs: fix CLAUDE and audit spec stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ podlog/
 │   │   ├── alembic/                # Database migrations
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 16 (App Router)
-│       ├── src/app/                # Pages: /, /about, /podcasts, /episodes/[id], /queue, /feeds, /ask, /search, /notifications, /docs
+│       ├── src/app/                # Pages: /, /about, /podcasts, /episodes/[id], /queue, /feeds, /ask, /search, /settings, /docs (and /notifications redirects to /settings)
 │       ├── src/app/api/            # API routes: search, search/grouped, search/mentions, feeds, queue, audio, ask, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, pipeline proxy
 │       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, DocsClient, etc.
 │       └── src/lib/                # db.ts, search.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx
@@ -68,7 +68,7 @@ podlog/
 | ORM | SQLAlchemy 2.0 + Alembic | Migrations auto-run on pipeline startup |
 | Web app | Next.js 16 (App Router) | `output: 'standalone'` for Docker |
 | Styling | Tailwind CSS + shadcn/ui | Dark mode via `class` strategy; shadcn/ui component set is installed |
-| Data fetching | TanStack React Query | Polling for queue status |
+| Data fetching | TanStack React Query + fetch/setInterval | React Query for search/coverage data; queue status uses `fetch` polling in `QueueStatus.tsx` |
 | DB client (web) | `pg` (node-postgres) raw SQL | Direct PostgreSQL queries for search |
 
 ## Key Architectural Decisions
@@ -86,7 +86,7 @@ cp .env.example .env   # Edit: set POSTGRES_PASSWORD and HF_TOKEN
 make build             # Build Docker images
 make up                # Start all 5 services
 make logs              # Follow logs
-make test-unit         # Run unit tests
+make test-unit         # Run pipeline unit tests + host healthcheck test (no web unit tests)
 make shell-db          # Open psql shell
 ```
 

--- a/docs/superpowers/specs/2026-04-03-codebase-audit-design.md
+++ b/docs/superpowers/specs/2026-04-03-codebase-audit-design.md
@@ -157,7 +157,9 @@ Each subagent's findings are appended to the report and committed as they comple
 
 ### Report File
 
-**Location:** `docs/audit/YYYY-MM-DD-audit.md`
+**Location:** `docs/audit/YYYY-MM-DD/codex/summary.md`
+
+Section artifacts are written alongside it in the same folder (for example `architecture.md`, `docs.md`, `tests.md`, `dead-code.md`, `wizard.md`, `claude.md`, and `deps.md`).
 
 **Structure:**
 
@@ -229,7 +231,7 @@ Auto-created for CRITICAL and WARNING findings. Each issue gets:
 
   ## Source
 
-  From [codebase audit report](docs/audit/YYYY-MM-DD-audit.md), section: <section name>
+  From [codebase audit report](docs/audit/YYYY-MM-DD/codex/summary.md), section: <section name>
   ```
 
 Issues are created via `gh issue create`. The `codebase-audit` label is created if it doesn't exist.
@@ -306,7 +308,7 @@ An interrupted report also implicitly shows which checks are missing — only co
 ```
 
 **Where to check:**
-1. **The report file on GitHub** — `docs/audit/YYYY-MM-DD-audit.md`, status line is the first thing you see
+1. **The report file on GitHub** — `docs/audit/YYYY-MM-DD/codex/summary.md`, status line is the first thing you see
 2. **The log file** — `/tmp/audit-YYYY-MM-DD.log` captures all stdout including the final status
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- update stale route inventory in `CLAUDE.md` to include `/settings` and clarify `/notifications` redirects there
- correct `CLAUDE.md` data-fetching statement: queue polling is `fetch` + `setInterval` (React Query is used for other pages)
- correct `CLAUDE.md` `make test-unit` description to match actual Makefile behavior (pipeline unit + healthcheck only)
- update audit-spec artifact paths to the sectioned output location used by the runner (`docs/audit/YYYY-MM-DD/codex/summary.md`)

## Verification
- validated queue polling implementation in `apps/web/src/components/QueueStatus.tsx`
- validated route behavior in `apps/web/src/app/notifications/page.tsx`
- verified all outdated audit artifact path references were updated in `docs/superpowers/specs/2026-04-03-codebase-audit-design.md`

Closes #368
