### PR TITLE
refactor: extract inference text helpers

### DIFF
--- a/apps/pipeline/app/services/inference.py
+++ b/apps/pipeline/app/services/inference.py
@@ -10,39 +10,19 @@ same GC pattern as Whisper and pyannote (PRD-01 §5.4).
 """
 import gc
 import logging
-import re
 import sys
 from dataclasses import dataclass, field
-from html.parser import HTMLParser
-from io import StringIO
 from typing import Optional
 
+from app.services.inference_helpers import (
+    name_after_colon_in_title,
+    name_near_guest_signal,
+    name_near_host_pattern,
+    normalize_name,
+    strip_html,
+)
+
 logger = logging.getLogger(__name__)
-
-# Proximity window (in characters) for guest signal detection
-GUEST_PROXIMITY_CHARS = 200
-
-GUEST_SIGNAL_PATTERNS = [
-    r"\bguest\b",
-    r"\bjoin(?:s|ing|ed)?\b",
-    r"\btoday'?s guest\b",
-    r"\bfeaturing\b",
-    r"\bfeat\.?\b",
-    r"\binterview(?:s|ing|ed)?\b",
-    r"\bsit(?:s|ting)? down with\b",
-    r"\btalk(?:s|ing)? to\b",
-    r"\bwelcome(?:s|d)?\b",
-    r"\bwith me today\b",
-    r"\bmy guest\b",
-    r"\bspecial guest\b",
-]
-
-HOST_DESCRIPTION_PATTERNS = [
-    r"\bhosted by\b",
-    r"\bhost of\b",
-    r"\byour host\b",
-    r"\bI'?m\b",
-]
 
 
 @dataclass
@@ -58,32 +38,6 @@ class InferenceResult:
     host: Optional[CandidateName] = None
     guests: list[CandidateName] = field(default_factory=list)
     raw_candidates: list[CandidateName] = field(default_factory=list)
-
-
-class _HTMLStripper(HTMLParser):
-    """Minimal HTML tag stripper."""
-
-    def __init__(self):
-        super().__init__()
-        self._text = StringIO()
-
-    def handle_data(self, data):
-        self._text.write(data)
-
-    def get_text(self) -> str:
-        return self._text.getvalue()
-
-
-def strip_html(text: str) -> str:
-    """Strip HTML tags from text (PRD-04 L-05)."""
-    stripper = _HTMLStripper()
-    stripper.feed(text)
-    return stripper.get_text()
-
-
-def _normalize_name(name: str) -> str:
-    """Lowercase, collapse whitespace."""
-    return " ".join(name.lower().split())
 
 
 def load_spacy_model():
@@ -147,7 +101,7 @@ def extract_candidates(
         for ent in doc.ents:
             if ent.label_ != "PERSON":
                 continue
-            norm = _normalize_name(ent.text)
+            norm = normalize_name(ent.text)
             if norm in seen_normalized:
                 continue
             seen_normalized.add(norm)
@@ -191,7 +145,7 @@ def classify_candidates(
             continue
 
         # Host signals — check feed description patterns (MEDIUM confidence)
-        if f_desc and _name_near_host_pattern(name_lower, f_desc):
+        if f_desc and name_near_host_pattern(name_lower, f_desc):
             c.role = "host"
             c.confidence = "MEDIUM"
             if not host:
@@ -204,7 +158,7 @@ def classify_candidates(
 
         # Guest signals — check episode description proximity (HIGH/MEDIUM confidence)
         if ep_desc:
-            guest_confidence = _name_near_guest_signal(name_lower, ep_desc)
+            guest_confidence = name_near_guest_signal(name_lower, ep_desc)
             if guest_confidence:
                 c.role = "guest"
                 c.confidence = guest_confidence
@@ -212,7 +166,7 @@ def classify_candidates(
                 continue
 
         # Guest signals — name after colon in episode title pattern
-        if ep_desc and _name_after_colon_in_title(c.name, episode_description or ""):
+        if ep_desc and name_after_colon_in_title(c.name, episode_description or ""):
             c.role = "guest"
             c.confidence = "HIGH"
             guests.append(c)
@@ -231,42 +185,6 @@ def classify_candidates(
         host = None
 
     return InferenceResult(host=host, guests=guests, raw_candidates=candidates)
-
-
-def _name_near_host_pattern(name_lower: str, feed_desc_lower: str) -> bool:
-    """Check if name appears near host-signal phrases in feed description."""
-    for pattern in HOST_DESCRIPTION_PATTERNS:
-        for m in re.finditer(pattern, feed_desc_lower):
-            # Look for name within proximity of the pattern match
-            start = max(0, m.start() - GUEST_PROXIMITY_CHARS)
-            end = min(len(feed_desc_lower), m.end() + GUEST_PROXIMITY_CHARS)
-            window = feed_desc_lower[start:end]
-            if name_lower in window:
-                return True
-    return False
-
-
-def _name_near_guest_signal(name_lower: str, ep_desc_lower: str) -> Optional[str]:
-    """Check if name appears near guest-signal phrases. Returns confidence or None."""
-    strong_patterns = [r"\bmy guest\b", r"\btoday'?s guest\b", r"\bspecial guest\b"]
-    for pattern in GUEST_SIGNAL_PATTERNS:
-        for m in re.finditer(pattern, ep_desc_lower):
-            start = max(0, m.start() - GUEST_PROXIMITY_CHARS)
-            end = min(len(ep_desc_lower), m.end() + GUEST_PROXIMITY_CHARS)
-            window = ep_desc_lower[start:end]
-            if name_lower in window:
-                is_strong = any(re.search(sp, window) for sp in strong_patterns)
-                return "HIGH" if is_strong else "MEDIUM"
-    return None
-
-
-def _name_after_colon_in_title(name: str, episode_description: str) -> bool:
-    """Check for 'Ep N: Name ...' pattern in the first line of description."""
-    first_line = episode_description.split("\n")[0]
-    if ":" not in first_line:
-        return False
-    after_colon = first_line.split(":", 1)[1].strip()
-    return name.lower() in after_colon.lower()
 
 
 def assign_speaker_slots(

--- a/apps/pipeline/app/services/inference_helpers.py
+++ b/apps/pipeline/app/services/inference_helpers.py
@@ -1,0 +1,95 @@
+"""
+Helper utilities for host/guest inference text processing and matching.
+"""
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from io import StringIO
+from typing import Optional
+
+# Proximity window (in characters) for guest signal detection
+GUEST_PROXIMITY_CHARS = 200
+
+GUEST_SIGNAL_PATTERNS = [
+    r"\bguest\b",
+    r"\bjoin(?:s|ing|ed)?\b",
+    r"\btoday'?s guest\b",
+    r"\bfeaturing\b",
+    r"\bfeat\.?\b",
+    r"\binterview(?:s|ing|ed)?\b",
+    r"\bsit(?:s|ting)? down with\b",
+    r"\btalk(?:s|ing)? to\b",
+    r"\bwelcome(?:s|d)?\b",
+    r"\bwith me today\b",
+    r"\bmy guest\b",
+    r"\bspecial guest\b",
+]
+
+HOST_DESCRIPTION_PATTERNS = [
+    r"\bhosted by\b",
+    r"\bhost of\b",
+    r"\byour host\b",
+    r"\bI'?m\b",
+]
+
+
+class _HTMLStripper(HTMLParser):
+    """Minimal HTML tag stripper."""
+
+    def __init__(self):
+        super().__init__()
+        self._text = StringIO()
+
+    def handle_data(self, data):
+        self._text.write(data)
+
+    def get_text(self) -> str:
+        return self._text.getvalue()
+
+
+def strip_html(text: str) -> str:
+    """Strip HTML tags from text (PRD-04 L-05)."""
+    stripper = _HTMLStripper()
+    stripper.feed(text)
+    return stripper.get_text()
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase and collapse whitespace for dedupe matching."""
+    return " ".join(name.lower().split())
+
+
+def name_near_host_pattern(name_lower: str, feed_desc_lower: str) -> bool:
+    """Check if name appears near host-signal phrases in feed description."""
+    for pattern in HOST_DESCRIPTION_PATTERNS:
+        for m in re.finditer(pattern, feed_desc_lower):
+            start = max(0, m.start() - GUEST_PROXIMITY_CHARS)
+            end = min(len(feed_desc_lower), m.end() + GUEST_PROXIMITY_CHARS)
+            window = feed_desc_lower[start:end]
+            if name_lower in window:
+                return True
+    return False
+
+
+def name_near_guest_signal(name_lower: str, ep_desc_lower: str) -> Optional[str]:
+    """Check if name appears near guest-signal phrases. Returns confidence or None."""
+    strong_patterns = [r"\bmy guest\b", r"\btoday'?s guest\b", r"\bspecial guest\b"]
+    for pattern in GUEST_SIGNAL_PATTERNS:
+        for m in re.finditer(pattern, ep_desc_lower):
+            start = max(0, m.start() - GUEST_PROXIMITY_CHARS)
+            end = min(len(ep_desc_lower), m.end() + GUEST_PROXIMITY_CHARS)
+            window = ep_desc_lower[start:end]
+            if name_lower in window:
+                is_strong = any(re.search(sp, window) for sp in strong_patterns)
+                return "HIGH" if is_strong else "MEDIUM"
+    return None
+
+
+def name_after_colon_in_title(name: str, episode_description: str) -> bool:
+    """Check for 'Ep N: Name ...' pattern in the first line of description."""
+    first_line = episode_description.split("\n")[0]
+    if ":" not in first_line:
+        return False
+    after_colon = first_line.split(":", 1)[1].strip()
+    return name.lower() in after_colon.lower()


### PR DESCRIPTION
## Summary
- move HTML stripping, name normalization, and regex proximity matching helpers from apps/pipeline/app/services/inference.py into a new helper module
- keep inference orchestration and classification flow in inference.py with imports from the helper module
- preserve behavior while reducing inference.py size and improving readability

## Testing
- cd apps/pipeline && python3 -m pytest tests/unit/test_inference.py tests/unit/test_task_infer.py -q

Part of #367