### PR TITLE
fix(archive): don't delete the archive file when re-running archive

### DIFF
--- a/apps/pipeline/app/tasks/archive.py
+++ b/apps/pipeline/app/tasks/archive.py
@@ -93,8 +93,15 @@ def archive_episode(episode_id: str) -> str:
         # Delegate payload construction and event emission to notification runtime.
         emit_episode_done_event(db, episode)
 
-        # Safe to delete raw audio now that status is confirmed
-        if raw_path and raw_path.exists():
+        # Safe to delete raw audio now that status is confirmed.
+        # Skip when the "raw" path is actually the archive path itself
+        # (happens when archive re-runs on an already-compressed episode —
+        # otherwise we'd delete the archive file we just kept).
+        if (
+            raw_path
+            and raw_path.exists()
+            and (archived_path is None or raw_path.resolve() != archived_path.resolve())
+        ):
             raw_path.unlink()
 
         logger.info('"action": "archive_complete", "episode_id": "%s"', episode_id)

--- a/apps/pipeline/tests/unit/test_task_archive.py
+++ b/apps/pipeline/tests/unit/test_task_archive.py
@@ -64,7 +64,7 @@ class TestArchiveEpisode:
 
         with (
             patch("app.tasks.archive.settings") as mock_settings,
-            patch("app.tasks.archive._compress_audio", return_value="/data/audio/archive/ep1.mp3"),
+            patch("app.tasks.archive._compress_audio", return_value=__import__("pathlib").Path("/data/audio/archive/ep1.mp3")),
             patch("app.tasks.archive._write_transcript", return_value="/data/transcripts/ep1.txt"),
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.unlink"),
@@ -144,6 +144,46 @@ class TestArchiveEpisode:
         with pytest.raises(RuntimeError, match="not found"):
             archive_episode("ep1")
 
+
+    @patch("app.tasks.archive.emit_episode_done_event")
+    @patch("app.tasks.archive.update_episode")
+    @patch("app.tasks.archive.SessionLocal")
+    def test_rerun_on_already_archived_does_not_delete_archive(
+        self, mock_session_cls, mock_update, mock_emit_done, tmp_path
+    ):
+        """Re-running archive when audio_local_path already points at the
+        archive file must not delete that file (regression test)."""
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        archive_file = archive_dir / "ep1.mp3"
+        archive_file.write_bytes(b"real-archive-bytes")
+
+        ep = _make_episode(audio_path=str(archive_file))
+        seg = _make_segment()
+        sn = _make_speaker_name()
+        db = MagicMock()
+
+        verified_ep = MagicMock()
+        verified_ep.status = "done"
+        db.query.return_value.filter.return_value.first.side_effect = [ep, verified_ep]
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [seg]
+        db.query.return_value.filter.return_value.all.return_value = [sn]
+        mock_session_cls.return_value = db
+
+        with (
+            patch("app.tasks.archive.settings") as mock_settings,
+            patch("app.tasks.archive._write_transcript", return_value="/data/transcripts/ep1.txt"),
+        ):
+            mock_settings.archive_audio = True
+            mock_settings.audio_archive_dir = str(archive_dir)
+            mock_settings.audio_archive_bitrate = "64k"
+
+            from app.tasks.archive import archive_episode
+
+            archive_episode("ep1")
+
+        assert archive_file.exists(), "archive file must not be deleted on re-run"
+        assert archive_file.read_bytes() == b"real-archive-bytes"
 
     def test_compress_skips_when_already_in_archive_dir(self, tmp_path):
         """_compress_audio should skip ffmpeg when source is already the dest."""


### PR DESCRIPTION
## Summary

Re-running \`archive\` on an already-archived episode deleted the archive file itself. Symptom: timestamp clicks in the transcript produced no audio because \`/api/audio/...\` served 404 even though \`audio_local_path\` pointed at a (now missing) file.

## Root cause

\`archive_episode()\` in \`apps/pipeline/app/tasks/archive.py\`:

1. \`raw_path = episode.audio_local_path\` — but for a previously archived episode this is already \`/data/audio/archive/<id>.mp3\`.
2. \`_compress_audio()\` correctly detects \`raw == dest\`, skips ffmpeg, returns \`dest\` → \`archived_path == raw_path\`.
3. At the end, the task unconditionally runs \`raw_path.unlink()\` — deleting the very archive file it just preserved.

This was triggered in the wild by re-queuing only the \`diarize\` job on a done episode (to re-run diarization after the torchaudio fix in #447); archive ran again and wiped the MP3.

## Fix

Skip the raw-audio unlink when \`raw_path.resolve() == archived_path.resolve()\`.

## Tests

- New regression test \`test_rerun_on_already_archived_does_not_delete_archive\` — creates a real archive file under \`tmp_path\`, invokes \`archive_episode()\`, asserts the file still exists with its original bytes.
- Existing 7 tests still pass.

## Checklist

- [x] Regression test added and passing
- [x] All existing archive tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)