### PR TITLE
feat: add MP4 support for manual audio uploads (#441)

### DIFF
--- a/apps/pipeline/app/api/episodes.py
+++ b/apps/pipeline/app/api/episodes.py
@@ -25,7 +25,7 @@ from app.services.pipeline_commands import enqueue_episode_ingest
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-ALLOWED_EXTENSIONS = {".mp3", ".m4a", ".wav", ".ogg", ".flac", ".opus", ".aac", ".wma", ".webm"}
+ALLOWED_EXTENSIONS = {".mp3", ".m4a", ".wav", ".ogg", ".flac", ".opus", ".aac", ".wma", ".webm", ".mp4"}
 
 
 class IngestEpisodeRequest(BaseModel):

--- a/apps/pipeline/tests/unit/test_episodes_api.py
+++ b/apps/pipeline/tests/unit/test_episodes_api.py
@@ -127,6 +127,42 @@ class TestUploadEndpoint:
         finally:
             _cleanup_db()
 
+    def test_upload_valid_mp4(self):
+        """MP4 files (often containing audio) should be accepted for upload. Issue #441"""
+        mock_db = MagicMock()
+        mock_db.flush.return_value = None
+
+        def refresh_side_effect(obj):
+            obj.id = "ep-upload-mp4"
+
+        mock_db.refresh.side_effect = refresh_side_effect
+        _override_db(mock_db)
+        try:
+            with patch("app.api.episodes.settings") as mock_settings, \
+                 patch("app.api.episodes.job_queue") as mock_jq, \
+                 patch("builtins.open", create=True), \
+                 patch("shutil.copyfileobj"), \
+                 patch("shutil.disk_usage") as mock_disk, \
+                 patch("pathlib.Path.mkdir"):
+                mock_settings.data_dir = "/tmp/test-data"
+                mock_settings.disk_headroom_bytes = 0
+                mock_settings.audio_raw_dir = "/tmp/test-data/audio/raw"
+                mock_disk.return_value = MagicMock(free=10_000_000_000)
+
+                resp = client.post(
+                    "/api/episodes/upload",
+                    files={"file": ("video_podcast.mp4", io.BytesIO(b"fake mp4 video with audio"), "video/mp4")},
+                    data={"title": "Video Podcast Episode"},
+                )
+
+            assert resp.status_code == 202
+            assert "episode_id" in resp.json()
+            mock_db.add.assert_called_once()
+            mock_db.commit.assert_called_once()
+            mock_jq.enqueue.assert_called_once()
+        finally:
+            _cleanup_db()
+
     def test_upload_rejects_unsupported_extension(self):
         mock_db = MagicMock()
         _override_db(mock_db)


### PR DESCRIPTION
## Summary
Allows users to upload MP4 files as audio sources for manual episode ingestion.

## Problem
Users were unable to upload MP4 files containing audio tracks through the manual upload endpoint (POST /api/episodes/upload), receiving an "Unsupported file type" error.

## Changes
- Added `.mp4` to `ALLOWED_EXTENSIONS` in `apps/pipeline/app/api/episodes.py`
- Added test case `test_upload_valid_mp4` to verify MP4 uploads work correctly

## Compatibility
MP4 files are fully compatible with the existing transcription pipeline:
- ffmpeg extracts audio from MP4 containers and converts to 16kHz mono WAV
- Both Whisper transcription and pyannote diarization support MP4 inputs

## Testing
- New unit test added: `test_upload_valid_mp4`
- All 10 episode API tests passing

Closes #441
