### PR TITLE
fix(docs): align TOC with navbar edge and stretch content (#439)

### DIFF
--- a/apps/web/src/app/docs/DocsClient.tsx
+++ b/apps/web/src/app/docs/DocsClient.tsx
@@ -200,7 +200,7 @@ export default function DocsClient({ docs }: DocsClientProps) {
   const renderHeadingId = makeUniqueSlugger();
 
   return (
-    <div className="mx-auto w-full max-w-[1360px] px-4 py-6">
+    <div className="w-full py-6">
       <div className="grid grid-cols-1 gap-6 md:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-[220px_minmax(0,1fr)_240px]">
       {/* Sidebar / mobile navigator */}
       <aside className="w-full md:w-[220px] md:shrink-0">
@@ -256,7 +256,7 @@ export default function DocsClient({ docs }: DocsClientProps) {
         ) : loading ? (
           <div className="text-muted-foreground">Loading...</div>
         ) : content ? (
-          <article className="prose prose-sm dark:prose-invert mx-auto max-w-[75ch] leading-7">
+          <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeRaw]}


### PR DESCRIPTION
## Summary
- Removes the double `px-4` padding from the `DocsClient` outer wrapper — `MainContent` already provides horizontal padding, so the extra layer was shifting everything inward and keeping the TOC away from the navbar's right edge
- Removes the `max-w-[75ch] mx-auto` cap from the article so the content stretches to fill the middle column between the knowledge base sidebar and the TOC

## Test plan
- [ ] All 12 existing docs unit tests pass (`npm test -- --testPathPattern=docs.test.tsx`)
- [ ] On desktop (`xl` breakpoint): TOC right edge aligns with navbar right edge (theme button)
- [ ] On desktop: content stretches to fill space between left sidebar and TOC
- [ ] On mobile: dropdown doc switcher still works

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)