### PR TITLE
refactor: extract transcribe task helpers

### DIFF
--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -10,7 +10,6 @@ Transcription task -- PRD-01 S5.3, S5.4, Issue #222
 - Both paths persist segments and queue diarization.
 """
 import gc
-import json
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -21,6 +20,12 @@ from app.database import SessionLocal
 from app.models import Episode, Segment
 from app.services.notification_settings import get_runtime_inference_settings
 from app.tasks.helpers import mark_failed as _mark_failed, update_episode
+from app.tasks.transcribe_helpers import (
+    compute_fireworks_cost,
+    estimate_fireworks_usage,
+    persist_transcription_artifacts,
+    remove_artifacts,
+)
 from app import job_queue
 
 logger = logging.getLogger(__name__)
@@ -31,23 +36,6 @@ def _load_fireworks_service():
     from app.services import fireworks_audio
 
     return fireworks_audio
-
-
-def _estimate_fireworks_usage(segments_data: list[dict], fallback_duration_secs: int | None) -> float:
-    """
-    Estimate billed audio seconds for Fireworks STT.
-
-    Prefer transcript segment bounds; fall back to episode metadata.
-    """
-    max_end = 0.0
-    for seg in segments_data:
-        try:
-            max_end = max(max_end, float(seg.get("end", 0.0) or 0.0))
-        except Exception:
-            continue
-    if max_end > 0:
-        return max_end
-    return float(fallback_duration_secs or 0)
 
 
 def transcribe_episode(episode_id: str) -> str:
@@ -78,12 +66,7 @@ def transcribe_episode(episode_id: str) -> str:
         fireworks_result: dict | None = None
 
         # Defensive cleanup of stale artifacts from previous failed attempts.
-        for artifact in (alignment_path, fireworks_path):
-            if artifact.exists():
-                try:
-                    artifact.unlink()
-                except Exception:
-                    pass
+        remove_artifacts(alignment_path, fireworks_path)
 
         runtime = get_runtime_inference_settings(db)
         provider = runtime.get("inference_provider") or "local"
@@ -112,8 +95,7 @@ def transcribe_episode(episode_id: str) -> str:
                     diarize=bool(runtime.get("fireworks_stt_diarize", True)),
                 )
                 transcribe_secs = round(time.monotonic() - t0, 1)
-                audio_secs = _estimate_fireworks_usage(segments_data, episode.duration_secs)
-                audio_minutes = round(audio_secs / 60.0, 3) if audio_secs > 0 else 0.0
+                audio_secs = estimate_fireworks_usage(segments_data, episode.duration_secs)
                 runtime_rate = runtime.get("fireworks_stt_cost_per_minute_usd")
                 configured_rate = (
                     runtime_rate
@@ -121,7 +103,7 @@ def transcribe_episode(episode_id: str) -> str:
                     else settings.fireworks_stt_cost_per_minute_usd
                 )
                 stt_rate = float(configured_rate if configured_rate is not None else 0.0)
-                stt_cost_usd = round(audio_minutes * stt_rate, 4)
+                audio_minutes, stt_cost_usd = compute_fireworks_cost(audio_secs, stt_rate)
 
                 update_episode(
                     db,
@@ -213,12 +195,13 @@ def transcribe_episode(episode_id: str) -> str:
         try:
             out_dir = Path(settings.transcript_dir)
             out_dir.mkdir(parents=True, exist_ok=True)
-            if aligned_result is not None:
-                with open(alignment_path, "w") as f:
-                    json.dump(aligned_result, f)
-            if fireworks_result is not None:
-                with open(fireworks_path, "w") as f:
-                    json.dump(fireworks_result, f)
+            if aligned_result is not None or fireworks_result is not None:
+                persist_transcription_artifacts(
+                    settings.transcript_dir,
+                    episode_id,
+                    aligned_result=aligned_result,
+                    fireworks_result=fireworks_result,
+                )
         except Exception as exc:
             logger.warning(
                 '"action": "alignment_save_failed", "episode_id": "%s", "error": "%s"',
@@ -254,12 +237,7 @@ def transcribe_episode(episode_id: str) -> str:
     finally:
         if not queued_next:
             # If we failed before enqueueing diarize, remove intermediate artifacts.
-            for artifact in (alignment_path, fireworks_path):
-                if artifact.exists():
-                    try:
-                        artifact.unlink()
-                    except Exception:
-                        pass
+            remove_artifacts(alignment_path, fireworks_path)
         db.close()
 
 

--- a/apps/pipeline/app/tasks/transcribe_helpers.py
+++ b/apps/pipeline/app/tasks/transcribe_helpers.py
@@ -1,0 +1,74 @@
+"""
+Helper utilities for transcription task bookkeeping.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def estimate_fireworks_usage(
+    segments_data: list[dict], fallback_duration_secs: int | None
+) -> float:
+    """
+    Estimate billed audio seconds for Fireworks STT.
+
+    Prefer transcript segment bounds; fall back to episode metadata.
+    """
+    max_end = 0.0
+    for seg in segments_data:
+        try:
+            max_end = max(max_end, float(seg.get("end", 0.0) or 0.0))
+        except Exception:
+            continue
+    if max_end > 0:
+        return max_end
+    return float(fallback_duration_secs or 0)
+
+
+def compute_fireworks_cost(
+    audio_secs: float, configured_rate_usd_per_minute: float
+) -> tuple[float, float]:
+    """
+    Convert audio seconds and rate into billable minutes and rounded USD cost.
+    """
+    audio_minutes = round(audio_secs / 60.0, 3) if audio_secs > 0 else 0.0
+    stt_cost_usd = round(audio_minutes * configured_rate_usd_per_minute, 4)
+    return audio_minutes, stt_cost_usd
+
+
+def remove_artifacts(*artifacts: Path) -> None:
+    """
+    Best-effort artifact cleanup.
+    """
+    for artifact in artifacts:
+        if artifact.exists():
+            try:
+                artifact.unlink()
+            except Exception:
+                pass
+
+
+def persist_transcription_artifacts(
+    transcript_dir: str,
+    episode_id: str,
+    *,
+    aligned_result: dict | None,
+    fireworks_result: dict | None,
+) -> tuple[Path, Path]:
+    """
+    Persist local/fireworks intermediate transcript artifacts when available.
+    """
+    out_dir = Path(transcript_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    alignment_path = out_dir / f"{episode_id}.whisperx.json"
+    fireworks_path = out_dir / f"{episode_id}.fireworks.json"
+
+    if aligned_result is not None:
+        with open(alignment_path, "w") as f:
+            json.dump(aligned_result, f)
+    if fireworks_result is not None:
+        with open(fireworks_path, "w") as f:
+            json.dump(fireworks_result, f)
+
+    return alignment_path, fireworks_path

--- a/apps/pipeline/tests/unit/test_task_transcribe.py
+++ b/apps/pipeline/tests/unit/test_task_transcribe.py
@@ -35,7 +35,7 @@ class TestTranscribeEpisode:
             patch("app.services.whisper.transcribe", return_value=(segments_data, "en", aligned_result)),
             patch("app.tasks.transcribe.settings") as mock_settings,
             patch("builtins.open", MagicMock()),
-            patch("app.tasks.transcribe.json"),
+            patch("app.tasks.transcribe_helpers.json"),
         ):
             mock_settings.whisper_model = "large-v3-turbo"
             mock_settings.transcript_dir = "/data/transcripts"
@@ -158,7 +158,7 @@ class TestTranscribeEpisode:
             ),
             patch("app.tasks.transcribe.settings") as mock_settings,
             patch("builtins.open", MagicMock()),
-            patch("app.tasks.transcribe.json"),
+            patch("app.tasks.transcribe_helpers.json"),
         ):
             mock_settings.fireworks_stt_model = "whisper-v3-large"
             mock_settings.fireworks_audio_base_url = "https://audio-turbo.api.fireworks.ai"
@@ -376,7 +376,7 @@ class TestTranscribeEpisode:
             ),
             patch("app.tasks.transcribe.settings") as mock_settings,
             patch("builtins.open", MagicMock()),
-            patch("app.tasks.transcribe.json"),
+            patch("app.tasks.transcribe_helpers.json"),
         ):
             # Non-zero default must not override explicit runtime 0.
             mock_settings.fireworks_stt_cost_per_minute_usd = 0.006


### PR DESCRIPTION
## Summary
- extract reusable helper functions from `transcribe.py` into `transcribe_helpers.py`
- replace duplicated inline cleanup/cost/artifact persistence logic with helper calls
- update transcribe unit tests to patch the helper module JSON writes
- preserve Fireworks artifact persistence when only Fireworks payload is available

## Testing
- cd apps/pipeline && python3 -m pytest tests/unit/test_task_transcribe.py -q

Part of #367