### PR TITLE
docs: fix PRD/CLAUDE.md drift (#497, #493, #492, #491, #490)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,21 @@ When making decisions, reference PRD sections (e.g. "per PRD-01 §5.4") rather t
 ```
 podlog/
 ├── docker-compose.yml              # Production-like local stack (5 services)
-├── docker-compose.test.yml         # Test stack with db_test, mock_rss, test runner
+├── docker-compose.remote.yml       # Overlay for remote-inference (Fireworks) profile
+├── docker-compose.test.yml         # Test stack (db_test, mock_rss, pipeline_test, web_test, test runner)
 ├── .env.example                    # All config vars documented
 ├── Makefile                        # make up / down / build / test / etc.
 ├── AGENTS.md
 ├── README.md
 ├── VERSION
 ├── LICENSE
+├── .node-version                   # Node version for local dev
+├── .nvmrc                          # Node version for nvm users
+├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow)
+├── .agents/                        # Agent configuration
+├── .superpowers/                   # Superpowers metadata (gitignored)
+├── .omx/                           # Oh-my-codex metadata (gitignored)
+├── issues/                         # Local issue drafts / notes
 ├── apps/
 │   ├── pipeline/                   # Python 3.11 — FastAPI + DB-backed job queue
 │   │   ├── app/
@@ -39,17 +47,21 @@ podlog/
 │   │   │   ├── config.py           # pydantic-settings, all env vars
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments, speaker_names)
 │   │   │   ├── database.py         # Engine + session factory
+│   │   │   ├── job_queue.py        # PostgreSQL-backed job queue (enqueue, claim, complete)
+│   │   │   ├── task_registry.py    # Maps pipeline stages to task functions + next-stage routing
+│   │   │   ├── worker.py           # Background job worker + feed polling loop
 │   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware)
-│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive, cleanup, prewarm)
-│   │   │   ├── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, notifications, digest, events)
-│   │   │   └── worker.py           # Background job worker
-│   │   ├── alembic/                # Database migrations
+│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, transcribe_helpers, diarize, chunk, embed, infer, archive, cleanup, prewarm, backfill_chunks, helpers)
+│   │   │   └── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, inference_helpers, notifications, notification_events, notification_runtime, notification_settings, digest, digest_formatters, events, hardware, fireworks_audio, pipeline_commands, timing_labels)
+│   │   ├── alembic/                # Database migrations (12 versions)
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 16 (App Router)
+│       ├── Dockerfile              # Production image (standalone output)
+│       ├── Dockerfile.test         # Test image used by docker-compose.test.yml
 │       ├── src/app/                # Pages: /, /about, /podcasts, /podcasts/[id], /episodes/[id], /queue, /feeds, /ask, /search, /search/print, /settings, /docs (and /notifications redirects to /settings)
 │       ├── src/app/api/            # API routes: search (search, grouped, mentions, speakers), feeds (CRUD, preview, poll), queue, audio, ask/coverage, episodes ([id], ingest, upload, retry, speakers, speakers/merge), docs, hardware, notifications (settings, test), pipeline (ask, embed, health, queue/retry)
 │       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, DocsClient, etc.
-│       └── src/lib/                # db.ts, search.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx
+│       └── src/lib/                # db.ts, search.ts, search/ (feedFilter, filters, grouping, queryParser, speakerTurns, types), searchHybrid.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx, episode-link.ts, page-state.ts, queueStatus.ts
 ├── docs/                           # User-facing documentation and guides
 ├── scripts/                        # Operational scripts (nightly audit, health check)
 └── prds/                           # Specifications and risk register

--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-01 — Ingestion Pipeline  
-**Version:** 1.4
+**Version:** 1.5
 **Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.5 — §5.2 retry copy corrected to match code: backoff formula is `RETRY_BACKOFF_BASE * 2^(attempt-1)` (30s → 60s → 120s), and HTTP 4xx is clarified as classified `HTTP_ACCESS` with retry (not "non-transient and retried").
 - v1.4 — Added optional remote inference provider mode (Fireworks) for transcription and diarization while keeping local-first defaults. Runtime provider settings can be sourced from DB-backed Settings UI (env fallback remains). Added Fireworks configuration vars.
 - v1.3 — Updated tech stack to reflect actual implementation: Celery+Redis replaced by PostgreSQL-backed job queue; Whisper via transformers replaced by WhisperX (CTranslate2); Celery Beat replaced by polling loop in worker.py; Flower removed. Added Ollama for RAG inference. Updated architecture diagram. Removed stale env vars (REDIS_URL, CELERY_CONCURRENCY). Moved semantic search and faster Whisper from Future to Done. Updated default model to large-v3-turbo.
 - v1.2 — Renamed project from PodSearch to Podlog. Added `updated_at` field to episodes table (prerequisite for GAP-01 zombie job detection). Added `DISK_HEADROOM_BYTES` environment variable for disk space pre-check (GAP-06). Database name changed from `podsearch` to `podlog`.
@@ -78,7 +79,7 @@ Podcast listeners who want to search, reference, or revisit specific moments in 
 - Download progress is tracked and surfaced to the queue dashboard.
 - Files are saved to a configurable local volume path: `/data/audio/raw/`.
 - Supported formats: MP3, M4A, AAC, OGG, FLAC, WAV. Any format `ffmpeg` can decode is acceptable.
-- **Failure handling:** If a download fails due to a transient access error (network timeout, HTTP 5xx), the job is automatically retried up to 3 times with exponential backoff (30s, 2m, 10m) before being marked permanently failed. HTTP 4xx errors (e.g. 403, 404) are considered non-transient and are retried up to 3 times with the same backoff, as feeds sometimes return temporary 4xx responses. OOM errors, disk full errors, and local system failures are **not** retried — they are marked failed immediately with a clear error classification (see §5.9).
+- **Failure handling:** If a download fails due to a transient access error (network timeout, HTTP 5xx classified as `TRANSIENT_NETWORK`), the job is automatically retried up to 3 times with exponential backoff (`RETRY_BACKOFF_BASE * 2^(attempt-1)` — with the default base of 30s, the delays are 30s → 60s → 120s) before being marked permanently failed. HTTP 4xx errors (e.g. 403, 404) are classified as `HTTP_ACCESS` and are also retried up to 3 times with the same backoff, since feeds and CDNs sometimes return temporary 4xx responses. OOM errors, disk full errors, and local system failures are **not** retried — they are marked failed immediately with a clear error classification (see §5.9).
 - The retry count and last error are stored per episode and surfaced in the queue dashboard (see PRD-02 §5.6).
 
 ### 5.3 Audio Preprocessing

--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-02 — Search Web Application  
-**Version:** 1.5
+**Version:** 1.6
 **Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.6 — Updated tech stack row to Next.js 16 (matches `apps/web/package.json`).
 - v1.5 — Marked document status as Active and removed stale non-goal note claiming semantic/vector search was out of scope.
 - v1.4 — Added Ask AI (RAG) documentation (§5.10): retrieval pipeline, key parameters (TOP_K, SIMILARITY_THRESHOLD), model options, source filtering, speaker attribution, citation rendering, error handling.
 - v1.3 — Queue dashboard (§5.6) redesigned: replaced kanban/grouping modes with a Summary + Table hybrid layout. Worker warm-up banner removed (brief warm-up does not warrant persistent UI). Retry countdown timer removed; retry count shown as N/M instead. Stage progress bar added (horizontal bar showing per-stage episode counts). Search/filter input added (debounced, filters by episode title or podcast name). Done episodes collapsed by default in an expandable section. Responsiveness: Podcast and Retries columns hidden on screens narrower than 640 px. ASCII diagram in §9.3 updated to match new layout.
@@ -257,7 +258,7 @@ The Ask page lets users ask natural-language questions about their podcast trans
 
 | Component | Choice | Rationale |
 |-----------|--------|-----------|
-| Framework | Next.js 14 (App Router) | Full-stack React; SSR for fast initial load; API routes co-located |
+| Framework | Next.js 16 (App Router) | Full-stack React; SSR for fast initial load; API routes co-located |
 | Styling | Tailwind CSS | Rapid UI development; dark mode via `class` strategy |
 | Component library | shadcn/ui | Accessible, unstyled-by-default; dark mode via CSS variables |
 | Data fetching | React Query (TanStack Query) | Automatic caching, polling for queue status, clean loading/error states |

--- a/prds/PRD-03-infrastructure.md
+++ b/prds/PRD-03-infrastructure.md
@@ -2,10 +2,11 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-03 — Infrastructure & DevOps  
-**Version:** 1.4
+**Version:** 1.5
 **Status:** Active
 **Author:** Claude (generated from user specification)
 **Changelog:**
+- v1.5 — Repo tree counts refreshed (12 Alembic migrations, 13 shadcn/ui components). Removed stale references to `api/wizard/` (retired in #361). Test-stack snippet now uses `pgvector/pgvector:pg15` to match the actual compose file. Removed the "web_test disabled" note — `web_test` and `pipeline_test` are both live in `docker-compose.test.yml`. Makefile section extended with `up-remote`, `down-remote`, `logs-remote`, `backfill`, `version`, `env-check`, `deps-outdated`, `test-healthcheck`. CI/CD section replaced with the current three-workflow split (`ci.yml`, `ci-full-unit.yml`, `ci-slow.yml`). Added `Dockerfile.test` to the web repo tree. `.env.example` retry comment corrected to `30s → 60s → 120s`.
 - v1.4 — Added optional Fireworks inference provider configuration (env + DB-backed Settings UI overrides). Updated `.env.example` with inference-provider variables. Updated web navigation from Notifications page to broader Settings page.
 - v1.3 — Major update to match actual implementation: Celery/Redis/Flower/Beat removed; PostgreSQL-backed job queue with worker.py. Redis service and volumes removed from docker-compose. Single Dockerfile replaced by Dockerfile.control and Dockerfile.worker. Repo structure updated with actual files (removed scheduler.py, celery_app.py, SearchBar.tsx, SpeakerLabel.tsx; added worker.py and current component list). Test stack updated (no redis_test). License corrected to O'Saasy. Makefile updated with all current targets. Ollama service added. .env.example updated to match actual vars.
 - v1.2 — Renamed project from PodSearch to Podlog. Database name changed to `podlog`. Added `redis_test` service to `docker-compose.test.yml`. Changed `beat` dependency from `- worker` to `pipeline: service_healthy`. Added `CELERY_CONCURRENCY` env var interpolation in worker command. Added `DISK_HEADROOM_BYTES` to `.env.example`. Repository root directory renamed from `podsearch/` to `podlog/`.
@@ -40,7 +41,7 @@ podlog/
 │   │   ├── poetry.lock
 │   │   ├── alembic/
 │   │   │   ├── env.py
-│   │   │   └── versions/           # 10 migrations
+│   │   │   └── versions/           # 12 migrations
 │   │   ├── app/
 │   │   │   ├── main.py
 │   │   │   ├── config.py
@@ -85,6 +86,7 @@ podlog/
 │   │
 │   └── web/
 │       ├── Dockerfile
+│       ├── Dockerfile.test         # Built by docker-compose.test.yml for the web_test runner
 │       ├── package.json
 │       ├── package-lock.json
 │       ├── next.config.ts
@@ -101,17 +103,21 @@ podlog/
 │       │   │   ├── search/
 │       │   │   ├── settings/
 │       │   │   └── api/
-│       │   │       ├── search/     # grouped + mentions routes
+│       │   │       ├── search/     # search, grouped, mentions, speakers
 │       │   │       ├── feeds/
 │       │   │       ├── queue/
-│       │   │       ├── wizard/
+│       │   │       ├── episodes/
+│       │   │       ├── ask/
+│       │   │       ├── docs/
+│       │   │       ├── hardware/
 │       │   │       ├── notifications/
+│       │   │       ├── pipeline/
 │       │   │       └── audio/
 │       │   │           └── [episodeId]/
 │       │   │               └── [filename]/
 │       │   │                   └── route.ts  # Path-validated audio serving
 │       │   ├── components/
-│       │   │   ├── ui/             # 12 shadcn/ui components
+│       │   │   ├── ui/             # 13 shadcn/ui components
 │       │   │   ├── Navbar.tsx
 │       │   │   ├── SearchResult.tsx
 │       │   │   ├── AudioPlayer.tsx
@@ -277,7 +283,7 @@ services:
 ```yaml
 services:
   db_test:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15   # pgvector required for vector-column tests
     environment:
       POSTGRES_DB: podlog_test
       POSTGRES_USER: postgres
@@ -295,6 +301,25 @@ services:
     volumes:
       - ./apps/pipeline/tests/fixtures:/usr/share/nginx/html:ro
 
+  pipeline_test:
+    build:
+      context: ./apps/pipeline
+      dockerfile: Dockerfile.worker
+      args:
+        INSTALL_DEV: "true"
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      HF_TOKEN: ${HF_TOKEN:-}
+    depends_on:
+      db_test:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/api/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   test:
     build:
       context: ./apps/pipeline
@@ -305,6 +330,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
       TEST_DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      PIPELINE_API_URL: http://pipeline_test:8000
       MOCK_RSS_URL: http://mock_rss/feed.xml
       HF_TOKEN: ${HF_TOKEN:-}
     depends_on:
@@ -312,9 +338,22 @@ services:
         condition: service_healthy
       mock_rss:
         condition: service_started
-```
+      pipeline_test:
+        condition: service_healthy
 
-**Note:** `web_test` service is currently disabled pending a pipeline_test service in the test stack (see issue #104).
+  web_test:
+    build:
+      context: ./apps/web
+      dockerfile: Dockerfile.test
+    environment:
+      DATABASE_URL: postgresql://postgres:test@db_test:5432/podlog_test
+      PIPELINE_API_URL: http://pipeline_test:8000
+    depends_on:
+      db_test:
+        condition: service_healthy
+      pipeline_test:
+        condition: service_healthy
+```
 
 ---
 
@@ -338,7 +377,7 @@ FEED_POLL_INTERVAL_HOURS=24
 
 # ── Retry configuration ───────────────────────────────────
 RETRY_MAX=3                        # Max retries for transient failures
-RETRY_BACKOFF_BASE=30              # Base backoff in seconds (30s → 2m → 10m)
+RETRY_BACKOFF_BASE=30              # Base backoff in seconds; delays = base * 2^(attempt-1) → 30s → 60s → 120s
 
 # ── Disk space guard (GAP-06) ─────────────────────────────
 DISK_HEADROOM_BYTES=2147483648     # 2 GB minimum free space before download starts
@@ -362,34 +401,50 @@ OLLAMA_URL=http://ollama:11434     # Ollama API endpoint for LLM inference
 ## 5. Makefile
 
 ```makefile
-.PHONY: up down build logs test test-unit test-integration test-e2e migrate \
+.PHONY: up up-remote down down-remote build logs logs-remote test test-unit \
+        test-healthcheck test-e2e test-integration migrate \
         shell-db shell-pipeline shell-web web ollama-pull \
-        health-check health-install health-uninstall help
+        health-check health-install health-uninstall \
+        backfill version env-check deps-outdated help
 
 up:               ## Start full stack
 	docker compose up -d
 
+up-remote:        ## Start remote-inference profile (Fireworks providers, no Ollama)
+	docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d
+
 down:             ## Stop all services
 	docker compose down
 
-build:            ## Rebuild all images
-	docker compose build
+down-remote:      ## Stop remote-inference profile stack
+	docker compose -f docker-compose.yml -f docker-compose.remote.yml down
+
+build:            ## Rebuild all images (reads version from VERSION file)
+	docker compose build --build-arg APP_VERSION=$$(cat VERSION)
 
 logs:             ## Follow logs for all services
 	docker compose logs -f
 
+logs-remote:      ## Follow logs for remote-inference profile stack
+	docker compose -f docker-compose.yml -f docker-compose.remote.yml logs -f
+
 migrate:          ## Run database migrations manually (also runs on pipeline startup)
 	docker compose exec pipeline alembic upgrade head
 
-test:             ## Run all tests (unit + e2e)
+test:             ## Run all tests (unit + e2e + host healthcheck)
 	docker compose -f docker-compose.test.yml run --rm test
 	docker compose -f docker-compose.test.yml run --rm web_test
+	python3 -m pytest apps/pipeline/tests/unit/test_healthcheck_script.py -v
 
 test-unit:        ## Run unit tests only (fast, no Docker required for ML models)
 	docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/ -v
+	python3 -m pytest apps/pipeline/tests/unit/test_healthcheck_script.py -v
+
+test-healthcheck: ## Run host healthcheck script tests
+	python3 -m pytest apps/pipeline/tests/unit/test_healthcheck_script.py -v
 
 test-integration: ## Run integration tests (requires HF_TOKEN for pyannote)
-	...
+	docker compose -f docker-compose.test.yml run --rm test pytest tests/integration/ -v
 
 test-e2e:         ## Run Playwright end-to-end tests
 	docker compose -f docker-compose.test.yml run --rm web_test
@@ -407,16 +462,30 @@ web:              ## Open web app in browser
 	open http://localhost:3000
 
 ollama-pull:      ## Pull default Ollama model (Qwen2.5-3B Q4)
-	...
+	docker compose exec ollama ollama pull qwen2.5:3b
 
-health-check:     ## Run health check once
-	...
+health-check:     ## Run health check once (requires python3, pg_isready, docker)
+	python3 scripts/healthcheck.py
 
 health-install:   ## Install health check cron job (every 15 min)
-	...
+	bash scripts/healthcheck-install.sh
 
 health-uninstall: ## Remove health check cron job
-	...
+	crontab -l 2>/dev/null | grep -vF "healthcheck.py" | crontab -
+
+backfill:         ## Run chunk+embed backfill (stops worker, runs backfill, restarts worker)
+	docker compose stop worker
+	curl -s -X POST http://localhost:8000/api/backfill/chunks?embed=true | python3 -m json.tool
+
+version:          ## Show current version
+	cat VERSION
+
+env-check:        ## Validate local Node runtime against apps/web requirement
+	bash scripts/check-web-node-version.sh
+
+deps-outdated:    ## Check npm outdated packages with resilient network handling
+	bash scripts/check-web-node-version.sh
+	bash scripts/check-npm-outdated.sh
 
 help:             ## Show this help
 	...
@@ -502,43 +571,15 @@ docker compose exec pipeline alembic current
 
 ## 8. CI/CD (GitHub Actions)
 
-```yaml
-name: CI
-on: [push, pull_request]
+CI is split across three workflows, each with a different speed/scope tradeoff:
 
-jobs:
-  test-pipeline:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run pipeline unit tests
-        run: |
-          docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/ -v --cov=app
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+| Workflow | Purpose | Scope |
+|---|---|---|
+| `.github/workflows/ci.yml` | Fast gate on every push/PR | Lint (Python + TypeScript), web unit tests, pipeline smoke-level unit tests |
+| `.github/workflows/ci-full-unit.yml` | Full unit suite | Complete pipeline unit tests with coverage; complete web Jest suite |
+| `.github/workflows/ci-slow.yml` | Heavy suites | Integration and slower end-to-end checks that require HF_TOKEN or significant CPU time |
 
-  test-web:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: apps/web/package-lock.json
-      - run: cd apps/web && npm ci && npm test
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Lint Python
-        run: cd apps/pipeline && pip install ruff && ruff check .
-      - name: Lint TypeScript
-        run: cd apps/web && npm ci && npm run lint
-```
-
-Integration and E2E tests are not run in CI (slow, require HF_TOKEN with pyannote access). Run locally before merging significant changes.
+README badges reflect the status of each. Integration and E2E tests that depend on pyannote model access remain manual / gated by the slow workflow — they are not guaranteed on every PR.
 
 ---
 

--- a/prds/PRD-04-host-guest-inference.md
+++ b/prds/PRD-04-host-guest-inference.md
@@ -2,9 +2,12 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-04 — Host & Guest Inference  
-**Version:** 1.1  
-**Status:** Draft  
+**Version:** 1.2
+**Status:** Active
 **Depends on:** PRD-01 v1.1, PRD-02 v1.1, PRD-03 v1.1
+
+**Changelog:**
+- v1.2 — Marked status Active (feature is shipped: `services/inference.py`, `tasks/infer.py`, `INFERRING` stage, spaCy `en_core_web_lg` bundled in `Dockerfile.worker`). Pipeline stage ordering in §4.6 updated to match actual code path (adds CHUNKING and EMBEDDING between DIARIZING and INFERRING).
 
 ---
 
@@ -106,10 +109,10 @@ pyannote outputs speaker labels in an arbitrary internal order. To enforce the i
 
 ### 4.6 Pipeline Integration
 
-Inference runs as a new pipeline stage **after** diarization and **before** archival:
+Inference runs as a pipeline stage **after** diarization and embedding, and **before** archival:
 
 ```
-DOWNLOADING → TRANSCRIBING → DIARIZING → INFERRING → ARCHIVING → DONE
+DOWNLOADING → TRANSCRIBING → DIARIZING → CHUNKING → EMBEDDING → INFERRING → ARCHIVING → DONE
 ```
 
 - New job state: `INFERRING`

--- a/prds/RISKS-AND-GAPS.md
+++ b/prds/RISKS-AND-GAPS.md
@@ -2,9 +2,12 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** RISKS-AND-GAPS
-**Version:** 1.4
+**Version:** 1.5
 **Status:** Living document — update as risks are resolved or new ones are identified  
 **How to use:** When a risk is mitigated or a gap is closed, move it to the Resolved section at the bottom with a note on how it was addressed. Add new entries as they are discovered during development.
+
+**Changelog:**
+- v1.5 — RISK-04 and GAP-04 (word-level alignment) moved to Resolved. WhisperX CTranslate2 + wav2vec2 word-level alignment is the default transcription stack per PRD-01 §5.4.
 
 ---
 
@@ -150,17 +153,9 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 
 ---
 
-### RISK-04: Diarization Alignment Quality
+### ~~RISK-04: Diarization Alignment Quality~~ → Resolved in v1.5
 
-**Severity:** Medium  
-**Component:** PRD-01 — `alignment.py`  
-**Description:** The majority-overlap alignment strategy assigns one speaker per Whisper segment. Whisper segments can be 5–30 seconds long. A segment spanning a speaker transition gets assigned to whichever speaker has more time in that segment — the other speaker's words are mis-attributed. There is no way to split a Whisper segment mid-word.  
-**Mitigation:**
-1. This is a known limitation of non-word-level alignment. It is acceptable for V1 — the transcript is still useful.
-2. In V1, explore using Whisper's word-level timestamps (`return_timestamps="word"`) to do word-level alignment against pyannote segments. This dramatically reduces mis-attribution at speaker transitions.
-3. Document in the README that diarization accuracy degrades on episodes with rapid back-and-forth dialogue.
-
-**Status:** Accepted for MVP. Word-level alignment is a V1 candidate.
+*Moved to Part 4: Resolved Items.*
 
 ---
 
@@ -229,12 +224,9 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 
 ---
 
-### GAP-04: Word-Level Alignment Not Implemented
+### ~~GAP-04: Word-Level Alignment Not Implemented~~ → Resolved in v1.5
 
-**Component:** PRD-01 — `alignment.py`  
-**Description:** Whisper supports word-level timestamps (`return_timestamps="word"`), which would enable much more accurate speaker assignment at sentence transitions. The current majority-overlap strategy operates at segment level (5–30 second chunks). This is a known quality gap at speaker transitions.  
-**Proposed fix:** In V1, implement word-level alignment: for each word token, find the overlapping pyannote segment and assign that speaker. Then group consecutive words with the same speaker into display segments. This requires a change to how segments are stored (word tokens → display segments rather than Whisper's raw segments).  
-**Target phase:** V1
+*Moved to Part 4: Resolved Items.*
 
 ---
 
@@ -269,3 +261,5 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 | GAP-01 | Zombie job cleanup | Periodic task every 30 min — queries episodes stuck in non-terminal status for >2 h and marks them `failed` with `error_class=SYSTEM_ERROR` (`app/tasks/cleanup.py`) | v1.3 |
 | GAP-03 | No episode re-processing | Episode reprocessing implemented — resets status to `pending`, clears segments, re-enqueues through the pipeline | v1.3 |
 | RISK-07 | Celery Beat single point of failure | No longer applicable — Celery/Redis replaced by PostgreSQL-backed job queue with polling loop in `worker.py` | v1.3 |
+| RISK-04 | Diarization alignment quality (segment-level mis-attribution) | WhisperX with wav2vec2 word-level alignment shipped (see PRD-01 §5.4); `apps/pipeline/app/services/whisper.py` + `alignment.py` implement word-level speaker assignment | v1.5 |
+| GAP-04 | Word-level alignment not implemented | WhisperX CTranslate2 + wav2vec2 word-level timestamps align transcript words against pyannote segments, replacing majority-overlap at the segment level | v1.5 |


### PR DESCRIPTION
## Summary

Groups 5 docs-only codebase-audit findings from the 2026-04-18 audit into a single PR.

## Changes by issue

**#497 — CLAUDE.md repo tree**
- Add `job_queue.py`, `task_registry.py` under `apps/pipeline/app/`
- Expand services listing (digest_formatters, fireworks_audio, hardware, inference_helpers, notification_events/runtime/settings, pipeline_commands, timing_labels)
- Expand tasks listing (backfill_chunks, helpers, transcribe_helpers)
- Expand web `src/lib/` listing (episode-link, page-state, queueStatus, searchHybrid, `search/` subdir)
- Add missing repo-root entries (docker-compose.remote.yml, .github/, .agents/, .superpowers/, .omx/, issues/, .node-version, .nvmrc)

**#493 — RISKS-AND-GAPS word-level alignment**
- Move RISK-04 and GAP-04 into the Resolved section (v1.5). WhisperX CTranslate2 + wav2vec2 word-level alignment is the default transcription path per PRD-01 §5.4.

**#492 — PRD-02 / PRD-04**
- PRD-02 tech stack row updated from "Next.js 14" → "Next.js 16" to match `apps/web/package.json`.
- PRD-04 marked **Active** (was Draft). §4.6 stage order now `DOWNLOADING → TRANSCRIBING → DIARIZING → CHUNKING → EMBEDDING → INFERRING → ARCHIVING → DONE` to match `task_registry.py`.

**#491 — PRD-01 retry wording**
- §5.2 rewritten: backoff formula is `RETRY_BACKOFF_BASE * 2^(attempt-1)` → 30s / 60s / 120s. HTTP 4xx clarified as `HTTP_ACCESS` (retried up to 3×), not "non-transient".
- PRD-03 `.env.example` comment corrected to `30s → 60s → 120s`.

**#490 — PRD-03 infrastructure drift**
- `versions/  # 10 migrations` → 12; `ui/  # 12 shadcn/ui components` → 13
- Remove `api/wizard/` (retired in #361)
- Test-stack snippet: `postgres:15-alpine` → `pgvector/pgvector:pg15`
- Remove stale "web_test disabled" note; add real `pipeline_test` and `web_test` blocks
- §5 Makefile section extended with `up-remote`, `down-remote`, `logs-remote`, `backfill`, `version`, `env-check`, `deps-outdated`, `test-healthcheck`
- §8 CI/CD section replaced with the current three-workflow split (`ci.yml`, `ci-full-unit.yml`, `ci-slow.yml`)
- Web tree: add `Dockerfile.test`

## Test plan

- [x] Docs-only change — no code execution required
- [x] Verified current counts: `ls apps/pipeline/alembic/versions | wc -l` = 12; `ls apps/web/src/components/ui | wc -l` = 13
- [x] Verified `docker-compose.test.yml` currently has `pipeline_test` and `web_test` blocks
- [x] Verified `apps/pipeline/app/tasks/download.py:167` uses `base * 2^(attempt-1)` and that `_classify_http_error` classifies 4xx as `HTTP_ACCESS` (retried)

Closes #497
Closes #493
Closes #492
Closes #491
Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)