### PR TITLE
ci: enforce test coverage thresholds in CI

### DIFF
--- a/.github/workflows/ci-full-unit.yml
+++ b/.github/workflows/ci-full-unit.yml
@@ -37,8 +37,8 @@ jobs:
           poetry config virtualenvs.create false
           poetry install --with dev --without ml --no-interaction --no-ansi --no-root
 
-      - name: Run all pipeline unit tests
-        run: pytest tests/unit -q
+      - name: Run all pipeline unit tests with coverage
+        run: pytest tests/unit -q --cov=app --cov-fail-under=82
 
   web-unit-full:
     name: Web Unit Full
@@ -61,5 +61,5 @@ jobs:
       - name: Install web dependencies
         run: npm ci
 
-      - name: Run all web unit tests
-        run: npm test -- --runInBand --testPathPattern=tests/unit
+      - name: Run all web unit tests with coverage
+        run: npm test -- --runInBand --coverage --testPathPattern=tests/unit

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -11,6 +11,14 @@ const config = createJestConfig({
     "!src/**/__tests__/**",
     "!src/**/__mocks__/**",
   ],
+  coverageThreshold: {
+    global: {
+      statements: 45,
+      branches: 35,
+      functions: 38,
+      lines: 45,
+    },
+  },
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },


### PR DESCRIPTION
## Summary
- Add `coverageThreshold` to `apps/web/jest.config.js` (45% statements, 35% branches, 38% functions, 45% lines)
- Add `--cov=app --cov-fail-under=82` to pipeline pytest step in CI
- Add `--coverage` flag to web test step in CI

Thresholds are set slightly below current measured levels as a baseline ratchet to prevent silent regressions. They should be increased as coverage improves.

Closes #475

## Test plan
- [ ] CI pipeline job passes with coverage threshold
- [ ] CI web job passes with coverage threshold
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)