### PR TITLE
test: fix CI failures from pyannote soundfile import and Ask floating button

### DIFF
--- a/apps/pipeline/tests/unit/test_pyannote_service.py
+++ b/apps/pipeline/tests/unit/test_pyannote_service.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Ensure pyannote.audio and torchaudio are mockable
+# Ensure pyannote.audio, torchaudio, torch, and soundfile are mockable
 if "pyannote" not in sys.modules:
     sys.modules["pyannote"] = MagicMock()
     sys.modules["pyannote.audio"] = MagicMock()
@@ -13,6 +13,10 @@ if "torchaudio" not in sys.modules:
 if "torch" not in sys.modules:
     sys.modules["torch"] = MagicMock()
     sys.modules["torch.cuda"] = MagicMock()
+# diarize() imports soundfile at call time; always use a mock so the tests
+# don't touch the real libsndfile on environments where it's installed.
+_soundfile_mock = MagicMock()
+sys.modules["soundfile"] = _soundfile_mock
 
 import app.services.pyannote as pyannote_mod
 
@@ -95,8 +99,8 @@ class TestDiarize:
 
         pyannote_mod._pipeline = mock_pipeline
 
-        torchaudio = sys.modules["torchaudio"]
-        torchaudio.load = MagicMock(return_value=(MagicMock(), 16000))
+        sf = sys.modules["soundfile"]
+        sf.read = MagicMock(return_value=(MagicMock(), 16000))
 
         result = pyannote_mod.diarize("/path/to/audio.wav")
 
@@ -114,8 +118,8 @@ class TestDiarize:
 
         pyannote_mod._pipeline = mock_pipeline
 
-        torchaudio = sys.modules["torchaudio"]
-        torchaudio.load = MagicMock(return_value=(MagicMock(), 16000))
+        sf = sys.modules["soundfile"]
+        sf.read = MagicMock(return_value=(MagicMock(), 16000))
 
         with pytest.raises(TypeError, match="itertracks"):
             pyannote_mod.diarize("/path/to/audio.wav")

--- a/apps/web/tests/unit/back-to-search-link.test.tsx
+++ b/apps/web/tests/unit/back-to-search-link.test.tsx
@@ -19,6 +19,10 @@ jest.mock("next/link", () => {
   );
 });
 
+jest.mock("@/components/AudioPlayerContext", () => ({
+  useAudioPlayer: () => ({ state: { src: null } }),
+}));
+
 import BackToSearchLink from "@/components/BackToSearchLink";
 
 describe("BackToSearchLink", () => {
@@ -49,7 +53,7 @@ describe("BackToSearchLink", () => {
       "fixed",
       "bottom-6",
       "left-6",
-      "z-40",
+      "z-[60]",
       "bg-action",
       "text-action-foreground",
       "hover:bg-action/90"

--- a/apps/web/tests/unit/episode-chat-trigger-icon.test.tsx
+++ b/apps/web/tests/unit/episode-chat-trigger-icon.test.tsx
@@ -4,6 +4,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+jest.mock("@/components/AudioPlayerContext", () => ({
+  useAudioPlayer: () => ({ state: { src: null } }),
+}));
+
 import EpisodeChat from "@/components/EpisodeChat";
 
 describe("EpisodeChat trigger icon", () => {


### PR DESCRIPTION
## Summary
CI Full Unit has been red on `main` since #447/#448 due to 5 pre-existing test failures — 2 pipeline, 3 web. This PR fixes all five.

### Pipeline (2 failures)
`app.services.pyannote.diarize` imports `soundfile as sf` at call time (added in #447), but CI installs deps with `--without ml` so the module isn't present.
- Mock `soundfile` unconditionally in `sys.modules` at the top of `test_pyannote_service.py` (alongside pyannote/torch/torchaudio).
- Route the two `TestDiarize` cases through `sf.read` instead of the now-unused `torchaudio.load`.

### Web (3 failures)
`BackToSearchLink` and `EpisodeChat` both call `useAudioPlayer()` now (since #448 follow-up), but their unit tests render them without the provider.
- Add `jest.mock("@/components/AudioPlayerContext", ...)` to both test files — same pattern already used in `ask-page-helpbox.test.tsx`.
- Update the stale `z-40` class assertion in `back-to-search-link.test.tsx` to the current `z-[60]` (was hidden by the provider error).

## Test plan
- [x] `pytest tests/unit/test_pyannote_service.py` → 6 passed
- [x] Full pipeline unit suite (minus a pre-existing env-only `test_healthcheck_script` collection issue) → 437 passed
- [x] Jest on the two fixed web test files → 3 passed
- [x] `npx tsc --noEmit` clean
- [ ] CI `CI Full Unit` returns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)