### PR TITLE
test(pipeline): fix integration tests for CI Slow

### DIFF
--- a/apps/pipeline/tests/integration/conftest.py
+++ b/apps/pipeline/tests/integration/conftest.py
@@ -34,14 +34,24 @@ def engine():
 
 @pytest.fixture
 def db_session(engine) -> Session:
-    """Per-test DB session wrapped in a transaction that rolls back after each test."""
+    """Per-test DB session wrapped in a transaction that rolls back after each test.
+
+    Pipeline tasks (transcribe/diarize/archive) call ``db.close()`` in their
+    ``finally`` blocks. When ``SessionLocal`` is patched to return this shared
+    session, that call would detach every instance from the session and break
+    the test's post-task ``session.refresh(...)`` assertions. We intercept
+    ``close`` so the task's cleanup is a no-op; the real close still runs at
+    teardown.
+    """
     connection = engine.connect()
     transaction = connection.begin()
     session = sessionmaker(bind=connection)()
+    real_close = session.close
+    session.close = lambda: None
 
     yield session
 
-    session.close()
+    real_close()
     transaction.rollback()
     connection.close()
 

--- a/apps/pipeline/tests/integration/test_pipeline.py
+++ b/apps/pipeline/tests/integration/test_pipeline.py
@@ -43,7 +43,7 @@ class TestTranscription:
 
         # Mock Whisper to return known segments, mock ffmpeg conversion, mock diarize chain
         with patch("app.tasks.transcribe._convert_to_wav") as mock_convert, \
-             patch("app.services.whisper.transcribe", return_value=(self.MOCK_SEGMENTS, "en")), \
+             patch("app.services.whisper.transcribe", return_value=(self.MOCK_SEGMENTS, "en", None)), \
              patch("app.tasks.transcribe._unload_whisper"), \
              patch("app.tasks.transcribe.SessionLocal", return_value=db_session), \
              patch("app.tasks.diarize.diarize_episode") as mock_diarize:


### PR DESCRIPTION
## Summary

CI Slow's Pipeline Integration job has never passed on GitHub. Two root causes:

1. **Tasks detach the test session.** The transcribe/diarize/archive tasks call `db.close()` in their finally blocks. When `SessionLocal` is patched to return the test's transaction-wrapped session, that close detaches every instance — subsequent `db_session.refresh(sample_episode)` fails with `InvalidRequestError: Instance is not persistent`.

2. **Stale whisper mock.** `app.services.whisper.transcribe` returns a 3-tuple `(segments, language, aligned_result)` but the test mock returned a 2-tuple, causing `ValueError: not enough values to unpack`.

## Changes

- `apps/pipeline/tests/integration/conftest.py`: `db_session` fixture now intercepts `session.close` as a no-op; teardown invokes the original `close` before rollback.
- `apps/pipeline/tests/integration/test_pipeline.py`: mock whisper return value updated to `(MOCK_SEGMENTS, "en", None)`.

## Testing

Locally, all 10 integration tests now pass:

```
tests/integration/test_pipeline.py ..........                          [100%]
======================== 10 passed, 1 warning in 3.75s =========================
```

Previously 7 of 10 were failing. Web E2E job was already green.

## Test plan

- [x] Run `docker compose -f docker-compose.test.yml run --rm test pytest tests/integration/ -v` — all pass
- [ ] Trigger CI Slow via workflow_dispatch after merge to confirm Pipeline Integration passes in GitHub Actions