### PR TITLE
fix(episode-chat): raise Ask download dropdown above chat panel

### DIFF
--- a/apps/web/src/components/EpisodeChat.tsx
+++ b/apps/web/src/components/EpisodeChat.tsx
@@ -318,7 +318,7 @@ export default function EpisodeChat({ episodeId, episodeTitle, feedTitle, episod
                   <Download size={16} />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent align="end" className="w-48 z-[70]">
                 <DropdownMenuItem onClick={() => handleExport("markdown")} className="gap-2">
                   <FileText size={14} />
                   <span className="text-sm">Markdown (.md)</span>


### PR DESCRIPTION
## Problem
On `/episodes/[id]`, after asking a question in the Ask panel the Download button appeared but clicking "Markdown" / "Plain Text" did nothing — no file was downloaded.

## Root cause
The Ask chat panel is `fixed z-[60]` (needed to float above the audio player, per #453). shadcn's `DropdownMenuContent` defaults to `z-50` and is portaled to `document.body`. In the root stacking context the chat panel (opaque `bg-background`, z-60) sits on top of the dropdown portal (z-50), so the menu opened but was hidden behind the panel — clicks on the menu items actually hit the chat panel's message area.

## Fix
Pass `z-[70]` to the `DropdownMenuContent` className in `EpisodeChat.tsx`. `tailwind-merge` (via `cn()`) replaces the built-in `z-50` with `z-[70]`, so the menu now stacks above the chat panel.

## Testing
- `npx tsc --noEmit` — clean.
- Rebuilt the web Docker image. Download button now opens a visible dropdown in front of the chat panel; both "Markdown (.md)" and "Plain Text (.txt)" items fire their click handlers and trigger a file download.