### PR TITLE
refactor(pipeline): extract task registry from worker.py

### DIFF
--- a/apps/pipeline/app/task_registry.py
+++ b/apps/pipeline/app/task_registry.py
@@ -39,7 +39,6 @@ TASK_HANDLERS: dict[str, Callable[[str], None]] = {
 
 
 class PeriodicTask:
-    __slots__ = ("name", "target", "interval_seconds")
 
     def __init__(self, name: str, target: str, interval_seconds: int | None):
         self.name = name

--- a/apps/pipeline/app/task_registry.py
+++ b/apps/pipeline/app/task_registry.py
@@ -1,0 +1,86 @@
+"""
+Single source of truth for task and periodic task handler registration.
+
+Each entry maps a task name to its dotted import path. Handlers are lazily
+resolved at dispatch time to avoid importing heavy modules (whisper, pyannote)
+at worker startup.
+"""
+import importlib
+from typing import Callable
+
+from app.config import settings
+
+
+def _resolve(dotted_path: str) -> Callable:
+    module_path, func_name = dotted_path.rsplit(":", 1)
+    mod = importlib.import_module(module_path)
+    return getattr(mod, func_name)
+
+
+def _lazy_handler(dotted_path: str) -> Callable[[str], None]:
+    def handler(episode_id: str) -> None:
+        _resolve(dotted_path)(episode_id)
+    return handler
+
+
+TASK_REGISTRY: dict[str, str] = {
+    "download": "app.tasks.download:download_episode",
+    "transcribe": "app.tasks.transcribe:transcribe_episode",
+    "diarize": "app.tasks.diarize:diarize_episode",
+    "chunk": "app.tasks.chunk:chunk_episode",
+    "embed": "app.tasks.embed:embed_episode",
+    "infer": "app.tasks.infer:infer_speakers",
+    "archive": "app.tasks.archive:archive_episode",
+}
+
+TASK_HANDLERS: dict[str, Callable[[str], None]] = {
+    name: _lazy_handler(path) for name, path in TASK_REGISTRY.items()
+}
+
+
+class PeriodicTask:
+    __slots__ = ("name", "target", "interval_seconds")
+
+    def __init__(self, name: str, target: str, interval_seconds: int | None):
+        self.name = name
+        self.target = target
+        self.interval_seconds = interval_seconds
+
+    def get_interval(self) -> int:
+        if self.interval_seconds is not None:
+            return self.interval_seconds
+        return settings.feed_poll_interval_hours * 3600
+
+    def run(self) -> None:
+        _resolve(self.target)()
+
+
+PERIODIC_TASKS: list[PeriodicTask] = [
+    PeriodicTask("poll_all_feeds", "app.tasks.ingest:poll_all_feeds", None),
+    PeriodicTask("cleanup_zombie_jobs", "app.tasks.cleanup:cleanup_zombie_jobs", 30 * 60),
+    PeriodicTask("send_digest", "app.services.digest:send_digest_if_due", 15 * 60),
+]
+
+
+def validate_wiring() -> None:
+    """Validate all task and periodic handler references resolve at startup."""
+    errors: list[str] = []
+
+    for name, path in TASK_REGISTRY.items():
+        try:
+            resolved = _resolve(path)
+            if not callable(resolved):
+                raise TypeError("resolved object is not callable")
+        except Exception as exc:
+            errors.append(f'TASK_REGISTRY["{name}"]: {type(exc).__name__}: {exc}')
+
+    for task in PERIODIC_TASKS:
+        try:
+            resolved = _resolve(task.target)
+            if not callable(resolved):
+                raise TypeError("resolved object is not callable")
+        except Exception as exc:
+            errors.append(f'PERIODIC_TASKS["{task.name}"]: {type(exc).__name__}: {exc}')
+
+    if errors:
+        raise RuntimeError(f"Invalid worker registry wiring: {'; '.join(errors)}")

--- a/apps/pipeline/app/worker.py
+++ b/apps/pipeline/app/worker.py
@@ -10,119 +10,19 @@ Usage:
 import logging
 import signal
 import time
-import importlib
 from datetime import datetime, timezone
-from typing import Callable
 
-from app.config import settings
 from app.database import SessionLocal
 from app import job_queue
+from app.task_registry import (
+    TASK_HANDLERS,
+    PERIODIC_TASKS,
+    validate_wiring,
+)
 
 logger = logging.getLogger(__name__)
 
-
-def _resolve_handler(dotted_path: str):
-    """Resolve 'module.path:function_name' to a callable."""
-    module_path, func_name = dotted_path.rsplit(":", 1)
-    mod = importlib.import_module(module_path)
-    return getattr(mod, func_name)
-
-def _download_handler(episode_id: str) -> None:
-    from app.tasks.download import download_episode
-
-    download_episode(episode_id)
-
-
-def _transcribe_handler(episode_id: str) -> None:
-    from app.tasks.transcribe import transcribe_episode
-
-    transcribe_episode(episode_id)
-
-
-def _diarize_handler(episode_id: str) -> None:
-    from app.tasks.diarize import diarize_episode
-
-    diarize_episode(episode_id)
-
-
-def _chunk_handler(episode_id: str) -> None:
-    from app.tasks.chunk import chunk_episode
-
-    chunk_episode(episode_id)
-
-
-def _embed_handler(episode_id: str) -> None:
-    from app.tasks.embed import embed_episode
-
-    embed_episode(episode_id)
-
-
-def _infer_handler(episode_id: str) -> None:
-    from app.tasks.infer import infer_speakers
-
-    infer_speakers(episode_id)
-
-
-def _archive_handler(episode_id: str) -> None:
-    from app.tasks.archive import archive_episode
-
-    archive_episode(episode_id)
-
-
-# Task name -> handler function (typed callable registry; lazy imports inside wrappers)
-TASK_HANDLERS: dict[str, Callable[[str], None]] = {
-    "download": _download_handler,
-    "transcribe": _transcribe_handler,
-    "diarize": _diarize_handler,
-    "chunk": _chunk_handler,
-    "embed": _embed_handler,
-    "infer": _infer_handler,
-    "archive": _archive_handler,
-}
-
-TASK_HANDLER_TARGETS: dict[str, str] = {
-    "download": "app.tasks.download:download_episode",
-    "transcribe": "app.tasks.transcribe:transcribe_episode",
-    "diarize": "app.tasks.diarize:diarize_episode",
-    "chunk": "app.tasks.chunk:chunk_episode",
-    "embed": "app.tasks.embed:embed_episode",
-    "infer": "app.tasks.infer:infer_speakers",
-    "archive": "app.tasks.archive:archive_episode",
-}
-
 POLL_INTERVAL = 2  # seconds between queue polls when idle
-
-
-def _poll_all_feeds() -> None:
-    from app.tasks.ingest import poll_all_feeds
-
-    poll_all_feeds()
-
-
-def _cleanup_zombie_jobs() -> None:
-    from app.tasks.cleanup import cleanup_zombie_jobs
-
-    cleanup_zombie_jobs()
-
-
-def _send_digest() -> None:
-    from app.services.digest import send_digest_if_due
-
-    send_digest_if_due()
-
-
-PERIODIC_TASKS: list[tuple[str, Callable[[], None], int | None]] = [
-    # (name, function, interval_seconds)
-    ("poll_all_feeds", _poll_all_feeds, None),  # interval set from settings
-    ("cleanup_zombie_jobs", _cleanup_zombie_jobs, 30 * 60),
-    ("send_digest", _send_digest, 15 * 60),
-]
-
-PERIODIC_TASK_TARGETS: dict[str, str] = {
-    "poll_all_feeds": "app.tasks.ingest:poll_all_feeds",
-    "cleanup_zombie_jobs": "app.tasks.cleanup:cleanup_zombie_jobs",
-    "send_digest": "app.services.digest:send_digest_if_due",
-}
 
 _shutdown = False
 
@@ -133,63 +33,18 @@ def _handle_signal(signum, frame):
     _shutdown = True
 
 
-def _validate_worker_wiring() -> None:
-    """Validate task/periodic handler references at startup."""
-    errors: list[str] = []
-
-    if set(TASK_HANDLERS) != set(TASK_HANDLER_TARGETS):
-        errors.append("TASK_HANDLERS and TASK_HANDLER_TARGETS keys differ")
-
-    for task, handler in TASK_HANDLERS.items():
-        try:
-            if not callable(handler):
-                raise TypeError("resolved object is not callable")
-            target = TASK_HANDLER_TARGETS[task]
-            resolved = _resolve_handler(target)
-            if not callable(resolved):
-                raise TypeError("import target is not callable")
-        except Exception as exc:
-            errors.append(
-                f'TASK_HANDLERS["{task}"]: {type(exc).__name__}: {exc}'
-            )
-
-    periodic_names = {name for name, _, _ in PERIODIC_TASKS}
-    if periodic_names != set(PERIODIC_TASK_TARGETS):
-        errors.append("PERIODIC_TASKS and PERIODIC_TASK_TARGETS keys differ")
-
-    for name, handler, _ in PERIODIC_TASKS:
-        try:
-            if not callable(handler):
-                raise TypeError("resolved object is not callable")
-            target = PERIODIC_TASK_TARGETS[name]
-            resolved = _resolve_handler(target)
-            if not callable(resolved):
-                raise TypeError("import target is not callable")
-        except Exception as exc:
-            errors.append(
-                f'PERIODIC_TASKS["{name}"]: {type(exc).__name__}: {exc}'
-            )
-
-    if errors:
-        joined = "; ".join(errors)
-        raise RuntimeError(f"Invalid worker registry wiring: {joined}")
-
-
 def _run_periodic_tasks(last_run: dict[str, datetime], now: datetime) -> None:
-    """Run any periodic tasks that are due."""
-    for name, handler, interval_secs in PERIODIC_TASKS:
-        if interval_secs is None:
-            interval_secs = settings.feed_poll_interval_hours * 3600
-
-        last = last_run.get(name)
-        if last is None or (now - last).total_seconds() >= interval_secs:
+    for task in PERIODIC_TASKS:
+        interval = task.get_interval()
+        last = last_run.get(task.name)
+        if last is None or (now - last).total_seconds() >= interval:
             try:
-                handler()
-                last_run[name] = now
-                logger.info('"action": "periodic_task_ran", "task": "%s"', name)
+                task.run()
+                last_run[task.name] = now
+                logger.info('"action": "periodic_task_ran", "task": "%s"', task.name)
             except Exception:
-                logger.exception('"action": "periodic_task_failed", "task": "%s"', name)
-                last_run[name] = now  # Don't retry immediately on failure
+                logger.exception('"action": "periodic_task_failed", "task": "%s"', task.name)
+                last_run[task.name] = now
 
 
 def main() -> None:
@@ -203,21 +58,18 @@ def main() -> None:
 
     logger.info('"action": "worker_start"')
 
-    # Register notification handlers
     from app.services.events import bus
     from app.services.digest import register_notification_handlers
     register_notification_handlers(bus)
-    _validate_worker_wiring()
+    validate_wiring()
 
     last_periodic_run: dict[str, datetime] = {}
 
     while not _shutdown:
         now = datetime.now(timezone.utc)
 
-        # Run periodic tasks
         _run_periodic_tasks(last_periodic_run, now)
 
-        # Poll for a job
         db = SessionLocal()
         try:
             job = job_queue.poll(db)

--- a/apps/pipeline/tests/unit/test_worker.py
+++ b/apps/pipeline/tests/unit/test_worker.py
@@ -1,4 +1,4 @@
-"""Unit tests for app.worker — DB-backed job worker."""
+"""Unit tests for app.worker and app.task_registry."""
 import signal
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -13,105 +13,104 @@ class TestHandleSignal:
         w._shutdown = False
         w._handle_signal(signal.SIGTERM, None)
         assert w._shutdown is True
-        w._shutdown = False  # reset
+        w._shutdown = False
 
 
-class TestWorkerRegistry:
+class TestTaskRegistry:
     def test_resolves_known_module(self):
-        import app.worker as w
+        from app.task_registry import _resolve
         from app.tasks.chunk import chunk_episode
 
-        assert w._resolve_handler("app.tasks.chunk:chunk_episode") is chunk_episode
+        assert _resolve("app.tasks.chunk:chunk_episode") is chunk_episode
 
     def test_raises_on_bad_path(self):
-        import app.worker as w
+        from app.task_registry import _resolve
 
         with pytest.raises(ModuleNotFoundError):
-            w._resolve_handler("nonexistent.module:func")
+            _resolve("nonexistent.module:func")
 
-    def test_worker_registries_are_callable(self):
-        import app.worker as w
+    def test_task_handlers_are_callable(self):
+        from app.task_registry import TASK_HANDLERS
 
-        for name, handler in w.TASK_HANDLERS.items():
+        for name, handler in TASK_HANDLERS.items():
             assert callable(handler), f"task handler for {name} is not callable"
 
-        for name, handler, _ in w.PERIODIC_TASKS:
-            assert callable(handler), f"periodic handler for {name} is not callable"
+    def test_periodic_tasks_are_runnable(self):
+        from app.task_registry import PERIODIC_TASKS
 
-    def test_validate_worker_wiring_raises_for_non_callable_task(self):
-        import app.worker as w
+        for task in PERIODIC_TASKS:
+            assert callable(task.run), f"periodic task {task.name} is not runnable"
 
-        with patch.dict(w.TASK_HANDLERS, {"chunk": object()}):
+    def test_validate_wiring_raises_for_broken_import(self):
+        from app.task_registry import validate_wiring
+
+        with patch("app.task_registry._resolve") as mock_resolve:
+            def side_effect(path: str):
+                if path == "app.tasks.chunk:chunk_episode":
+                    raise ModuleNotFoundError("broken import")
+                return MagicMock()
+
+            mock_resolve.side_effect = side_effect
+
             with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
-                w._validate_worker_wiring()
-
-    def test_validate_worker_wiring_raises_for_non_callable_periodic(self):
-        import app.worker as w
-
-        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", object(), None)]):
-            with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
-                w._validate_worker_wiring()
-
-    @patch("app.worker._resolve_handler")
-    def test_validate_worker_wiring_raises_for_broken_import_target(self, mock_resolve):
-        import app.worker as w
-
-        def side_effect(path: str):
-            if path == "app.tasks.chunk:chunk_episode":
-                raise ModuleNotFoundError("broken import")
-            return MagicMock()
-
-        mock_resolve.side_effect = side_effect
-
-        with pytest.raises(RuntimeError, match="Invalid worker registry wiring"):
-            w._validate_worker_wiring()
+                validate_wiring()
 
 
 class TestRunPeriodicTasks:
-    @patch("app.worker.settings")
+    @patch("app.task_registry.settings")
     def test_runs_task_when_due(self, mock_settings):
         import app.worker as w
+        from app.task_registry import PeriodicTask
 
         mock_settings.feed_poll_interval_hours = 1
-        mock_handler = MagicMock()
-        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", mock_handler, None)]):
+        mock_run = MagicMock()
+        task = PeriodicTask("poll_all_feeds", "app.tasks.ingest:poll_all_feeds", None)
+        task.run = mock_run
+
+        with patch.object(w, "PERIODIC_TASKS", [task]):
             last_run = {}
             now = datetime.now(timezone.utc)
             w._run_periodic_tasks(last_run, now)
 
-        mock_handler.assert_called_once()
+        mock_run.assert_called_once()
         assert "poll_all_feeds" in last_run
 
-    @patch("app.worker.settings")
+    @patch("app.task_registry.settings")
     def test_skips_task_when_not_due(self, mock_settings):
         import app.worker as w
+        from app.task_registry import PeriodicTask
 
         mock_settings.feed_poll_interval_hours = 1
-        mock_handler = MagicMock()
-        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", mock_handler, None)]):
+        mock_run = MagicMock()
+        task = PeriodicTask("poll_all_feeds", "app.tasks.ingest:poll_all_feeds", None)
+        task.run = mock_run
+
+        with patch.object(w, "PERIODIC_TASKS", [task]):
             now = datetime.now(timezone.utc)
             last_run = {"poll_all_feeds": now - timedelta(minutes=30)}
             w._run_periodic_tasks(last_run, now)
 
-        mock_handler.assert_not_called()
+        mock_run.assert_not_called()
 
-    @patch("app.worker.settings")
+    @patch("app.task_registry.settings")
     def test_failure_still_updates_last_run(self, mock_settings):
         import app.worker as w
+        from app.task_registry import PeriodicTask
 
         mock_settings.feed_poll_interval_hours = 1
-        crashing_handler = MagicMock(side_effect=RuntimeError("boom"))
-        with patch.object(w, "PERIODIC_TASKS", [("poll_all_feeds", crashing_handler, None)]):
+        task = PeriodicTask("poll_all_feeds", "app.tasks.ingest:poll_all_feeds", None)
+        task.run = MagicMock(side_effect=RuntimeError("boom"))
+
+        with patch.object(w, "PERIODIC_TASKS", [task]):
             last_run = {}
             now = datetime.now(timezone.utc)
             w._run_periodic_tasks(last_run, now)
 
-        # Should still mark as run to avoid immediate retry
         assert "poll_all_feeds" in last_run
 
 
 class TestMainLoop:
-    @patch("app.worker._validate_worker_wiring")
+    @patch("app.worker.validate_wiring")
     @patch("app.worker.time")
     @patch("app.worker._run_periodic_tasks")
     @patch("app.worker.job_queue")


### PR DESCRIPTION
## Summary
- Extract `task_registry.py` from `worker.py` to create a single source of truth for task handler registration
- Eliminate duplicated `TASK_HANDLERS`/`TASK_HANDLER_TARGETS` and `PERIODIC_TASKS`/`PERIODIC_TASK_TARGETS` registries
- New `PeriodicTask` class replaces tuple+dict pairs
- worker.py: 258 -> 109 lines (thin event loop)
- task_registry.py: 86 lines (registry + validation)
- Tests updated to reference new module structure

Closes #469

## Test plan
- [ ] Pipeline unit tests pass (test_worker.py updated)
- [ ] Worker starts correctly in Docker (`make up`)
- [ ] Tasks dispatch correctly through the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)