### PR TITLE
refactor(feeds): unify web BFF boundary for /api/feeds

### DIFF
--- a/apps/pipeline/app/api/feeds.py
+++ b/apps/pipeline/app/api/feeds.py
@@ -1,13 +1,11 @@
 """
 Feed management API — control-plane endpoints.
 
+GET    /api/feeds             List feeds with episode counts
 GET    /api/feeds/preview     Preview a feed URL (returns metadata + episodes, no DB writes)
 POST   /api/feeds             Add a new RSS feed (with validation — GAP-02)
 DELETE /api/feeds/{id}        Remove a feed (optionally delete episodes)
 POST   /api/feeds/{id}/poll   Trigger immediate re-poll
-
-Feed listing (GET /api/feeds) is served directly by the Next.js web app
-via PostgreSQL queries (no proxy needed).
 """
 import logging
 from datetime import datetime
@@ -15,6 +13,7 @@ from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -61,6 +60,39 @@ class FeedPreviewResponse(BaseModel):
     image_url: Optional[str]
     website_url: Optional[str]
     episodes: list[EpisodePreview]
+
+
+class FeedListItem(BaseModel):
+    id: str
+    url: str
+    title: Optional[str]
+    mode: str
+    last_polled_at: Optional[datetime]
+    episode_count: int
+
+
+@router.get("/feeds", response_model=list[FeedListItem])
+def list_feeds(db: Session = Depends(get_db)) -> list[FeedListItem]:
+    """
+    Return feeds with episode counts for the web feed-management UI.
+    """
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT f.id, f.url, f.title, f.mode, f.last_polled_at,
+                       COUNT(e.id)::int AS episode_count
+                FROM feeds f
+                LEFT JOIN episodes e ON e.feed_id = f.id
+                GROUP BY f.id
+                ORDER BY f.created_at DESC
+                """
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return [FeedListItem.model_validate(dict(row)) for row in rows]
 
 
 @router.get("/feeds/preview", response_model=FeedPreviewResponse)

--- a/apps/pipeline/tests/unit/test_api.py
+++ b/apps/pipeline/tests/unit/test_api.py
@@ -166,7 +166,26 @@ class TestFeedsEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_list_feeds_removed(self):
-        """GET /api/feeds was moved to Next.js direct DB — should return 405."""
-        resp = client.get("/api/feeds")
-        assert resp.status_code == 405
+    def test_list_feeds_returns_rows(self):
+        mock_db = MagicMock()
+        mock_rows = [
+            {
+                "id": "feed-1",
+                "url": "https://example.com/rss.xml",
+                "title": "Example Feed",
+                "mode": "full",
+                "last_polled_at": None,
+                "episode_count": 12,
+            }
+        ]
+        mock_db.execute.return_value.mappings.return_value.all.return_value = mock_rows
+
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = client.get("/api/feeds")
+            assert resp.status_code == 200
+            assert resp.json() == mock_rows
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/web/src/app/api/feeds/route.ts
+++ b/apps/web/src/app/api/feeds/route.ts
@@ -1,18 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
-import pool from "@/lib/db";
 import { PIPELINE_API } from "@/lib/pipeline";
 
 export async function GET() {
   try {
-    const result = await pool.query(`
-      SELECT f.id, f.url, f.title, f.mode, f.last_polled_at,
-             COUNT(e.id)::int AS episode_count
-      FROM feeds f
-      LEFT JOIN episodes e ON e.feed_id = f.id
-      GROUP BY f.id
-      ORDER BY f.created_at DESC
-    `);
-    return NextResponse.json(result.rows);
+    const resp = await fetch(`${PIPELINE_API}/api/feeds`);
+    const text = await resp.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { detail: text || "Pipeline API returned a non-JSON error" };
+    }
+    return NextResponse.json(data, { status: resp.status });
   } catch (err) {
     console.error("Feeds list error:", err);
     return NextResponse.json({ error: "Failed to load feeds" }, { status: 500 });

--- a/apps/web/tests/unit/feeds-route.test.ts
+++ b/apps/web/tests/unit/feeds-route.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/feeds/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({
+  PIPELINE_API: "http://pipeline:8000",
+}));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("/api/feeds route", () => {
+  it("GET proxies feed list to pipeline API", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify([{ id: "feed-1", title: "Feed", episode_count: 2 }]),
+    });
+
+    const resp = await GET();
+    const data = await resp.json();
+
+    expect(mockFetch).toHaveBeenCalledWith("http://pipeline:8000/api/feeds");
+    expect(resp.status).toBe(200);
+    expect(data).toEqual([{ id: "feed-1", title: "Feed", episode_count: 2 }]);
+  });
+
+  it("POST continues proxying feed creation to pipeline API", async () => {
+    mockFetch.mockResolvedValue({
+      status: 201,
+      text: async () => JSON.stringify({ id: "feed-1" }),
+    });
+
+    const req = new NextRequest("http://localhost/api/feeds", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+
+    const resp = await POST(req);
+    const data = await resp.json();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    expect(resp.status).toBe(201);
+    expect(data).toEqual({ id: "feed-1" });
+  });
+});


### PR DESCRIPTION
## Summary
This PR delivers the first architecture slice for #367 (API boundary cleanup).

- add `GET /api/feeds` to the pipeline API (`apps/pipeline/app/api/feeds.py`)
- refactor web `GET /api/feeds` route to proxy to pipeline, matching existing POST proxy behavior
- remove split ownership where web BFF mixed direct DB reads with pipeline writes
- add/adjust unit tests for both pipeline and web route behavior

## Verification
- `cd apps/web && npm test -- --runTestsByPath tests/unit/feeds-route.test.ts`
- `cd apps/pipeline && python3 -m pytest tests/unit/test_api.py -k list_feeds_returns_rows -q`

Part of #367
