### PR TITLE
test(web): cover 6 more zero-coverage proxy routes (#489)

### DIFF
--- a/apps/web/tests/unit/episodes-id-route.test.ts
+++ b/apps/web/tests/unit/episodes-id-route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { DELETE } from "@/app/api/episodes/[id]/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function call(id: string) {
+  const req = new Request(`http://localhost/api/episodes/${id}`, {
+    method: "DELETE",
+  });
+  return DELETE(req, { params: Promise.resolve({ id }) });
+}
+
+describe("DELETE /api/episodes/[id]", () => {
+  it("returns empty 204 when pipeline returns 204", async () => {
+    mockFetch.mockResolvedValue({
+      status: 204,
+      text: async () => "",
+    });
+
+    const resp = await call("ep-1");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/episodes/ep-1",
+      { method: "DELETE" }
+    );
+    expect(resp.status).toBe(204);
+    expect(await resp.text()).toBe("");
+  });
+
+  it("forwards JSON error body when upstream returns JSON", async () => {
+    mockFetch.mockResolvedValue({
+      status: 409,
+      text: async () => JSON.stringify({ detail: "episode locked" }),
+    });
+
+    const resp = await call("ep-2");
+
+    expect(resp.status).toBe(409);
+    expect(await resp.json()).toEqual({ detail: "episode locked" });
+  });
+
+  it("wraps non-JSON error text in a detail field", async () => {
+    mockFetch.mockResolvedValue({
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    const resp = await call("ep-3");
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ detail: "Internal Server Error" });
+  });
+
+  it("uses fallback detail when upstream returns empty non-JSON body", async () => {
+    mockFetch.mockResolvedValue({
+      status: 500,
+      text: async () => "",
+    });
+
+    const resp = await call("ep-4");
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({
+      detail: "Pipeline API returned a non-JSON error",
+    });
+  });
+});

--- a/apps/web/tests/unit/episodes-retry-route.test.ts
+++ b/apps/web/tests/unit/episodes-retry-route.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/episodes/[id]/retry/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function call(id: string) {
+  const req = new NextRequest(`http://localhost/api/episodes/${id}/retry`, {
+    method: "POST",
+  });
+  return POST(req, { params: Promise.resolve({ id }) });
+}
+
+describe("POST /api/episodes/[id]/retry", () => {
+  it("forwards retry to pipeline queue endpoint and mirrors response", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: async () => ({ queued: true }),
+    });
+
+    const resp = await call("ep-xyz");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/queue/ep-xyz/retry",
+      { method: "POST" }
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ queued: true });
+  });
+
+  it("mirrors 404 when episode not found upstream", async () => {
+    mockFetch.mockResolvedValue({
+      status: 404,
+      json: async () => ({ detail: "episode not found" }),
+    });
+
+    const resp = await call("missing");
+
+    expect(resp.status).toBe(404);
+    expect(await resp.json()).toEqual({ detail: "episode not found" });
+  });
+});

--- a/apps/web/tests/unit/feeds-id-route.test.ts
+++ b/apps/web/tests/unit/feeds-id-route.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { DELETE } from "@/app/api/feeds/[id]/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function call(id: string, url: string) {
+  const req = new NextRequest(url, { method: "DELETE" });
+  return DELETE(req, { params: Promise.resolve({ id }) });
+}
+
+describe("DELETE /api/feeds/[id]", () => {
+  it("returns empty 204 when pipeline returns 204", async () => {
+    mockFetch.mockResolvedValue({ status: 204, json: async () => ({}) });
+
+    const resp = await call("feed-1", "http://localhost/api/feeds/feed-1");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/feed-1?delete_episodes=false",
+      { method: "DELETE" }
+    );
+    expect(resp.status).toBe(204);
+    expect(await resp.text()).toBe("");
+  });
+
+  it("forwards delete_episodes=true when query param is set", async () => {
+    mockFetch.mockResolvedValue({ status: 204, json: async () => ({}) });
+
+    await call(
+      "feed-1",
+      "http://localhost/api/feeds/feed-1?delete_episodes=true"
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/feed-1?delete_episodes=true",
+      { method: "DELETE" }
+    );
+  });
+
+  it("mirrors non-204 status and JSON body from upstream", async () => {
+    mockFetch.mockResolvedValue({
+      status: 409,
+      json: async () => ({ detail: "Feed has running jobs" }),
+    });
+
+    const resp = await call("feed-1", "http://localhost/api/feeds/feed-1");
+
+    expect(resp.status).toBe(409);
+    expect(await resp.json()).toEqual({ detail: "Feed has running jobs" });
+  });
+});

--- a/apps/web/tests/unit/feeds-poll-route.test.ts
+++ b/apps/web/tests/unit/feeds-poll-route.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/feeds/[id]/poll/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function call(id: string) {
+  const req = new NextRequest(`http://localhost/api/feeds/${id}/poll`, {
+    method: "POST",
+  });
+  return POST(req, { params: Promise.resolve({ id }) });
+}
+
+describe("POST /api/feeds/[id]/poll", () => {
+  it("proxies poll request and mirrors upstream status + body", async () => {
+    mockFetch.mockResolvedValue({
+      status: 202,
+      json: async () => ({ queued_episodes: 3 }),
+    });
+
+    const resp = await call("feed-abc");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/feed-abc/poll",
+      { method: "POST" }
+    );
+    expect(resp.status).toBe(202);
+    expect(await resp.json()).toEqual({ queued_episodes: 3 });
+  });
+
+  it("mirrors error status from pipeline", async () => {
+    mockFetch.mockResolvedValue({
+      status: 500,
+      json: async () => ({ detail: "RSS parse error" }),
+    });
+
+    const resp = await call("feed-bad");
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ detail: "RSS parse error" });
+  });
+});

--- a/apps/web/tests/unit/notifications-settings-route.test.ts
+++ b/apps/web/tests/unit/notifications-settings-route.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT } from "@/app/api/notifications/settings/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("/api/notifications/settings", () => {
+  describe("GET", () => {
+    it("proxies settings fetch to pipeline without cache", async () => {
+      mockFetch.mockResolvedValue({
+        status: 200,
+        json: async () => ({ email_enabled: true, digest_cadence: "daily" }),
+      });
+
+      const resp = await GET();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://pipeline:8000/api/notifications/settings",
+        { cache: "no-store" }
+      );
+      expect(resp.status).toBe(200);
+      expect(await resp.json()).toEqual({
+        email_enabled: true,
+        digest_cadence: "daily",
+      });
+    });
+  });
+
+  describe("PUT", () => {
+    it("forwards JSON body and mirrors status", async () => {
+      mockFetch.mockResolvedValue({
+        status: 200,
+        json: async () => ({ updated: true }),
+      });
+
+      const req = new NextRequest(
+        "http://localhost/api/notifications/settings",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email_enabled: false }),
+        }
+      );
+      const resp = await PUT(req);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://pipeline:8000/api/notifications/settings",
+        expect.objectContaining({
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email_enabled: false }),
+        })
+      );
+      expect(resp.status).toBe(200);
+      expect(await resp.json()).toEqual({ updated: true });
+    });
+
+    it("mirrors validation error from pipeline", async () => {
+      mockFetch.mockResolvedValue({
+        status: 422,
+        json: async () => ({ detail: "invalid digest_cadence" }),
+      });
+
+      const req = new NextRequest(
+        "http://localhost/api/notifications/settings",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ digest_cadence: "bogus" }),
+        }
+      );
+      const resp = await PUT(req);
+
+      expect(resp.status).toBe(422);
+    });
+  });
+});

--- a/apps/web/tests/unit/notifications-test-route.test.ts
+++ b/apps/web/tests/unit/notifications-test-route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/notifications/test/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("POST /api/notifications/test", () => {
+  it("forwards body to pipeline test endpoint and mirrors response", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      json: async () => ({ delivered: true }),
+    });
+
+    const req = new NextRequest("http://localhost/api/notifications/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com" }),
+    });
+
+    const resp = await POST(req);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/notifications/test",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "user@example.com" }),
+      })
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ delivered: true });
+  });
+
+  it("mirrors pipeline error status when SMTP fails", async () => {
+    mockFetch.mockResolvedValue({
+      status: 502,
+      json: async () => ({ detail: "SMTP unreachable" }),
+    });
+
+    const req = new NextRequest("http://localhost/api/notifications/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const resp = await POST(req);
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({ detail: "SMTP unreachable" });
+  });
+});


### PR DESCRIPTION
## Summary

Third slice toward #489. Handler tests for 6 more thin proxy API routes that sat at 0% coverage.

## Routes covered

| Route | Methods | Coverage |
|---|---|---|
| `api/feeds/[id]` | DELETE (with `delete_episodes` query, 204, JSON errors) | 100% |
| `api/feeds/[id]/poll` | POST | 100% |
| `api/notifications/settings` | GET + PUT | 100% |
| `api/notifications/test` | POST | 100% |
| `api/episodes/[id]` | DELETE (204, JSON body, non-JSON text fallback, empty-body fallback) | 100% |
| `api/episodes/[id]/retry` | POST | 100% |

All 6 routes: 100% branches and functions (statement %s 88–100 — uncovered statements are unreachable default-param slots).

## Verified

- 16 new test cases
- Full web unit suite: 241/241 pass (up from 225)

## Remaining on #489

Still at 0%: `api/episodes/ingest`, `api/episodes/upload`, `api/episodes/[id]/speakers(+/merge)`, `api/queue`, `api/pipeline/ask` (SSE), plus several pages and components. More PRs to come.

Refs #489