### PR TITLE
feat(docs): remove width cap on docs page to maximise content column

### DIFF
--- a/apps/web/src/components/MainContent.tsx
+++ b/apps/web/src/components/MainContent.tsx
@@ -8,10 +8,11 @@ export default function MainContent({ children }: { children: React.ReactNode })
   const pathname = usePathname();
   const hasPlayer = Boolean(state.src);
   const isHome = pathname === "/";
+  const isDocs = pathname === "/docs";
 
   return (
     <main
-      className={`max-w-5xl mx-auto px-4 py-8 flex-1 w-full ${isHome ? "flex flex-col" : ""} ${hasPlayer ? "pb-24" : ""}`}
+      className={`${isDocs ? "" : "max-w-5xl"} mx-auto px-4 py-8 flex-1 w-full ${isHome ? "flex flex-col" : ""} ${hasPlayer ? "pb-24" : ""}`}
     >
       {children}
     </main>


### PR DESCRIPTION
## Summary
- Removes `max-w-5xl` from `MainContent` specifically for the `/docs` route
- The 3-column docs grid (Knowledge base / content / TOC) now stretches to full viewport width with only `px-4` margins on each side
- All other pages are unaffected

## Test plan
- [ ] Docs page content column fills the full available viewport width
- [ ] Other pages (Search, Ask, Queue, etc.) still use the original `max-w-5xl` layout
- [ ] Mobile dropdown doc switcher still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)