### PR TITLE
feat(episodes): delete button for manual uploads (#454)

### DIFF
--- a/apps/pipeline/app/api/episodes.py
+++ b/apps/pipeline/app/api/episodes.py
@@ -1,8 +1,9 @@
 """
 Episode API — control-plane endpoints only.
 
-POST  /api/episodes/ingest   Manually ingest a single audio URL
-POST  /api/episodes/upload   Upload a local audio file for processing
+POST   /api/episodes/ingest        Manually ingest a single audio URL
+POST   /api/episodes/upload        Upload a local audio file for processing
+DELETE /api/episodes/{episode_id}  Delete a manually uploaded episode
 
 Read-only episode data is served directly by the Next.js web app
 via PostgreSQL queries (no proxy needed).
@@ -120,3 +121,75 @@ def upload_audio(
         episode.id, file.filename,
     )
     return {"episode_id": str(episode.id)}
+
+
+@router.delete("/episodes/{episode_id}", status_code=204)
+def delete_episode(episode_id: str, db: Session = Depends(get_db)) -> None:
+    """Delete a manually uploaded episode (issue #454).
+
+    Restricted to episodes with feed_id IS NULL — feed-linked episodes
+    should be removed by deleting the feed (DELETE /api/feeds/{id}?delete_episodes=true).
+    Removes on-disk audio + transcript; DB cascade handles segments, chunks,
+    speaker_names, jobs, and notifications.
+    """
+    episode = db.query(Episode).filter(Episode.id == episode_id).first()
+    if not episode:
+        raise HTTPException(status_code=404, detail="Episode not found")
+    if episode.feed_id is not None:
+        raise HTTPException(
+            status_code=403,
+            detail="Feed-linked episodes can only be deleted by removing the feed",
+        )
+
+    _remove_episode_files(episode_id, episode.audio_local_path, episode.transcript_path)
+
+    db.delete(episode)
+    db.commit()
+    logger.info('"action": "episode_deleted", "episode_id": "%s"', episode_id)
+
+
+def _remove_episode_files(
+    episode_id: str,
+    audio_local_path: Optional[str],
+    transcript_path: Optional[str],
+) -> None:
+    """Best-effort removal of files associated with an episode.
+
+    Only unlinks files under the configured audio/transcript directories —
+    any path outside those roots is ignored as a safety measure.
+    """
+    allowed_roots = [
+        Path(settings.audio_raw_dir).resolve(),
+        Path(settings.audio_archive_dir).resolve(),
+        Path(settings.transcript_dir).resolve(),
+    ]
+
+    def _unlink_if_allowed(p: Path) -> None:
+        try:
+            resolved = p.resolve()
+        except OSError:
+            return
+        if not any(str(resolved).startswith(str(root) + "/") for root in allowed_roots):
+            return
+        try:
+            resolved.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                '"action": "episode_file_unlink_failed", "episode_id": "%s", "path": "%s", "error": "%s"',
+                episode_id, resolved, exc,
+            )
+
+    # Explicit paths recorded on the row
+    if audio_local_path:
+        _unlink_if_allowed(Path(audio_local_path))
+    if transcript_path:
+        _unlink_if_allowed(Path(transcript_path))
+
+    # Defensive sweep — any {episode_id}.* in raw/, {episode_id}.mp3 in archive/
+    raw_dir = Path(settings.audio_raw_dir)
+    if raw_dir.is_dir():
+        for path in raw_dir.glob(f"{episode_id}.*"):
+            _unlink_if_allowed(path)
+    archive_file = Path(settings.audio_archive_dir) / f"{episode_id}.mp3"
+    if archive_file.exists():
+        _unlink_if_allowed(archive_file)

--- a/apps/pipeline/tests/integration/test_pipeline.py
+++ b/apps/pipeline/tests/integration/test_pipeline.py
@@ -373,3 +373,104 @@ class TestFeedsListEndpoint:
         feed = next(f for f in body if f["url"] == sample_feed.url)
         assert feed["id"] == sample_feed.id
         assert isinstance(feed["id"], str)
+
+
+class TestDeleteEpisodeEndpoint:
+    """Issue #454: DELETE /api/episodes/{id} removes a manually uploaded episode."""
+
+    def test_delete_removes_row_cascades_children_and_cleans_files(
+        self, db_session, tmp_path
+    ):
+        from fastapi.testclient import TestClient
+        from unittest.mock import patch
+        from app.database import get_db
+        from app.main import app
+        from app.models import Chunk, Episode, Segment, SpeakerName
+
+        # Match the layout computed by Settings.audio_raw_dir / audio_archive_dir / transcript_dir
+        raw_dir = tmp_path / "audio" / "raw"
+        archive_dir = tmp_path / "audio" / "archive"
+        transcript_dir = tmp_path / "transcripts"
+        raw_dir.mkdir(parents=True)
+        archive_dir.mkdir(parents=True)
+        transcript_dir.mkdir(parents=True)
+
+        episode = Episode(
+            id=str(uuid.uuid4()),
+            feed_id=None,
+            guid=f"upload:test-{uuid.uuid4().hex[:8]}",
+            title="Manual Upload",
+            audio_url="local://sample.mp3",
+            status="done",
+        )
+        db_session.add(episode)
+        db_session.flush()
+
+        seg = Segment(
+            episode_id=episode.id, start_time=0.0, end_time=1.0, text="hello"
+        )
+        db_session.add(seg)
+        db_session.flush()
+        chunk = Chunk(
+            episode_id=episode.id,
+            start_time=0.0,
+            end_time=1.0,
+            text="hello",
+            segment_ids=[seg.id],
+        )
+        db_session.add(chunk)
+        db_session.add(
+            SpeakerName(episode_id=episode.id, speaker_label="SPEAKER_00", display_name="Alice")
+        )
+
+        # On-disk artifacts
+        audio_file = raw_dir / f"{episode.id}.mp3"
+        audio_file.write_bytes(b"audio")
+        archived_file = archive_dir / f"{episode.id}.mp3"
+        archived_file.write_bytes(b"archived")
+        transcript_file = transcript_dir / f"{episode.id}.txt"
+        transcript_file.write_text("transcript")
+
+        episode.audio_local_path = str(audio_file)
+        episode.transcript_path = str(transcript_file)
+        db_session.flush()
+
+        app.dependency_overrides[get_db] = lambda: db_session
+        try:
+            with (
+                patch("app.api.episodes.settings.data_dir", str(tmp_path)),
+            ):
+                client = TestClient(app)
+                resp = client.delete(f"/api/episodes/{episode.id}")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 204
+        assert db_session.query(Episode).filter(Episode.id == episode.id).first() is None
+        assert db_session.query(Segment).filter(Segment.episode_id == episode.id).count() == 0
+        assert db_session.query(Chunk).filter(Chunk.episode_id == episode.id).count() == 0
+        assert (
+            db_session.query(SpeakerName).filter(SpeakerName.episode_id == episode.id).count() == 0
+        )
+        assert not audio_file.exists()
+        assert not archived_file.exists()
+        assert not transcript_file.exists()
+
+    def test_delete_refuses_feed_linked_episode(self, db_session, sample_episode):
+        from fastapi.testclient import TestClient
+
+        from app.database import get_db
+        from app.main import app
+        from app.models import Episode
+
+        assert sample_episode.feed_id is not None  # sanity
+
+        app.dependency_overrides[get_db] = lambda: db_session
+        try:
+            client = TestClient(app)
+            resp = client.delete(f"/api/episodes/{sample_episode.id}")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 403
+        assert db_session.query(Episode).filter(Episode.id == sample_episode.id).first() is not None

--- a/apps/pipeline/tests/unit/test_api.py
+++ b/apps/pipeline/tests/unit/test_api.py
@@ -189,3 +189,58 @@ class TestFeedsEndpoint:
             assert resp.json() == mock_rows
         finally:
             app.dependency_overrides.clear()
+
+
+class TestDeleteEpisodeEndpoint:
+    """Issue #454: manually uploaded episodes need a delete endpoint."""
+
+    def test_delete_unknown_episode_returns_404(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = client.delete("/api/episodes/does-not-exist")
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == "Episode not found"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_delete_feed_linked_episode_returns_403(self):
+        mock_db = MagicMock()
+        mock_episode = MagicMock()
+        mock_episode.feed_id = "feed-uuid"
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_episode
+
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = client.delete("/api/episodes/some-episode-id")
+            assert resp.status_code == 403
+            assert "Feed-linked" in resp.json()["detail"]
+            mock_db.delete.assert_not_called()
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_delete_manual_upload_returns_204(self):
+        mock_db = MagicMock()
+        mock_episode = MagicMock()
+        mock_episode.feed_id = None
+        mock_episode.audio_local_path = None
+        mock_episode.transcript_path = None
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_episode
+
+        from app.database import get_db
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            with patch("app.api.episodes._remove_episode_files"):
+                resp = client.delete("/api/episodes/some-episode-id")
+            assert resp.status_code == 204
+            mock_db.delete.assert_called_once_with(mock_episode)
+            mock_db.commit.assert_called_once()
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/web/src/app/api/episodes/[id]/route.ts
+++ b/apps/web/src/app/api/episodes/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { PIPELINE_API } from "@/lib/pipeline";
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const resp = await fetch(`${PIPELINE_API}/api/episodes/${id}`, { method: "DELETE" });
+  if (resp.status === 204) return new NextResponse(null, { status: 204 });
+  const text = await resp.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = { detail: text || "Pipeline API returned a non-JSON error" };
+  }
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 import Image from "next/image";
-import { FlaskConical, FileAudio, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { FlaskConical } from "lucide-react";
 import pool from "@/lib/db";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import AudioUpload from "@/components/AudioUpload";
+import UploadedEpisodeCard from "@/components/UploadedEpisodeCard";
 
 export const dynamic = "force-dynamic";
 
@@ -143,26 +144,13 @@ export default async function SourcesPage() {
         {uploads.episodes.length > 0 && (
           <div className="mt-4 space-y-2">
             {uploads.episodes.map((ep) => (
-              <Link key={ep.id} href={`/episodes/${ep.id}`}>
-                <Card className="hover:bg-accent/30 transition-colors">
-                  <CardContent className="p-3 flex items-center gap-3">
-                    <FileAudio size={16} className="text-muted-foreground shrink-0" />
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium truncate">{ep.title ?? "Untitled"}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {new Date(ep.created_at).toLocaleDateString()}
-                      </p>
-                    </div>
-                    {ep.status === "done" ? (
-                      <CheckCircle2 size={14} className="text-green-600 dark:text-green-400 shrink-0" />
-                    ) : ep.status === "failed" ? (
-                      <XCircle size={14} className="text-red-600 dark:text-red-400 shrink-0" />
-                    ) : (
-                      <Loader2 size={14} className="text-blue-600 dark:text-blue-400 animate-spin shrink-0" />
-                    )}
-                  </CardContent>
-                </Card>
-              </Link>
+              <UploadedEpisodeCard
+                key={ep.id}
+                id={ep.id}
+                title={ep.title}
+                status={ep.status}
+                created_at={ep.created_at}
+              />
             ))}
           </div>
         )}

--- a/apps/web/src/components/UploadedEpisodeCard.tsx
+++ b/apps/web/src/components/UploadedEpisodeCard.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { CheckCircle2, FileAudio, Loader2, Trash2, XCircle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface UploadedEpisodeCardProps {
+  id: string;
+  title: string | null;
+  status: string;
+  created_at: string;
+}
+
+export default function UploadedEpisodeCard({ id, title, status, created_at }: UploadedEpisodeCardProps) {
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!confirm(`Delete "${title ?? "this upload"}"? The audio file and transcript will be removed.`)) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      const resp = await fetch(`/api/episodes/${id}`, { method: "DELETE" });
+      if (!resp.ok && resp.status !== 204) {
+        const body = await resp.json().catch(() => ({}));
+        alert(body.detail ?? "Failed to delete episode");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Link href={`/episodes/${id}`}>
+      <Card className="hover:bg-accent/30 transition-colors">
+        <CardContent className="p-3 flex items-center gap-3">
+          <FileAudio size={16} className="text-muted-foreground shrink-0" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium truncate">{title ?? "Untitled"}</p>
+            <p className="text-xs text-muted-foreground">
+              {new Date(created_at).toLocaleDateString()}
+            </p>
+          </div>
+          {status === "done" ? (
+            <CheckCircle2 size={14} className="text-green-600 dark:text-green-400 shrink-0" />
+          ) : status === "failed" ? (
+            <XCircle size={14} className="text-red-600 dark:text-red-400 shrink-0" />
+          ) : (
+            <Loader2 size={14} className="text-blue-600 dark:text-blue-400 animate-spin shrink-0" />
+          )}
+          <button
+            type="button"
+            aria-label="Delete upload"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="shrink-0 p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {deleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          </button>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
Manually uploaded episodes live outside any feed (`feed_id IS NULL`), so the existing feed-delete flow can't remove them. They pile up on `/podcasts` with no way out. This adds a per-upload delete control on the Manual uploads section, backed by a new scoped pipeline endpoint.

## Changes

### Pipeline (`apps/pipeline`)
- `DELETE /api/episodes/{episode_id}` in `app/api/episodes.py`:
  - 404 when the episode is missing.
  - 403 when the episode belongs to a feed — feed-linked episodes keep using the feed delete path, so we don't silently break a feed's episode set.
  - Best-effort filesystem cleanup under `audio_raw_dir`, `audio_archive_dir`, and `transcript_dir` (paths outside those roots are ignored as a safety check).
  - `db.delete(episode)` — existing `ondelete="CASCADE"` FKs on segments/chunks/speaker_names/job_queue/notification_log take care of children.

### Web (`apps/web`)
- `src/app/api/episodes/[id]/route.ts` — thin `DELETE` proxy to the pipeline, consistent with the existing feed delete proxy.
- `src/components/UploadedEpisodeCard.tsx` — new client component replacing the previous inline `<Link>`/`<Card>` on `/podcasts`. Keeps the click-through to the episode page and adds a trash button that confirms, calls the proxy, and `router.refresh()`es.
- `src/app/podcasts/page.tsx` — use the new card component; drop now-unused lucide/card imports from this file.

## Testing
- Pipeline unit (`tests/unit/test_api.py::TestDeleteEpisodeEndpoint`): 404, 403, 204 paths with mocked DB.
- Pipeline integration (`tests/integration/test_pipeline.py::TestDeleteEpisodeEndpoint`):
  - Deleting a manual upload removes the row and cascades segments/chunks/speaker_names; raw + archived audio and transcript files are unlinked.
  - Deleting a feed-linked episode returns 403 and leaves the row in place.
- `docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/test_api.py tests/integration/test_pipeline.py::TestDeleteEpisodeEndpoint tests/integration/test_pipeline.py::TestFeedsListEndpoint -v` — 16 passed.
- Web: `next build` succeeds; `/api/episodes/[id]` route is picked up.
- Manual browser verification deferred until post-merge rebuild of the web + pipeline images.

## Test plan
- [x] Pipeline unit + integration tests
- [x] Web `next build`
- [ ] Post-deploy: upload an audio file on `/podcasts`, confirm the new trash button appears and deletes the row + on-disk files.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)