### PR TITLE
fix(feeds): serialize feed id as text in GET /api/feeds (#455)

### DIFF
--- a/apps/pipeline/app/api/feeds.py
+++ b/apps/pipeline/app/api/feeds.py
@@ -80,7 +80,7 @@ def list_feeds(db: Session = Depends(get_db)) -> list[FeedListItem]:
         db.execute(
             text(
                 """
-                SELECT f.id, f.url, f.title, f.mode, f.last_polled_at,
+                SELECT f.id::text AS id, f.url, f.title, f.mode, f.last_polled_at,
                        COUNT(e.id)::int AS episode_count
                 FROM feeds f
                 LEFT JOIN episodes e ON e.feed_id = f.id

--- a/apps/pipeline/tests/integration/test_pipeline.py
+++ b/apps/pipeline/tests/integration/test_pipeline.py
@@ -349,3 +349,27 @@ class TestArchive:
         assert sample_episode.error_class == "DISK_FULL"
         # Raw file is preserved (not deleted)
         assert audio_dest.exists()
+
+
+class TestFeedsListEndpoint:
+    """Issue #455: GET /api/feeds must return feeds as JSON (id serialized as string)."""
+
+    def test_list_feeds_returns_rows_with_string_id(self, db_session, sample_feed):
+        from fastapi.testclient import TestClient
+
+        from app.database import get_db
+        from app.main import app
+
+        app.dependency_overrides[get_db] = lambda: db_session
+        try:
+            client = TestClient(app)
+            resp = client.get("/api/feeds")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list) and len(body) >= 1
+        feed = next(f for f in body if f["url"] == sample_feed.url)
+        assert feed["id"] == sample_feed.id
+        assert isinstance(feed["id"], str)


### PR DESCRIPTION
## Summary
- Fixes issue #455: the feed-management page appeared empty and delete controls were hidden because `GET /api/feeds` was returning `500 Internal server error: ValidationError`.
- Root cause: `list_feeds` uses a raw SQL query, which returns `f.id` as a psycopg `UUID` object. Under Pydantic 2.12, `FeedListItem.id: str` no longer coerces UUIDs and raises a validation error for every feed row.
- Fix: cast `f.id::text` in the SELECT so the endpoint serializes cleanly.

## Changes
- `apps/pipeline/app/api/feeds.py`: cast `f.id::text AS id` in the `list_feeds` query.
- `apps/pipeline/tests/integration/test_pipeline.py`: new `TestFeedsListEndpoint` integration test exercising the endpoint against a real Postgres DB (the existing unit test mocked dict rows and so missed the UUID path).

## Test plan
- [x] `docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/test_api.py tests/integration/test_pipeline.py::TestFeedsListEndpoint -v` — all pass
- [ ] After merge: rebuild pipeline image, restart `pipeline` service, confirm `/api/feeds` returns 200 and the UI lists existing feeds with delete controls

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)