### PR TITLE
fix(queue): reset inference_provider_used when reprocessing episode (#436)

### DIFF
--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -58,6 +58,8 @@ def retry_job(episode_id: str, db: Session = Depends(get_db)) -> dict:
     episode.transcribe_duration_secs = None
     episode.diarize_duration_secs = None
     episode.diarize_step_durations = None
+    # Clear inference provider so fresh config is picked up on reprocess (Issue #436)
+    episode.inference_provider_used = None
     db.commit()
 
     enqueue_episode_ingest(db, str(episode.id))


### PR DESCRIPTION
## Summary
Ensures fresh inference configuration is picked up when reprocessing a failed episode.

## Problem
When a user clicks the reprocess button on a failed episode, they expect to be able to change the inference provider (local vs Fireworks) in settings first, and have the new settings take effect.

While the transcribe task already calls `get_runtime_inference_settings()` to get current settings at runtime, it is clearer to also reset the `inference_provider_used` field when the episode is reset for retry.

## Solution
Added `episode.inference_provider_used = None` to the state reset in the retry endpoint.

## Changes
- **apps/pipeline/app/api/queue.py**: Clear `inference_provider_used` when resetting episode for reprocess

## Testing
- All 454 pipeline unit tests pass
- All 10 queue API tests pass

Closes #436