### PR TITLE
chore: remove orphaned root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "350-docs",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Remove root `package-lock.json` (name: `"350-docs"`, empty packages) that has no corresponding `package.json`
- This file confused tooling and served no purpose

Note: The extraneous npm packages in `apps/web` (`@emnapi/*`, `@napi-rs/*`, `@tybys/*`) are local `node_modules` drift and should be resolved by running `npm ci` — not a repo-level fix.

Closes #474

## Test plan
- [ ] No build or test changes — this file was unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)