### PR TITLE
fix(rag): skip similarity threshold when Ask is scoped to one episode

### DIFF
--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -106,6 +106,11 @@ def retrieve_chunks(
     """)
 
     rows = db.execute(query, params).fetchall()
+    # When scoped to a single episode the caller has already narrowed the
+    # candidate set. Apply the similarity threshold only for broader
+    # searches, where it protects against low-quality matches across
+    # thousands of chunks; for episode-scoped asks, return top-K as-is so
+    # generic questions ("what is this about?") still work.
     return [
         ChunkResult(
             chunk_id=row.chunk_id,
@@ -119,7 +124,7 @@ def retrieve_chunks(
             similarity=row.similarity,
         )
         for row in rows
-        if row.similarity >= SIMILARITY_THRESHOLD
+        if episode_id is not None or row.similarity >= SIMILARITY_THRESHOLD
     ]
 
 

--- a/apps/pipeline/tests/unit/test_rag.py
+++ b/apps/pipeline/tests/unit/test_rag.py
@@ -291,6 +291,28 @@ class TestRetrieveChunks:
         assert "episode_id" in query_str
         assert params["episode_id"] == "ep-42"
 
+    @patch("app.services.rag.embed_query", return_value=[0.1, 0.2, 0.3])
+    def test_episode_scoped_skips_similarity_threshold(self, mock_embed):
+        """Generic questions scoped to one episode must return chunks even
+        when every candidate's similarity is below SIMILARITY_THRESHOLD."""
+        low_row = MagicMock()
+        low_row.chunk_id = 1
+        low_row.episode_id = "ep-42"
+        low_row.episode_title = "Scoped"
+        low_row.speaker_label = None
+        low_row.start_time = 0.0
+        low_row.end_time = 5.0
+        low_row.text = "Below-threshold but still relevant within episode"
+        low_row.similarity = 0.1  # Below SIMILARITY_THRESHOLD (0.3)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = [low_row]
+
+        from app.services.rag import retrieve_chunks
+        results = retrieve_chunks(mock_db, "what is this about?", episode_id="ep-42")
+        assert len(results) == 1
+        assert results[0].similarity == 0.1
+
 
 class TestCheckModelAvailable:
     def test_model_found(self):


### PR DESCRIPTION
## Summary

The episode-page Ask button appeared broken on some episodes (notably the manual upload \`35c09d63\`): generic questions like "What is this about?" returned \`No relevant transcript excerpts found\`.

## Root cause

\`retrieve_chunks\` filters results by \`SIMILARITY_THRESHOLD = 0.3\`. That threshold is a safeguard for broad searches where it protects against low-quality matches across thousands of chunks. When the caller has already narrowed to a single \`episode_id\`, the same filter backfires: a technical episode + a vague question produces cosine similarities in the 0.1–0.2 range for *every* chunk, the threshold drops them all, and the endpoint emits \`"No relevant transcript excerpts found"\`.

Verified: top match for "What is this about?" against this episode was 0.193 — below 0.3, above zero, perfectly usable.

## Fix

Apply the threshold only when \`episode_id is None\`. Episode-scoped asks now return the top-K chunks ordered by similarity, as-is. Relative ranking still surfaces the best excerpts from the episode.

## Testing

- New unit test: \`test_episode_scoped_skips_similarity_threshold\` — a low-similarity row with \`episode_id\` set must be returned.
- All 33 \`test_rag.py\` tests pass.
- End-to-end: rebuilt pipeline + worker, asked "What is this about?" against the failing episode — now returns 8 sources and streams an answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)