### PR TITLE
fix(web): stack floating buttons above audio player (#448 follow-up)

### DIFF
--- a/apps/web/src/components/BackToSearchLink.tsx
+++ b/apps/web/src/components/BackToSearchLink.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { useAudioPlayer } from "@/components/AudioPlayerContext";
 
 /**
  * Renders a "Back to search results" link when the episode page was reached
@@ -11,13 +12,17 @@ import { ArrowLeft } from "lucide-react";
 export default function BackToSearchLink() {
   const searchParams = useSearchParams();
   const query = searchParams.get("q");
+  const { state: playerState } = useAudioPlayer();
+  const playerVisible = !!playerState.src;
 
   if (!query) return null;
 
   return (
     <Link
       href={`/search?q=${encodeURIComponent(query)}`}
-      className="fixed bottom-6 left-6 z-40 inline-flex items-center gap-2 rounded-full bg-action px-4 py-3 text-sm font-medium text-action-foreground shadow-lg hover:bg-action/90 transition-colors"
+      className={`fixed left-6 z-[60] inline-flex items-center gap-2 rounded-full bg-action px-4 py-3 text-sm font-medium text-action-foreground shadow-lg hover:bg-action/90 transition-all ${
+        playerVisible ? "bottom-24" : "bottom-6"
+      }`}
     >
       <ArrowLeft size={14} />
       Back to search results

--- a/apps/web/src/components/EpisodeChat.tsx
+++ b/apps/web/src/components/EpisodeChat.tsx
@@ -144,7 +144,7 @@ export default function EpisodeChat({ episodeId, episodeTitle }: EpisodeChatProp
       <button
         onClick={() => setIsOpen(true)}
         className={`fixed right-6 z-[60] flex items-center gap-2 rounded-full bg-action px-4 py-3 text-action-foreground shadow-lg hover:bg-action/90 transition-all ${
-          playerVisible ? "bottom-24" : "bottom-6"
+          playerVisible ? "bottom-40" : "bottom-6"
         }`}
         aria-label="Ask about this episode"
       >
@@ -157,7 +157,7 @@ export default function EpisodeChat({ episodeId, episodeTitle }: EpisodeChatProp
   // Chat panel
   return (
     <div className={`fixed right-6 z-[60] flex flex-col w-[calc(100vw-2rem)] sm:w-96 h-[min(28rem,calc(100vh-4rem))] rounded-xl border bg-background shadow-2xl ${
-      playerVisible ? "bottom-24" : "bottom-6"
+      playerVisible ? "bottom-40" : "bottom-6"
     }`}>
       {/* Header */}
       <div className="flex items-center justify-between gap-2 px-4 py-3 border-b shrink-0">

--- a/apps/web/src/components/TranscriptSection.tsx
+++ b/apps/web/src/components/TranscriptSection.tsx
@@ -5,6 +5,7 @@ import { ArrowUp } from "lucide-react";
 import SpeakerPanel from "@/components/SpeakerPanel";
 import TranscriptView from "@/components/TranscriptView";
 import TranscriptExportButton from "@/components/TranscriptExportButton";
+import { useAudioPlayer } from "@/components/AudioPlayerContext";
 import type { Segment } from "@/lib/types";
 
 interface Props {
@@ -45,6 +46,8 @@ export default function TranscriptSection({
   const [segments, setSegments] = useState(initial);
   const [activeSpeaker, setActiveSpeaker] = useState<string | null>(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
+  const { state: playerState } = useAudioPlayer();
+  const playerVisible = !!playerState.src;
 
   useEffect(() => {
     function handleScroll() {
@@ -138,7 +141,9 @@ export default function TranscriptSection({
       {showBackToTop && (
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          className="fixed bottom-20 right-6 z-40 p-2.5 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+          className={`fixed right-6 z-[60] p-2.5 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-all ${
+            playerVisible ? "bottom-24" : "bottom-20"
+          }`}
           title="Back to top"
         >
           <ArrowUp size={18} />


### PR DESCRIPTION
## Summary

Follow-up to #451. Two regressions reported on #448:

1. The Ask FAB, after being bumped to \`bottom-24\` when the player shows, started covering the "back to top" button (which sits at \`bottom-20\`).
2. The "back to search results" button on the left was still hidden behind the player bar.

## Fix

When \`AudioPlayerContext.state.src\` is set, shift all three floating buttons so they stack cleanly above the player:

| Button | Default | Player visible |
|---|---|---|
| Back to search (left) | \`bottom-6\` | \`bottom-24\` |
| Back to top (right)   | \`bottom-20\` | \`bottom-24\` |
| Ask FAB + chat panel (right) | \`bottom-6\` / \`bottom-6\` | \`bottom-40\` (stacks above back-to-top) |

All three now also use \`z-[60]\` so they always win over the player's \`z-50\`.

## Testing

- \`tsc --noEmit\` clean.
- Rebuilt web, verified each button clears the player with no overlap, and that the Ask FAB no longer covers the back-to-top button when both are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)