### PR TITLE
feat(podcast): enhance source page header with image, website, and description (#424)

### DIFF
--- a/apps/web/src/app/podcasts/[id]/page.tsx
+++ b/apps/web/src/app/podcasts/[id]/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
+import Image from "next/image";
 import { notFound } from "next/navigation";
-import { FlaskConical } from "lucide-react";
+import { FlaskConical, ExternalLink } from "lucide-react";
 import pool from "@/lib/db";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import EpisodesList, { type EnrichedEpisode } from "@/components/EpisodesList";
 
 export const dynamic = "force-dynamic";
@@ -10,13 +12,17 @@ export const dynamic = "force-dynamic";
 interface Feed {
   id: string;
   title: string | null;
+  description: string | null;
   image_url: string | null;
   website_url: string | null;
   mode: string;
 }
 
 async function getFeed(id: string): Promise<Feed | null> {
-  const result = await pool.query("SELECT * FROM feeds WHERE id = $1", [id]);
+  const result = await pool.query(
+    "SELECT id, title, description, image_url, website_url, mode FROM feeds WHERE id = $1",
+    [id]
+  );
   return result.rows[0] ?? null;
 }
 
@@ -76,15 +82,58 @@ export default async function PodcastPage({ params }: { params: Promise<{ id: st
         <Link href="/podcasts" className="text-sm text-muted-foreground hover:text-foreground">
           ← Podcasts
         </Link>
-        <div className="flex items-center gap-2 mt-2">
-          <h1 className="text-2xl font-semibold">{feed.title ?? "Untitled podcast"}</h1>
-          {feed.mode === "test" && (
-            <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-1">
-              <FlaskConical size={12} />
-              Test
-            </Badge>
-          )}
-        </div>
+
+        <Card className="mt-4 overflow-hidden">
+          <CardContent className="p-0">
+            <div className="flex flex-col sm:flex-row gap-4 p-4">
+              {/* Podcast Image */}
+              {feed.image_url ? (
+                <Image
+                  src={feed.image_url}
+                  alt={feed.title ?? "Podcast"}
+                  width={150}
+                  height={150}
+                  className="w-32 h-32 sm:w-36 sm:h-36 object-cover rounded-md shrink-0"
+                />
+              ) : (
+                <div className="w-32 h-32 sm:w-36 sm:h-36 bg-muted flex items-center justify-center text-4xl rounded-md shrink-0">
+                  🎙
+                </div>
+              )}
+
+              {/* Podcast Info */}
+              <div className="flex-1 min-w-0 space-y-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h1 className="text-xl sm:text-2xl font-semibold">{feed.title ?? "Untitled podcast"}</h1>
+                  {feed.mode === "test" && (
+                    <Badge variant="outline" className="text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-1">
+                      <FlaskConical size={12} />
+                      Test
+                    </Badge>
+                  )}
+                </div>
+
+                {feed.website_url && (
+                  <a
+                    href={feed.website_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm text-link hover:underline"
+                  >
+                    <ExternalLink size={14} />
+                    {new URL(feed.website_url).hostname.replace(/^www\./, "")}
+                  </a>
+                )}
+
+                {feed.description && (
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {feed.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       <EpisodesList episodes={episodes} feedId={feed.id} />

--- a/apps/web/tests/unit/podcast-page-speakers.test.tsx
+++ b/apps/web/tests/unit/podcast-page-speakers.test.tsx
@@ -41,7 +41,7 @@ describe("Podcast page speaker metadata", () => {
   it("filters speaker_name_tags to labels that still exist in episode segments", async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: "feed-1", title: "Feed One", image_url: null, website_url: null, mode: "live" }],
+        rows: [{ id: "feed-1", title: "Feed One", description: null, image_url: null, website_url: null, mode: "live" }],
       })
       .mockResolvedValueOnce({ rows: [] });
 


### PR DESCRIPTION
## Summary
Enhances the podcast detail page (Source page) header to be more descriptive with image, website link, and description.

## Changes
- **Feed interface**: Added `description` field to the TypeScript interface
- **getFeed query**: Updated SQL query to fetch `description` column from database
- **UI enhancements**:
  - Added podcast image/artwork display (or fallback emoji)
  - Added website link with hostname display and external link icon
  - Added podcast description text
  - Used Card component for a polished, responsive layout
  - Responsive design: image on left, content on right (stacks on mobile)

## Visual Improvements
The header now shows:
1. **Podcast artwork** - 150x150px image or placeholder
2. **Title** - with Test badge when applicable
3. **Website link** - clickable link to podcast website (shows clean hostname)
4. **Description** - from RSS feed, explaining what the podcast is about

## Testing
- All 199 existing tests pass
- Updated podcast-page-speakers test to include description field

## Screenshots
Before: Just title with "Podcasts" back link
After: Rich card with image, title, website link, and description

Closes #424