### PR TITLE
refactor(web): un-export page-state snapshot types (#498)

### DIFF
--- a/apps/web/src/lib/page-state.ts
+++ b/apps/web/src/lib/page-state.ts
@@ -6,7 +6,7 @@ type AskStatus = "idle" | "connecting" | "streaming" | "done" | "error";
 const SEARCH_STORAGE_KEY = "podlog-search-page-state";
 const ASK_STORAGE_KEY = "podlog-ask-page-state";
 
-export interface SearchPageSnapshot {
+interface SearchPageSnapshot {
   query: string;
   submittedQuery: string;
   selectedFeedIds: string[];
@@ -16,7 +16,7 @@ export interface SearchPageSnapshot {
   viewMode: ViewMode;
 }
 
-export interface AskPageSnapshot {
+interface AskPageSnapshot {
   question: string;
   answer: string;
   sources: Source[];

--- a/apps/web/tests/unit/ask-page-play.test.tsx
+++ b/apps/web/tests/unit/ask-page-play.test.tsx
@@ -26,7 +26,9 @@ jest.mock("next/link", () => {
 });
 
 import AskPage from "@/app/ask/page";
-import { saveAskSnapshot, type AskPageSnapshot } from "@/lib/page-state";
+import { saveAskSnapshot } from "@/lib/page-state";
+
+type AskPageSnapshot = Parameters<typeof saveAskSnapshot>[0];
 
 describe("Ask page source card actions", () => {
   beforeEach(() => {

--- a/apps/web/tests/unit/page-state-persistence.test.ts
+++ b/apps/web/tests/unit/page-state-persistence.test.ts
@@ -3,9 +3,10 @@ import {
   loadSearchSnapshot,
   saveAskSnapshot,
   saveSearchSnapshot,
-  type AskPageSnapshot,
-  type SearchPageSnapshot,
 } from "@/lib/page-state";
+
+type SearchPageSnapshot = Parameters<typeof saveSearchSnapshot>[0];
+type AskPageSnapshot = Parameters<typeof saveAskSnapshot>[0];
 
 function makeStorage(): Storage {
   const data = new Map<string, string>();

--- a/apps/web/tests/unit/search-url-priority.test.tsx
+++ b/apps/web/tests/unit/search-url-priority.test.tsx
@@ -21,7 +21,9 @@ jest.mock("next/link", () => {
 });
 
 import SearchPage from "@/app/search/page";
-import { saveSearchSnapshot, type SearchPageSnapshot } from "@/lib/page-state";
+import { saveSearchSnapshot } from "@/lib/page-state";
+
+type SearchPageSnapshot = Parameters<typeof saveSearchSnapshot>[0];
 
 describe("Search page URL query priority", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

`SearchPageSnapshot` and `AskPageSnapshot` in \`apps/web/src/lib/page-state.ts\` had no direct imports in \`src/\` — only the three unit tests referenced them by name. The types still flow through the save/load function signatures, so this PR drops the \`export\` and has the tests derive the type from \`Parameters<typeof save…>[0]\`.

## Changes

- \`apps/web/src/lib/page-state.ts\`: remove \`export\` from both interfaces
- \`apps/web/tests/unit/page-state-persistence.test.ts\`: derive types via \`Parameters<typeof save*>[0]\`
- \`apps/web/tests/unit/search-url-priority.test.tsx\`: same
- \`apps/web/tests/unit/ask-page-play.test.tsx\`: same

## Test plan

- [x] \`npx jest tests/unit/page-state-persistence.test.ts tests/unit/search-url-priority.test.tsx tests/unit/ask-page-play.test.tsx\` → 6/6 pass
- [x] \`npx tsc --noEmit\` reports no new errors (preexisting \`.next/\` wizard-route artifacts unchanged, tracked under #499)
- [x] \`npm run lint\` → 0 errors (preexisting warnings unchanged)

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)