### PR TITLE
test(web): cover episode mutation routes incl. transactional merge (#489)

### DIFF
--- a/apps/web/tests/unit/episodes-ingest-route.test.ts
+++ b/apps/web/tests/unit/episodes-ingest-route.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/episodes/ingest/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/episodes/ingest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/episodes/ingest", () => {
+  it("forwards JSON body to pipeline and mirrors response", async () => {
+    mockFetch.mockResolvedValue({
+      status: 201,
+      json: async () => ({ episode_id: "ep-1" }),
+    });
+
+    const resp = await POST(makeReq({ audio_url: "https://ex.com/a.mp3" }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/episodes/ingest",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ audio_url: "https://ex.com/a.mp3" }),
+      })
+    );
+    expect(resp.status).toBe(201);
+    expect(await resp.json()).toEqual({ episode_id: "ep-1" });
+  });
+
+  it("mirrors validation error from pipeline", async () => {
+    mockFetch.mockResolvedValue({
+      status: 422,
+      json: async () => ({ detail: "audio_url is required" }),
+    });
+
+    const resp = await POST(makeReq({}));
+
+    expect(resp.status).toBe(422);
+    expect(await resp.json()).toEqual({ detail: "audio_url is required" });
+  });
+});

--- a/apps/web/tests/unit/episodes-speakers-route.test.ts
+++ b/apps/web/tests/unit/episodes-speakers-route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ */
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
+
+import { NextRequest } from "next/server";
+
+type RouteModule = typeof import("@/app/api/episodes/[id]/speakers/route");
+let PUT: RouteModule["PUT"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/episodes/[id]/speakers/route");
+  PUT = mod.PUT;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function call(id: string, body: unknown) {
+  const req = new NextRequest(`http://localhost/api/episodes/${id}/speakers`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return PUT(req, { params: Promise.resolve({ id }) });
+}
+
+describe("PUT /api/episodes/[id]/speakers", () => {
+  it("upserts the display name with inferred=false and confirmed_by_user=true", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+
+    const resp = await call("ep-1", {
+      speaker_label: "SPEAKER_00",
+      display_name: "Alice",
+    });
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ ok: true });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO speaker_names");
+    expect(sql).toContain("ON CONFLICT");
+    expect(sql).toContain("inferred = false");
+    expect(sql).toContain("confirmed_by_user = true");
+    expect(params).toEqual(["ep-1", "SPEAKER_00", "Alice"]);
+  });
+
+  it("trims whitespace from display_name before persisting", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+
+    await call("ep-1", {
+      speaker_label: "SPEAKER_00",
+      display_name: "   Alice   ",
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[2]).toBe("Alice");
+  });
+
+  it("returns 400 when speaker_label is missing", async () => {
+    const resp = await call("ep-1", { display_name: "Alice" });
+
+    expect(resp.status).toBe(400);
+    expect(await resp.json()).toEqual({
+      error: "speaker_label and display_name are required",
+    });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when display_name is blank whitespace", async () => {
+    const resp = await call("ep-1", {
+      speaker_label: "SPEAKER_00",
+      display_name: "   ",
+    });
+
+    expect(resp.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when DB query throws", async () => {
+    mockQuery.mockRejectedValue(new Error("constraint violation"));
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const resp = await call("ep-1", {
+      speaker_label: "SPEAKER_00",
+      display_name: "Alice",
+    });
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ error: "Failed to update speaker name" });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/tests/unit/episodes-upload-route.test.ts
+++ b/apps/web/tests/unit/episodes-upload-route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/episodes/upload/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function makeReq(form: FormData) {
+  return new NextRequest("http://localhost/api/episodes/upload", {
+    method: "POST",
+    body: form,
+  });
+}
+
+describe("POST /api/episodes/upload", () => {
+  it("forwards formData to pipeline upload endpoint", async () => {
+    mockFetch.mockResolvedValue({
+      status: 201,
+      json: async () => ({ episode_id: "uploaded-1" }),
+    });
+
+    const form = new FormData();
+    form.append("title", "My Episode");
+    form.append("file", new Blob(["audio-bytes"], { type: "audio/mpeg" }), "ep.mp3");
+
+    const resp = await POST(makeReq(form));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://pipeline:8000/api/episodes/upload");
+    expect(opts.method).toBe("POST");
+    expect(opts.body).toBeInstanceOf(FormData);
+    expect((opts.body as FormData).get("title")).toBe("My Episode");
+    expect(resp.status).toBe(201);
+    expect(await resp.json()).toEqual({ episode_id: "uploaded-1" });
+  });
+
+  it("mirrors pipeline error status", async () => {
+    mockFetch.mockResolvedValue({
+      status: 413,
+      json: async () => ({ detail: "file too large" }),
+    });
+
+    const form = new FormData();
+    form.append("file", new Blob(["x"]), "x.mp3");
+    const resp = await POST(makeReq(form));
+
+    expect(resp.status).toBe(413);
+    expect(await resp.json()).toEqual({ detail: "file too large" });
+  });
+});

--- a/apps/web/tests/unit/speaker-merge-route.test.ts
+++ b/apps/web/tests/unit/speaker-merge-route.test.ts
@@ -1,68 +1,236 @@
 /**
- * @jest-environment node
+ * Tests for POST /api/episodes/[id]/speakers/merge.
  *
- * Unit tests for speaker merge API route validation logic.
- * Tests the pure validation function without hitting the database.
+ * Exercises the transactional handler with a mocked pg client so
+ * the BEGIN/COMMIT/ROLLBACK flow, validation, missing-label check,
+ * and error path all get real coverage. Pure-validation tests for
+ * the validateMergeRequest helper live alongside in this file.
+ *
+ * @jest-environment node
  */
+const mockClientQuery = jest.fn();
+const mockClientRelease = jest.fn();
+const mockConnect = jest.fn();
 
+jest.mock("@/lib/db", () => ({
+  __esModule: true,
+  default: { connect: mockConnect },
+}));
+
+import { NextRequest } from "next/server";
 import { validateMergeRequest } from "@/lib/validateMergeRequest";
 
-describe("speaker merge validation", () => {
+type RouteModule = typeof import("@/app/api/episodes/[id]/speakers/merge/route");
+let POST: RouteModule["POST"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import(
+    "@/app/api/episodes/[id]/speakers/merge/route"
+  );
+  POST = mod.POST;
+});
+
+beforeEach(() => {
+  mockClientQuery.mockReset();
+  mockClientRelease.mockReset();
+  mockConnect.mockReset();
+  mockConnect.mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+});
+
+function call(id: string, bodyText: string | null) {
+  const req = new NextRequest(
+    `http://localhost/api/episodes/${id}/speakers/merge`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: bodyText ?? "",
+    }
+  );
+  return POST(req, { params: Promise.resolve({ id }) });
+}
+
+describe("validateMergeRequest (pure)", () => {
   test("valid request passes", () => {
-    const result = validateMergeRequest({
-      source_labels: ["SPEAKER_01"],
-      target_label: "SPEAKER_00",
+    expect(
+      validateMergeRequest({
+        source_labels: ["SPEAKER_01"],
+        target_label: "SPEAKER_00",
+      })
+    ).toBeNull();
+  });
+
+  test("missing source_labels rejected", () => {
+    expect(validateMergeRequest({ target_label: "SPEAKER_00" })).toEqual({
+      error: "source_labels must be a non-empty array",
     });
-    expect(result).toBeNull();
   });
 
-  test("missing source_labels returns error", () => {
-    const result = validateMergeRequest({ target_label: "SPEAKER_00" });
-    expect(result).toEqual({ error: "source_labels must be a non-empty array" });
+  test("non-string element in source_labels rejected", () => {
+    expect(
+      validateMergeRequest({
+        source_labels: ["SPEAKER_01", 42],
+        target_label: "SPEAKER_00",
+      })
+    ).toEqual({ error: "source_labels must contain non-empty strings" });
   });
 
-  test("empty source_labels returns error", () => {
-    const result = validateMergeRequest({
-      source_labels: [],
-      target_label: "SPEAKER_00",
+  test("target_label present in source_labels rejected", () => {
+    expect(
+      validateMergeRequest({
+        source_labels: ["SPEAKER_00"],
+        target_label: "SPEAKER_00",
+      })
+    ).toEqual({ error: "target_label must not appear in source_labels" });
+  });
+});
+
+describe("POST /api/episodes/[id]/speakers/merge", () => {
+  it("returns 400 on invalid JSON", async () => {
+    const resp = await call("ep-1", "{not json");
+    expect(resp.status).toBe(400);
+    expect(await resp.json()).toEqual({ error: "Invalid JSON" });
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when validation fails (skipping DB)", async () => {
+    const resp = await call(
+      "ep-1",
+      JSON.stringify({ source_labels: [], target_label: "SPEAKER_00" })
+    );
+    expect(resp.status).toBe(400);
+    expect(await resp.json()).toEqual({
+      error: "source_labels must be a non-empty array",
     });
-    expect(result).toEqual({ error: "source_labels must be a non-empty array" });
+    expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  test("non-string element in source_labels returns error", () => {
-    const result = validateMergeRequest({
-      source_labels: ["SPEAKER_01", 42],
-      target_label: "SPEAKER_00",
+  it("commits and reassigns segments on happy path", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (/^BEGIN/.test(sql)) return Promise.resolve({});
+      if (/SELECT DISTINCT speaker_label/.test(sql)) {
+        return Promise.resolve({
+          rows: [
+            { speaker_label: "SPEAKER_00" },
+            { speaker_label: "SPEAKER_01" },
+          ],
+        });
+      }
+      if (/^UPDATE segments/.test(sql)) return Promise.resolve({ rowCount: 42 });
+      if (/^DELETE FROM speaker_names/.test(sql)) return Promise.resolve({});
+      if (/^COMMIT/.test(sql)) return Promise.resolve({});
+      return Promise.resolve({});
     });
-    expect(result).toEqual({ error: "source_labels must contain non-empty strings" });
+
+    const resp = await call(
+      "ep-1",
+      JSON.stringify({
+        source_labels: ["SPEAKER_01"],
+        target_label: "SPEAKER_00",
+      })
+    );
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ ok: true, merged_segments: 42 });
+
+    const sqlStatements = mockClientQuery.mock.calls.map((c) => c[0]);
+    expect(sqlStatements[0]).toBe("BEGIN");
+    expect(sqlStatements.some((s) => /^UPDATE segments/.test(s))).toBe(true);
+    expect(sqlStatements.some((s) => /^DELETE FROM speaker_names/.test(s))).toBe(
+      true
+    );
+    expect(sqlStatements[sqlStatements.length - 1]).toBe("COMMIT");
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
   });
 
-  test("missing target_label returns error", () => {
-    const result = validateMergeRequest({ source_labels: ["SPEAKER_01"] });
-    expect(result).toEqual({ error: "target_label must be a non-empty string" });
-  });
-
-  test("empty target_label returns error", () => {
-    const result = validateMergeRequest({
-      source_labels: ["SPEAKER_01"],
-      target_label: "",
+  it("rolls back and returns 400 when a label is missing from episode", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (/^BEGIN/.test(sql)) return Promise.resolve({});
+      if (/SELECT DISTINCT speaker_label/.test(sql)) {
+        return Promise.resolve({ rows: [{ speaker_label: "SPEAKER_00" }] });
+      }
+      if (/^ROLLBACK/.test(sql)) return Promise.resolve({});
+      return Promise.resolve({});
     });
-    expect(result).toEqual({ error: "target_label must be a non-empty string" });
+
+    const resp = await call(
+      "ep-1",
+      JSON.stringify({
+        source_labels: ["SPEAKER_99"],
+        target_label: "SPEAKER_00",
+      })
+    );
+
+    expect(resp.status).toBe(400);
+    expect(await resp.json()).toEqual({
+      error: "Labels not found in episode: SPEAKER_99",
+    });
+    const sqlStatements = mockClientQuery.mock.calls.map((c) => c[0]);
+    expect(sqlStatements).toContain("ROLLBACK");
+    expect(sqlStatements).not.toContain("COMMIT");
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
   });
 
-  test("target_label in source_labels returns error", () => {
-    const result = validateMergeRequest({
-      source_labels: ["SPEAKER_00", "SPEAKER_01"],
-      target_label: "SPEAKER_00",
+  it("rolls back and returns 500 when an inner query throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (/^BEGIN/.test(sql)) return Promise.resolve({});
+      if (/SELECT DISTINCT speaker_label/.test(sql)) {
+        return Promise.resolve({
+          rows: [
+            { speaker_label: "SPEAKER_00" },
+            { speaker_label: "SPEAKER_01" },
+          ],
+        });
+      }
+      if (/^UPDATE segments/.test(sql)) {
+        return Promise.reject(new Error("deadlock"));
+      }
+      if (/^ROLLBACK/.test(sql)) return Promise.resolve({});
+      return Promise.resolve({});
     });
-    expect(result).toEqual({ error: "target_label must not appear in source_labels" });
+
+    const resp = await call(
+      "ep-1",
+      JSON.stringify({
+        source_labels: ["SPEAKER_01"],
+        target_label: "SPEAKER_00",
+      })
+    );
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ error: "Failed to merge speakers" });
+    expect(mockClientQuery.mock.calls.map((c) => c[0])).toContain("ROLLBACK");
+    expect(mockClientRelease).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
   });
 
-  test("non-array source_labels returns error", () => {
-    const result = validateMergeRequest({
-      source_labels: "SPEAKER_01",
-      target_label: "SPEAKER_00",
+  it("defaults merged_segments to 0 when UPDATE rowCount is null", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (/^BEGIN/.test(sql)) return Promise.resolve({});
+      if (/SELECT DISTINCT speaker_label/.test(sql)) {
+        return Promise.resolve({
+          rows: [
+            { speaker_label: "SPEAKER_00" },
+            { speaker_label: "SPEAKER_01" },
+          ],
+        });
+      }
+      if (/^UPDATE segments/.test(sql)) return Promise.resolve({ rowCount: null });
+      return Promise.resolve({});
     });
-    expect(result).toEqual({ error: "source_labels must be a non-empty array" });
+
+    const resp = await call(
+      "ep-1",
+      JSON.stringify({
+        source_labels: ["SPEAKER_01"],
+        target_label: "SPEAKER_00",
+      })
+    );
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ ok: true, merged_segments: 0 });
   });
 });


### PR DESCRIPTION
## Summary

Fourth slice of #489. This is the one that crosses the 60% lines threshold from the audit.

## Routes covered

| Route | Shape | Coverage |
|---|---|---|
| `api/episodes/ingest` | POST JSON proxy | 100% |
| `api/episodes/upload` | POST formData proxy | 100% |
| `api/episodes/[id]/speakers` | PUT — DB upsert (inferred=false, confirmed_by_user=true) | 100% |
| `api/episodes/[id]/speakers/merge` | POST — transactional handler | 100% |

## Highlights

- **Speakers PUT** asserts the full SQL contract: upsert, inferred flag cleared, confirmation flag set, trim, 400s, 500 on DB error.
- **Speakers merge POST** replaces the old test-only `validateMergeRequest` coverage with real handler tests. Mocks a pg client to exercise the full transactional flow: BEGIN → SELECT → UPDATE → DELETE → COMMIT, plus ROLLBACK paths on missing-label validation and inner-query throws. Verifies `release()` always fires.

## Coverage impact

Overall web suite:
- Lines: **53.03% → 60.59%** (crosses audit's 60% target)
- Statements: 51.56% → 58.65% (still below 60%, follow-up PRs)
- Full suite: 258/258 pass (was 241)

## Remaining on #489

Still at 0%: `api/pipeline/ask` (SSE streaming — trickier), several pages (server components), and UI components. Subsequent PRs will push statement coverage over 60 as well.

Refs #489