### PR TITLE
Revert About page to max-w-2xl width

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -27,7 +27,7 @@ const PLATFORMS = [
 
 export default function AboutPage() {
   return (
-    <div className="space-y-8 py-4">
+    <div className="max-w-2xl mx-auto space-y-8 py-4">
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">About Podlog</h1>
         <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary
Reverts the full-width change from issue #425.

## Problem
The full-width layout made the About page content feel too stretched and less readable.

## Solution
Restored the original  constraints for a centered, narrower layout that is easier to read.

## Changes
- Added back  class to the About page container div

## Testing
- All 199 tests pass