### PR TITLE
fix(about): span content full width like other pages (#425)

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -27,7 +27,7 @@ const PLATFORMS = [
 
 export default function AboutPage() {
   return (
-    <div className="max-w-2xl mx-auto space-y-8 py-4">
+    <div className="space-y-8 py-4">
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">About Podlog</h1>
         <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary
Makes the About page content span full width like the Ask page, matching the navbar width.

## Problem
The About page was constrained to `max-w-2xl` (672px max width) which made the content appear narrow and inconsistent with other pages like the Ask page.

## Solution
Removed the `max-w-2xl mx-auto` constraints from the About page container div, allowing content to span the full available width.

## Changes
- **about/page.tsx**: Removed `max-w-2xl mx-auto` class from main container

## Visual Impact
Before: Narrow centered column (max 672px)
After: Full-width layout consistent with Ask page and other full-width pages

## Testing
- All 199 existing tests pass
- No breaking changes

Closes #425