### PR TITLE
style(sources): compact section buttons + podcast count

### DIFF
--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -92,16 +92,26 @@ async function getUploadedEpisodes(): Promise<{
 export default async function SourcesPage() {
   const [feeds, uploads] = await Promise.all([getFeeds(), getUploadedEpisodes()]);
 
+  const feedEpisodeTotal = feeds.reduce((sum, f) => sum + f.episode_count, 0);
+  const feedEpisodeProcessed = feeds.reduce((sum, f) => sum + f.processed_count, 0);
+
   return (
     <div className="space-y-6">
       {/* Podcasts section */}
       {feeds.length > 0 && (
         <div>
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-xl font-semibold">Podcasts</h2>
-            <Button size="sm" className="gap-1.5" asChild>
+          <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+            <h2 className="text-xl font-semibold">
+              Podcasts
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                ({feedEpisodeTotal > 0 && feedEpisodeProcessed < feedEpisodeTotal
+                  ? `${feedEpisodeProcessed} / ${feedEpisodeTotal} episodes processed`
+                  : `${feeds.length} podcast${feeds.length !== 1 ? "s" : ""}`})
+              </span>
+            </h2>
+            <Button className="h-7 px-2.5 text-xs gap-1.5 [&_svg]:size-3" asChild>
               <Link href="/feeds">
-                <Rss size={14} />
+                <Rss />
                 Manage feeds
               </Link>
             </Button>

--- a/apps/web/src/components/UploadsSection.tsx
+++ b/apps/web/src/components/UploadsSection.tsx
@@ -89,8 +89,11 @@ export default function UploadsSection({ uploads, processed, total }: Props) {
             </span>
           )}
         </h2>
-        <Button onClick={() => setDialogOpen(true)} size="sm" className="gap-1.5">
-          <Upload size={14} />
+        <Button
+          onClick={() => setDialogOpen(true)}
+          className="h-7 px-2.5 text-xs gap-1.5 [&_svg]:size-3"
+        >
+          <Upload />
           Upload audio
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Shrink **Manage feeds** and **Upload audio** buttons on `/podcasts` to `h-7` so they line up with their section headings instead of towering over them.
- Add a podcast/episode count next to **Podcasts**, mirroring the pattern already used for **Manual uploads** (`N / M episodes processed` while in-flight, otherwise `N podcasts`).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes
- [x] Web Docker image rebuilt and `/podcasts` returns 200
- [ ] Visually confirm both buttons align with their h2 headings and the new count renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)