### PR TITLE
fix(web): stop Ask SSE proxy crashing on client disconnect

### DIFF
--- a/apps/web/src/app/api/pipeline/ask/route.ts
+++ b/apps/web/src/app/api/pipeline/ask/route.ts
@@ -3,22 +3,54 @@ import { PIPELINE_API } from "@/lib/pipeline";
 
 /**
  * POST /api/pipeline/ask — SSE proxy to pipeline's /api/ask endpoint.
- * Streams the response directly to the client.
+ *
+ * Pipes the upstream stream through a ReadableStream we control so that
+ * client disconnects (abort, navigate away, resubmit) cleanly close the
+ * upstream fetch instead of crashing the route with
+ * `TypeError: Invalid state: Controller is already closed`.
  */
 export async function POST(req: NextRequest) {
   const body = await req.json();
+
+  const upstreamAbort = new AbortController();
+  req.signal.addEventListener("abort", () => upstreamAbort.abort(), {
+    once: true,
+  });
 
   const resp = await fetch(`${PIPELINE_API}/api/ask`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: upstreamAbort.signal,
   });
 
   if (!resp.ok || !resp.body) {
     return new Response("Pipeline API error", { status: resp.status });
   }
 
-  return new Response(resp.body, {
+  const upstream = resp.body;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = upstream.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+        controller.close();
+      } catch {
+        // Client disconnected or upstream errored. Nothing to do —
+        // cancel() will run and abort the upstream fetch.
+      }
+    },
+    cancel() {
+      upstreamAbort.abort();
+    },
+  });
+
+  return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",


### PR DESCRIPTION
## Summary

The Ask feature appeared broken because every resubmit crashed the SSE proxy route.

## Root cause

\`apps/web/src/app/api/pipeline/ask/route.ts\` returned \`new Response(resp.body, ...)\` directly. When a client aborted mid-stream — which the Ask UI does on every new submit via \`abortRef.current?.abort()\` — Node kept piping upstream bytes into the already-closed response controller and threw:

\`\`\`
uncaughtException: TypeError: Invalid state: Controller is already closed
    at ReadStream.<anonymous> (.next/server/chunks/[root-of-the-server]__13ed17l._.js:1:2701) {
  code: 'ERR_INVALID_STATE'
}
\`\`\`

Confirmed reproducible by running \`curl -X POST /api/pipeline/ask --max-time 3\`: the log error fires every time.

## Fix

- Wrap the upstream body in a \`ReadableStream\` we control.
- Forward \`req.signal\` to the upstream fetch via an \`AbortController\`.
- On client disconnect, \`cancel()\` fires, we abort the upstream fetch, Ollama stops generating (instead of running to completion orphaned).

## Testing

- \`tsc --noEmit\` clean.
- Rebuilt web image, restarted container.
- Reproduced the old crash case (curl --max-time 3) — no more \`Controller is already closed\` entries in logs.
- Verified full happy path still completes: sources → tokens → done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)