### PR TITLE
refactor(search): extract top controls from search page

### DIFF
--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useState, useEffect, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import {
-  Search,
   List,
   Layers,
 } from "lucide-react";
@@ -12,11 +11,8 @@ import SearchResult from "@/components/SearchResult";
 import FeedGroupCard from "@/components/FeedGroupCard";
 import DownloadReportButton from "@/components/DownloadReportButton";
 import { Button } from "@/components/ui/button";
-import SearchInput from "@/components/SearchInput";
-import HelpPopover from "@/components/HelpPopover";
 import SearchSpinner from "@/components/SearchSpinner";
-import PodcastFilter from "@/components/PodcastFilter";
-import SpeakerFilter from "@/components/SpeakerFilter";
+import SearchTopPanel from "@/components/SearchTopPanel";
 import type { SearchPage as SearchPageType, GroupedSearchResult } from "@/lib/search";
 import { loadSearchSnapshot, saveSearchSnapshot } from "@/lib/page-state";
 
@@ -271,61 +267,29 @@ function SearchPageContent() {
 
   return (
     <div className="space-y-6">
-      {/* Centered header + search bar */}
-      <div className={`flex flex-col items-center ${submittedQuery ? "pt-2" : "pt-16"} transition-all`}>
-        <div className="w-full max-w-2xl space-y-3">
-          {/* Title + help popover */}
-          <HelpPopover title="Search">
-            <p className="font-medium mb-1">Search tips</p>
-            <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
-              <li>Use quotes for exact phrases: &quot;machine learning&quot;</li>
-              <li>Exclude words with minus: climate -politics</li>
-              <li>Combine terms: AI regulation ethics</li>
-              <li>Field search: title:, description:, speaker: (case-insensitive; speaker supports partial matching)</li>
-            </ul>
-          </HelpPopover>
-
-          {/* Search input */}
-          <SearchInput
-            value={query}
-            onChange={setQuery}
-            onSubmit={handleSubmit}
-            onClear={handleClear}
-            placeholder="Search transcripts, titles, descriptions..."
-            icon={<Search size={18} />}
-          />
-
-          {/* Stats below search bar */}
-          {!submittedQuery && coverageQuery.data && (
-            <p className="text-center text-xs text-muted-foreground">
-              Searching across {feeds.length} podcast
-              {feeds.length !== 1 ? "s" : ""} and{" "}
-              {coverageQuery.data.processed} episode
-              {coverageQuery.data.processed !== 1 ? "s" : ""}
-              {coverageQuery.data.total > coverageQuery.data.processed && (
-                <> ({coverageQuery.data.total - coverageQuery.data.processed} still processing)</>
-              )}
-            </p>
-          )}
-
-          {/* Filters: podcast + speaker */}
-          <div className="flex justify-center gap-2 flex-wrap">
-            <PodcastFilter
-              feeds={feeds}
-              selectedFeedIds={selectedFeedIds}
-              onSelectionChange={(next) => { setSelectedFeedIds(next); setSelectedSpeaker(null); setPage(1); }}
-              hasManualUploads={hasManualUploads}
-              loading={feedsQuery.isLoading && feeds.length === 0 && !hasManualUploads}
-            />
-            <SpeakerFilter
-              feedIds={Array.from(selectedFeedIds)}
-              includeManualUploads={includeManualUploads}
-              selectedSpeaker={selectedSpeaker}
-              onSelectionChange={(s) => { setSelectedSpeaker(s); setPage(1); }}
-            />
-          </div>
-        </div>
-      </div>
+      <SearchTopPanel
+        submittedQuery={submittedQuery}
+        query={query}
+        onQueryChange={setQuery}
+        onSubmit={handleSubmit}
+        onClear={handleClear}
+        coverage={coverageQuery.data ? { processed: coverageQuery.data.processed, total: coverageQuery.data.total } : null}
+        feeds={feeds}
+        selectedFeedIds={selectedFeedIds}
+        onFeedSelectionChange={(next) => {
+          setSelectedFeedIds(next);
+          setSelectedSpeaker(null);
+          setPage(1);
+        }}
+        hasManualUploads={hasManualUploads}
+        feedsLoading={feedsQuery.isLoading}
+        includeManualUploads={includeManualUploads}
+        selectedSpeaker={selectedSpeaker}
+        onSpeakerSelectionChange={(s) => {
+          setSelectedSpeaker(s);
+          setPage(1);
+        }}
+      />
 
       {/* Search spinner */}
       {submittedQuery && isLoading && (

--- a/apps/web/src/components/SearchTopPanel.tsx
+++ b/apps/web/src/components/SearchTopPanel.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Search } from "lucide-react";
+import SearchInput from "@/components/SearchInput";
+import HelpPopover from "@/components/HelpPopover";
+import PodcastFilter from "@/components/PodcastFilter";
+import SpeakerFilter from "@/components/SpeakerFilter";
+
+interface Feed {
+  id: string;
+  title: string | null;
+  episode_count: number;
+}
+
+export default function SearchTopPanel({
+  submittedQuery,
+  query,
+  onQueryChange,
+  onSubmit,
+  onClear,
+  coverage,
+  feeds,
+  selectedFeedIds,
+  onFeedSelectionChange,
+  hasManualUploads,
+  feedsLoading,
+  includeManualUploads,
+  selectedSpeaker,
+  onSpeakerSelectionChange,
+}: {
+  submittedQuery: string;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onClear: () => void;
+  coverage: { processed: number; total: number } | null;
+  feeds: Feed[];
+  selectedFeedIds: Set<string>;
+  onFeedSelectionChange: (next: Set<string>) => void;
+  hasManualUploads: boolean;
+  feedsLoading: boolean;
+  includeManualUploads: boolean;
+  selectedSpeaker: string | null;
+  onSpeakerSelectionChange: (speaker: string | null) => void;
+}) {
+  return (
+    <div className={`flex flex-col items-center ${submittedQuery ? "pt-2" : "pt-16"} transition-all`}>
+      <div className="w-full max-w-2xl space-y-3">
+        <HelpPopover title="Search">
+          <p className="font-medium mb-1">Search tips</p>
+          <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+            <li>Use quotes for exact phrases: &quot;machine learning&quot;</li>
+            <li>Exclude words with minus: climate -politics</li>
+            <li>Combine terms: AI regulation ethics</li>
+            <li>Field search: title:, description:, speaker: (case-insensitive; speaker supports partial matching)</li>
+          </ul>
+        </HelpPopover>
+
+        <SearchInput
+          value={query}
+          onChange={onQueryChange}
+          onSubmit={onSubmit}
+          onClear={onClear}
+          placeholder="Search transcripts, titles, descriptions..."
+          icon={<Search size={18} />}
+        />
+
+        {!submittedQuery && coverage && (
+          <p className="text-center text-xs text-muted-foreground">
+            Searching across {feeds.length} podcast
+            {feeds.length !== 1 ? "s" : ""} and {" "}
+            {coverage.processed} episode
+            {coverage.processed !== 1 ? "s" : ""}
+            {coverage.total > coverage.processed && (
+              <> ({coverage.total - coverage.processed} still processing)</>
+            )}
+          </p>
+        )}
+
+        <div className="flex justify-center gap-2 flex-wrap">
+          <PodcastFilter
+            feeds={feeds}
+            selectedFeedIds={selectedFeedIds}
+            onSelectionChange={onFeedSelectionChange}
+            hasManualUploads={hasManualUploads}
+            loading={feedsLoading && feeds.length === 0 && !hasManualUploads}
+          />
+          <SpeakerFilter
+            feedIds={Array.from(selectedFeedIds)}
+            includeManualUploads={includeManualUploads}
+            selectedSpeaker={selectedSpeaker}
+            onSelectionChange={onSpeakerSelectionChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fifth refactor slice for #367 (god-file decomposition).

- extract top search controls (help, search input, stats, source/speaker filters) from `search/page.tsx` into `SearchTopPanel.tsx`
- keep search behavior unchanged (same handlers/state wiring, same filter reset behavior)
- reduce `search/page.tsx` from 516 lines to 480 lines

## Verification
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm test -- --runTestsByPath tests/unit/search-spinner.test.tsx tests/unit/search-url-priority.test.tsx`

Part of #367
