### PR TITLE
test(web): cover audio route with full handler tests (#489)

### DIFF
--- a/apps/web/tests/unit/audio-route.test.ts
+++ b/apps/web/tests/unit/audio-route.test.ts
@@ -1,44 +1,248 @@
 /**
- * Unit test for audio route path validation — PRD-02 §13
+ * Unit tests for GET /api/audio/[episodeId]/[filename] — PRD-02 §5.2, §11
  *
- * Tests the path traversal prevention logic without a live filesystem.
+ * Exercises the real route handler with mocked DB + fs to cover:
+ * - episode validation (404 when missing)
+ * - filename/episode mismatch (404)
+ * - path traversal neutralisation (basename-stripped, then 404 if not found)
+ * - file resolution across archive + raw dirs
+ * - Range and non-Range responses
+ * - content-type selection per extension
+ *
+ * @jest-environment node
  */
+import { EventEmitter } from "events";
 import path from "path";
+import { NextRequest } from "next/server";
 
-const AUDIO_ARCHIVE_DIR = "/data/audio/archive";
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
 
-function isPathSafe(filename: string): boolean {
-  const safeName = path.basename(filename);
-  const resolved = path.resolve(AUDIO_ARCHIVE_DIR, safeName);
-  return resolved.startsWith(AUDIO_ARCHIVE_DIR + path.sep);
+const mockExistsSync = jest.fn();
+const mockStatSync = jest.fn();
+const mockCreateReadStream = jest.fn();
+jest.mock("fs", () => ({
+  __esModule: true,
+  default: {
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    statSync: (...args: unknown[]) => mockStatSync(...args),
+    createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
+  },
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  statSync: (...args: unknown[]) => mockStatSync(...args),
+  createReadStream: (...args: unknown[]) => mockCreateReadStream(...args),
+}));
+
+function makeFakeStream(chunks: Buffer[] = [Buffer.from("audio-bytes")]) {
+  const ee = new EventEmitter() as EventEmitter & { destroy?: () => void };
+  setImmediate(() => {
+    for (const c of chunks) ee.emit("data", c);
+    ee.emit("end");
+  });
+  return ee;
 }
 
-describe("audio route path validation", () => {
-  test("valid filename passes", () => {
-    expect(isPathSafe("ep-123.mp3")).toBe(true);
+async function readBody(resp: Response): Promise<Buffer> {
+  const ab = await resp.arrayBuffer();
+  return Buffer.from(ab);
+}
+
+type RouteModule = typeof import("@/app/api/audio/[episodeId]/[filename]/route");
+let GET: RouteModule["GET"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/audio/[episodeId]/[filename]/route");
+  GET = mod.GET;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockExistsSync.mockReset();
+  mockStatSync.mockReset();
+  mockCreateReadStream.mockReset();
+});
+
+function callGET(episodeId: string, filename: string, headers: Record<string, string> = {}) {
+  const req = new NextRequest(
+    `http://localhost/api/audio/${episodeId}/${encodeURIComponent(filename)}`,
+    { headers }
+  );
+  return GET(req, {
+    params: Promise.resolve({ episodeId, filename }),
+  });
+}
+
+describe("GET /api/audio/[episodeId]/[filename]", () => {
+  it("returns 404 when episode does not exist", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const resp = await callGET("missing-id", "ep.mp3");
+
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).toBe("Episode not found");
+    expect(mockQuery).toHaveBeenCalledWith(
+      "SELECT audio_local_path FROM episodes WHERE id = $1",
+      ["missing-id"]
+    );
   });
 
-  test("path traversal attempt is neutralised by basename stripping", () => {
-    // basename("../../../etc/passwd") → "passwd", which resolves safely
-    // inside the archive dir. The function returns true because the
-    // sanitised name IS safe — traversal was stripped, not merely detected.
-    expect(isPathSafe("../../../etc/passwd")).toBe(true);
+  it("returns 404 when filename does not match the episode's audio file", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/real-file.mp3" }],
+    });
+
+    const resp = await callGET("ep-1", "attacker.mp3");
+
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).toBe("File does not belong to this episode");
+    expect(mockExistsSync).not.toHaveBeenCalled();
   });
 
-  test("nested path is reduced to basename", () => {
-    // path.basename strips directories, so this resolves to just "passwd"
-    // which IS inside the archive dir — that's correct, basename strips the traversal
-    const safeName = path.basename("../../../etc/passwd");
-    expect(safeName).toBe("passwd");
+  it("strips path separators from filename (path traversal prevention)", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/passwd" }],
+    });
+    mockExistsSync.mockReturnValue(false);
+
+    const resp = await callGET("ep-1", "../../../etc/passwd");
+
+    expect(resp.status).toBe(404);
+    const calledPaths = mockExistsSync.mock.calls.map((c) => c[0]);
+    for (const p of calledPaths) {
+      expect(typeof p).toBe("string");
+      expect(p).not.toContain("..");
+      expect(
+        p.startsWith("/data/audio/archive/") || p.startsWith("/data/audio/raw/")
+      ).toBe(true);
+    }
   });
 
-  test("filename with no extension passes", () => {
-    expect(isPathSafe("ep-abc")).toBe(true);
+  it("returns 404 when file is absent from both audio directories", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/ep.mp3" }],
+    });
+    mockExistsSync.mockReturnValue(false);
+
+    const resp = await callGET("ep-1", "ep.mp3");
+
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).toBe("Not found");
+    const tried = mockExistsSync.mock.calls.map((c) => c[0]);
+    expect(tried).toEqual([
+      path.resolve("/data/audio/archive", "ep.mp3"),
+      path.resolve("/data/audio/raw", "ep.mp3"),
+    ]);
   });
 
-  test("absolute path input is reduced to basename", () => {
-    // Even if the client sends an absolute path, basename strips it
-    const safeName = path.basename("/etc/shadow");
-    expect(safeName).toBe("shadow");
+  it("streams the full file with correct headers when no Range header is provided", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/ep.mp3" }],
+    });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith("archive/ep.mp3"));
+    mockStatSync.mockReturnValue({ size: 1234 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream([Buffer.from("audio-bytes")]));
+
+    const resp = await callGET("ep-1", "ep.mp3");
+
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(resp.headers.get("Content-Length")).toBe("1234");
+    expect(resp.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(mockCreateReadStream).toHaveBeenCalledWith(
+      path.resolve("/data/audio/archive", "ep.mp3")
+    );
+    expect(await readBody(resp)).toEqual(Buffer.from("audio-bytes"));
+  });
+
+  it("falls back to raw dir when file is not in archive", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/raw/ep.mp3" }],
+    });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith("raw/ep.mp3"));
+    mockStatSync.mockReturnValue({ size: 10 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream([Buffer.from("x")]));
+
+    const resp = await callGET("ep-1", "ep.mp3");
+
+    expect(resp.status).toBe(200);
+    expect(mockCreateReadStream).toHaveBeenCalledWith(
+      path.resolve("/data/audio/raw", "ep.mp3")
+    );
+  });
+
+  it("handles Range requests with 206 and correct Content-Range", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/ep.mp3" }],
+    });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith("archive/ep.mp3"));
+    mockStatSync.mockReturnValue({ size: 1000 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream([Buffer.from("range-bytes")]));
+
+    const resp = await callGET("ep-1", "ep.mp3", { range: "bytes=100-199" });
+
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("Content-Range")).toBe("bytes 100-199/1000");
+    expect(resp.headers.get("Content-Length")).toBe("100");
+    expect(resp.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(mockCreateReadStream).toHaveBeenCalledWith(
+      path.resolve("/data/audio/archive", "ep.mp3"),
+      { start: 100, end: 199 }
+    );
+  });
+
+  it("defaults open-ended Range end to fileSize - 1", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: "/data/audio/archive/ep.mp3" }],
+    });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith("archive/ep.mp3"));
+    mockStatSync.mockReturnValue({ size: 500 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream());
+
+    const resp = await callGET("ep-1", "ep.mp3", { range: "bytes=10-" });
+
+    expect(resp.status).toBe(206);
+    expect(resp.headers.get("Content-Range")).toBe("bytes 10-499/500");
+    expect(resp.headers.get("Content-Length")).toBe("490");
+    expect(mockCreateReadStream).toHaveBeenCalledWith(expect.any(String), {
+      start: 10,
+      end: 499,
+    });
+  });
+
+  it.each([
+    ["ep.mp3", "audio/mpeg"],
+    ["ep.m4a", "audio/mp4"],
+    ["ep.mp4", "audio/mp4"],
+    ["ep.ogg", "audio/ogg"],
+    ["ep.wav", "audio/wav"],
+    ["ep.flac", "audio/flac"],
+    ["ep.opus", "audio/opus"],
+    ["ep.aac", "audio/aac"],
+    ["ep.wma", "audio/x-ms-wma"],
+    ["ep.unknown", "audio/mpeg"],
+    ["ep-no-ext", "audio/mpeg"],
+  ])("sets Content-Type for %s to %s", async (filename, expected) => {
+    mockQuery.mockResolvedValue({
+      rows: [{ audio_local_path: `/data/audio/archive/${filename}` }],
+    });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith(filename));
+    mockStatSync.mockReturnValue({ size: 1 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream());
+
+    const resp = await callGET("ep-1", filename);
+
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe(expected);
+  });
+
+  it("allows access when episode has no recorded audio_local_path", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ audio_local_path: null }] });
+    mockExistsSync.mockImplementation((p: string) => p.endsWith("archive/ep.mp3"));
+    mockStatSync.mockReturnValue({ size: 5 });
+    mockCreateReadStream.mockReturnValue(makeFakeStream());
+
+    const resp = await callGET("ep-1", "ep.mp3");
+
+    expect(resp.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

Replace the placeholder `isPathSafe` helper test with real `GET /api/audio/[episodeId]/[filename]` handler tests. The route is security-critical (path-traversal guard) and was at 0% coverage per the 2026-04-18 audit.

## Coverage impact

`apps/web/src/app/api/audio/[episodeId]/[filename]/route.ts`: **100% lines / 94.4% branches / 60% functions**.

## Test cases

- 404 when episode is missing
- 404 when filename does not match episode's `audio_local_path`
- 404 when file is absent from both `/data/audio/archive` and `/data/audio/raw`
- `path.basename()` neutralises `../..` traversal attempts (asserts the resolved paths stay inside allowed dirs)
- Full-file streaming with correct `Content-Length`, `Content-Type`, `Accept-Ranges`
- `Range` requests return 206 with correct `Content-Range`
- Open-ended range (`bytes=N-`) defaults end to `fileSize - 1`
- Fallback from archive → raw dir
- Content-type map for all supported extensions + default

## Verified

- `npx jest tests/unit/audio-route.test.ts` — 20/20 pass
- `npx jest --runInBand` — 213/213 pass

## Scope

First PR toward #489 (raise web coverage above 60%). Started with the audit's only security-critical 0%-coverage file. More 0%-coverage routes/pages will follow in separate PRs.

Refs #489