### PR TITLE
test(web): cover 5 zero-coverage proxy API routes (#489)

### DIFF
--- a/apps/web/tests/unit/ask-coverage-route.test.ts
+++ b/apps/web/tests/unit/ask-coverage-route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
+
+type RouteModule = typeof import("@/app/api/ask/coverage/route");
+let GET: RouteModule["GET"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/ask/coverage/route");
+  GET = mod.GET;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("GET /api/ask/coverage", () => {
+  it("returns processed/total counts and manual-upload flag", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ processed: "42", total: "100", has_manual_uploads: true }],
+    });
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({
+      processed: 42,
+      total: 100,
+      has_manual_uploads: true,
+    });
+
+    const sql: string = mockQuery.mock.calls[0][0];
+    expect(sql).toContain("status = 'done'");
+    expect(sql).toContain("feed_id IS NULL");
+  });
+
+  it("coerces string counts to numbers", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ processed: "0", total: "0", has_manual_uploads: false }],
+    });
+
+    const resp = await GET();
+
+    const data = await resp.json();
+    expect(data.processed).toBe(0);
+    expect(data.total).toBe(0);
+    expect(typeof data.processed).toBe("number");
+    expect(typeof data.total).toBe("number");
+    expect(data.has_manual_uploads).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/hardware-route.test.ts
+++ b/apps/web/tests/unit/hardware-route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/hardware/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("GET /api/hardware", () => {
+  it("proxies pipeline hardware info on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hardware: { cpu: "x86_64" }, profile: "local" }),
+    });
+
+    const resp = await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/hardware",
+      { cache: "no-store" }
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({
+      hardware: { cpu: "x86_64" },
+      profile: "local",
+    });
+  });
+
+  it("returns fallback with upstream status when pipeline returns non-OK", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(503);
+    const body = await resp.json();
+    expect(body.hardware).toBeNull();
+    expect(body.profile).toBeNull();
+    expect(body.estimates.remote_cost_per_hour_usd).toBe(0.36);
+  });
+
+  it("returns fallback with 502 when fetch throws", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(502);
+    const body = await resp.json();
+    expect(body.hardware).toBeNull();
+    expect(body.estimates.remote_transcription_minutes_per_hour).toBe(3);
+  });
+});

--- a/apps/web/tests/unit/pipeline-embed-route.test.ts
+++ b/apps/web/tests/unit/pipeline-embed-route.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/pipeline/embed/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  consoleErrorSpy.mockClear();
+});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/pipeline/embed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/pipeline/embed", () => {
+  it("forwards body to pipeline and returns embedding on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ embedding: [0.1, 0.2, 0.3] }),
+    });
+
+    const resp = await POST(makeReq({ text: "hello" }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/embed",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "hello" }),
+      })
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ embedding: [0.1, 0.2, 0.3] });
+  });
+
+  it("propagates upstream status and returns error JSON when pipeline fails", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    const resp = await POST(makeReq({ text: "x" }));
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ error: "Embedding failed" });
+  });
+
+  it("returns 503 when fetch throws", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const resp = await POST(makeReq({ text: "x" }));
+
+    expect(resp.status).toBe(503);
+    expect(await resp.json()).toEqual({ error: "Embedding service unavailable" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/pipeline-health-route.test.ts
+++ b/apps/web/tests/unit/pipeline-health-route.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "@/app/api/pipeline/health/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("GET /api/pipeline/health", () => {
+  it("proxies pipeline health JSON on success", async () => {
+    const payload = {
+      status: "HEALTHY",
+      services: [{ name: "Database", status: "HEALTHY" }],
+    };
+    mockFetch.mockResolvedValue({ json: async () => payload });
+
+    const resp = await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/health",
+      { cache: "no-store" }
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual(payload);
+  });
+
+  it("returns full DEGRADED payload on fetch failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(200);
+    const data = await resp.json();
+    expect(data.status).toBe("DEGRADED");
+    expect(data.services).toHaveLength(3);
+    for (const svc of data.services) {
+      expect(svc.status).toBe("DEGRADED");
+    }
+    expect(data.services.map((s: { name: string }) => s.name)).toEqual([
+      "Pipeline API",
+      "Database",
+      "Worker",
+    ]);
+  });
+});

--- a/apps/web/tests/unit/pipeline-queue-retry-route.test.ts
+++ b/apps/web/tests/unit/pipeline-queue-retry-route.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/pipeline/queue/[episodeId]/retry/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function call(episodeId: string) {
+  const req = new NextRequest(
+    `http://localhost/api/pipeline/queue/${episodeId}/retry`,
+    { method: "POST" }
+  );
+  return POST(req, { params: Promise.resolve({ episodeId }) });
+}
+
+describe("POST /api/pipeline/queue/[episodeId]/retry", () => {
+  it("forwards retry request to pipeline and mirrors status + body", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: async () => ({ queued: true, episode_id: "ep-1" }),
+    });
+
+    const resp = await call("ep-1");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/queue/ep-1/retry",
+      { method: "POST" }
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ queued: true, episode_id: "ep-1" });
+  });
+
+  it("mirrors non-200 status from upstream", async () => {
+    mockFetch.mockResolvedValue({
+      status: 404,
+      json: async () => ({ error: "not found" }),
+    });
+
+    const resp = await call("missing");
+
+    expect(resp.status).toBe(404);
+    expect(await resp.json()).toEqual({ error: "not found" });
+  });
+});


### PR DESCRIPTION
## Summary

Second slice toward #489. Adds handler tests for 5 thin API routes that sat at 0% coverage in the 2026-04-18 audit.

## Routes covered

| Route | Type | Coverage (lines) |
|---|---|---|
| `api/hardware` | fetch proxy w/ fallback | 100% |
| `api/pipeline/health` | fetch proxy w/ DEGRADED fallback | 100% |
| `api/pipeline/embed` | fetch proxy w/ error propagation | 100% |
| `api/pipeline/queue/[episodeId]/retry` | fetch proxy w/ params | 100% |
| `api/ask/coverage` | DB count query + numeric coercion | 100% |

All 5 routes: 100% branches, 100% functions.

## Verified

- 12 new test cases, all pass
- Full web unit suite: 225/225 pass (was 213 pre-PR)

## Follow-ups

Remaining 0%-coverage routes (episodes/*, feeds/[id]/*, notifications/*, queue, upload, ingest) and the SSE streaming `pipeline/ask` route will land in subsequent PRs.

Refs #489