### PR TITLE
docs: update CLAUDE.md and fix stale documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ FEED_POLL_INTERVAL_HOURS=24
 
 # -- Retry configuration --
 RETRY_MAX=3                   # Max retries for transient failures
-RETRY_BACKOFF_BASE=30         # Base backoff in seconds (30s -> 2m -> 10m)
+RETRY_BACKOFF_BASE=30         # Base backoff in seconds (30s -> 60s -> 120s)
 
 # -- Disk space guard (GAP-06) --
 DISK_HEADROOM_BYTES=2147483648  # 2 GB minimum free space before download starts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Podlog is a self-hosted podcast transcription and search app. It downloads episodes from RSS feeds, transcribes them with Whisper, labels speakers with pyannote, and provides a web UI to search across all transcripts. Single user, local only. Production runs in Docker Compose; development can run services natively (see `docs/development.md`).
+Podlog is a self-hosted podcast transcription and search app. It downloads episodes from RSS feeds, transcribes them with Whisper, labels speakers with pyannote, and provides a web UI to search across all transcripts. Supports local-only operation or remote inference via Fireworks AI. Production runs in Docker Compose; development can run services natively (see `docs/development.md`).
 
 **Phase:** Core pipeline is operational. Episodes are being ingested, transcribed, diarized, chunked, and archived. The repo has an active automated test suite and Alembic migration history. Web UI serves search, queue dashboard, feed management, and an Ask AI feature.
 
@@ -39,15 +39,15 @@ podlog/
 │   │   │   ├── config.py           # pydantic-settings, all env vars
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments, speaker_names)
 │   │   │   ├── database.py         # Engine + session factory
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware)
 │   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive, cleanup, prewarm)
 │   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, notifications, digest, events)
 │   │   │   └── worker.py           # Background job worker
 │   │   ├── alembic/                # Database migrations
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 16 (App Router)
-│       ├── src/app/                # Pages: /, /about, /podcasts, /episodes/[id], /queue, /feeds, /ask, /search, /settings, /docs (and /notifications redirects to /settings)
-│       ├── src/app/api/            # API routes: search, search/grouped, search/mentions, feeds, queue, audio, ask, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, pipeline proxy
+│       ├── src/app/                # Pages: /, /about, /podcasts, /podcasts/[id], /episodes/[id], /queue, /feeds, /ask, /search, /search/print, /settings, /docs (and /notifications redirects to /settings)
+│       ├── src/app/api/            # API routes: search (search, grouped, mentions, speakers), feeds (CRUD, preview, poll), queue, audio, ask/coverage, episodes ([id], ingest, upload, retry, speakers, speakers/merge), docs, hardware, notifications (settings, test), pipeline (ask, embed, health, queue/retry)
 │       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, DocsClient, etc.
 │       └── src/lib/                # db.ts, search.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx
 ├── docs/                           # User-facing documentation and guides
@@ -63,7 +63,7 @@ podlog/
 | Task queue | PostgreSQL-backed job queue | Sequential processing (concurrency=1) to avoid OOM |
 | Transcription | WhisperX (CTranslate2 backend), default `large-v3-turbo` | Explicit unload before diarization — mandatory |
 | Diarization | `pyannote/speaker-diarization-3.1` | Requires HF_TOKEN; graceful failure path |
-| LLM inference | Ollama (local) | RAG-based Ask AI feature; model is selected in the Ask UI and sent per request (no `OLLAMA_MODEL` env var) |
+| LLM inference | Ollama (local) or Fireworks AI (remote) | RAG-based Ask AI feature; provider selected via `inference_provider` config; model selected in Ask UI per request |
 | Database | PostgreSQL 15 (pgvector/pgvector:pg15) | FTS via `to_tsvector` + GIN index, vector HNSW index |
 | ORM | SQLAlchemy 2.0 + Alembic | Migrations auto-run on pipeline startup |
 | Web app | Next.js 16 (App Router) | `output: 'standalone'` for Docker |
@@ -113,10 +113,10 @@ Services: web (:3000), pipeline API (:8000), ollama (:11434).
 - Alembic migration history is maintained under `apps/pipeline/alembic/versions/`
 - shadcn/ui component set is installed and used in the web app
 - Docs tab for user documentation
-- RAG-based Ask AI feature via Ollama
+- RAG-based Ask AI feature via Ollama (local) or Fireworks AI (remote)
 - Speaker merge/rename UI
 - Notification settings
 
 **Not yet done:**
-- Some integration and e2e test bodies still stubbed or skipped
 - Full end-to-end pipeline smoke test in CI
+- Test coverage thresholds not yet enforced in CI

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,8 +24,8 @@ podlog/
 │   │   └── tests/                  # Unit, integration, e2e tests
 │   └── web/                        # Next.js 16.2.2 (App Router)
 │       ├── src/app/                # Pages: /, /search, /ask, /podcasts, /episodes/[id], /queue, /feeds, /settings, /docs, /about (/notifications redirects to /settings)
-│       │   └── api/                # Route handlers: search, search/grouped, search/mentions, feeds, queue, audio, ask, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, hardware, wizard, pipeline proxy
-│       ├── src/components/         # React components (Navbar, AudioPlayer, SearchResult, QueueStatus, DocsClient, …)
+│       │   └── api/                # Route handlers: search, search/grouped, search/mentions, feeds, queue, audio, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, hardware, pipeline proxy
+│       ├── src/components/         # React components (Navbar, AudioPlayer, SearchResult, QueueStatus, …)
 │       └── src/lib/                # Utilities (db, search, searchHybrid, timestamp, pipeline, types, utils, speakerColors, validateMergeRequest, citations, …)
 ├── docs/                           # User-facing documentation
 └── prds/                           # Internal design specs and risk register

--- a/docs/guide/13-troubleshooting.md
+++ b/docs/guide/13-troubleshooting.md
@@ -86,7 +86,7 @@ See [Notifications](09-notifications.md) for full setup instructions.
 
 ## Container health
 
-**Symptom:** `/api/health` reports `DOWN` for a service, or `make logs` shows repeated restarts.
+**Symptom:** `/api/health` reports `DEGRADED` for a service, or `make logs` shows repeated restarts.
 
 **Diagnosis:**
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md: add Fireworks AI inference support, fix route/page inventories, add hardware router, fix stale "not yet done" section
- Fix troubleshooting guide: health API uses `DEGRADED` not `DOWN`
- Fix .env.example: retry backoff comment corrected to `30s -> 60s -> 120s`
- Fix development.md: remove wizard route reference, fix DocsClient location

Closes #472, closes #473

## Test plan
- [ ] Documentation-only changes — no code behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)