### PR TITLE
test(web): cover simple components, pages, and grouping helper (#489)

### DIFF
--- a/apps/web/tests/unit/about-page.test.tsx
+++ b/apps/web/tests/unit/about-page.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for the server-component /about page.
+ *
+ * The page reads docs/about.md from disk. We mock fs/promises to
+ * exercise both the success path (markdown shown via a stubbed
+ * ReactMarkdown) and the fallback path (file missing → "Could not
+ * load" message). react-markdown + remark/rehype are ESM-only; we
+ * stub them to a plain renderer that exposes the link-mapper logic
+ * the page defines.
+ */
+const mockReadFile = jest.fn();
+jest.mock("fs/promises", () => ({ readFile: mockReadFile }));
+
+type LinkProps = {
+  href?: string;
+  children?: React.ReactNode;
+};
+type ComponentsMap = { a?: (p: LinkProps) => React.ReactElement };
+type MarkdownProps = { components?: ComponentsMap; children?: string };
+
+jest.mock(
+  "react-markdown",
+  () => ({
+    __esModule: true,
+    default: ({ children, components }: MarkdownProps) => {
+      const Link = components?.a;
+      const text = children ?? "";
+      const linkMatch = /\[([^\]]+)\]\(([^)]+)\)/.exec(text);
+      return (
+        <div data-testid="markdown">
+          {linkMatch && Link
+            ? Link({ href: linkMatch[2], children: linkMatch[1] })
+            : text}
+        </div>
+      );
+    },
+  }),
+  { virtual: true }
+);
+jest.mock("remark-gfm", () => ({ __esModule: true, default: () => null }), {
+  virtual: true,
+});
+jest.mock("rehype-raw", () => ({ __esModule: true, default: () => null }), {
+  virtual: true,
+});
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+type PageModule = typeof import("@/app/about/page");
+let AboutPage: PageModule["default"];
+
+beforeAll(async () => {
+  const mod: PageModule = await import("@/app/about/page");
+  AboutPage = mod.default;
+});
+
+beforeEach(() => {
+  mockReadFile.mockReset();
+});
+
+describe("<AboutPage>", () => {
+  it("marks external links with target=_blank and rel=noopener", async () => {
+    mockReadFile.mockResolvedValue("See [example](https://example.com/x).");
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    const link = screen.getByRole("link", { name: "example" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not set target/rel for relative links", async () => {
+    mockReadFile.mockResolvedValue("See [docs](/docs) for more.");
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    const link = screen.getByRole("link", { name: "docs" });
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+  });
+
+  it("renders the fallback block when about.md is missing", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    expect(screen.getByRole("heading", { name: "About" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Could not load the About page.")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/notifications-redirect.test.ts
+++ b/apps/web/tests/unit/notifications-redirect.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment node
+ */
+const mockRedirect = jest.fn();
+jest.mock("next/navigation", () => ({ redirect: mockRedirect }));
+
+type PageModule = typeof import("@/app/notifications/page");
+let NotificationsPage: PageModule["default"];
+
+beforeAll(async () => {
+  const mod: PageModule = await import("@/app/notifications/page");
+  NotificationsPage = mod.default;
+});
+
+beforeEach(() => {
+  mockRedirect.mockReset();
+});
+
+describe("/notifications page", () => {
+  it("redirects to /settings", () => {
+    NotificationsPage();
+    expect(mockRedirect).toHaveBeenCalledWith("/settings");
+    expect(mockRedirect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/unit/search-grouping.test.ts
+++ b/apps/web/tests/unit/search-grouping.test.ts
@@ -1,0 +1,74 @@
+import { groupRowsByFeed } from "@/lib/search/grouping";
+
+type Row = Parameters<typeof groupRowsByFeed>[0][number];
+
+function row(overrides: Partial<Row>): Row {
+  return {
+    feed_id: "feed-1",
+    feed_title: "Feed One",
+    feed_mode: "full",
+    episode_id: "ep-1",
+    episode_title: "Ep Title",
+    audio_url: "https://example.com/ep-1.mp3",
+    audio_local_path: "/data/audio/archive/ep-1.mp3",
+    episode_url: "https://example.com/ep-1",
+    mention_count: 1,
+    best_rank: "0.5",
+    ...overrides,
+  };
+}
+
+describe("groupRowsByFeed", () => {
+  it("returns an empty array for empty input", () => {
+    expect(groupRowsByFeed([])).toEqual([]);
+  });
+
+  it("groups rows by feed and sums mention counts within each group", () => {
+    const groups = groupRowsByFeed([
+      row({ feed_id: "feed-1", episode_id: "ep-1", mention_count: 3 }),
+      row({ feed_id: "feed-1", episode_id: "ep-2", mention_count: 2 }),
+      row({ feed_id: "feed-2", feed_title: "Feed Two", episode_id: "ep-3", mention_count: 5 }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const byId = Object.fromEntries(groups.map((g) => [g.feedId, g]));
+    expect(byId["feed-1"].mentionCount).toBe(5);
+    expect(byId["feed-1"].episodes).toHaveLength(2);
+    expect(byId["feed-2"].mentionCount).toBe(5);
+    expect(byId["feed-2"].episodes).toHaveLength(1);
+  });
+
+  it("parses best_rank string into a number", () => {
+    const [group] = groupRowsByFeed([row({ best_rank: "0.1234" })]);
+    expect(group.episodes[0].bestRank).toBeCloseTo(0.1234, 6);
+    expect(typeof group.episodes[0].bestRank).toBe("number");
+  });
+
+  it("groups null feed_id rows together under the __manual__ key", () => {
+    const groups = groupRowsByFeed([
+      row({ feed_id: null, feed_title: "Manual episode", episode_id: "ep-m1", mention_count: 1 }),
+      row({ feed_id: null, feed_title: "Manual episode", episode_id: "ep-m2", mention_count: 2 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].mentionCount).toBe(3);
+    expect(groups[0].episodes.map((e) => e.episodeId)).toEqual(["ep-m1", "ep-m2"]);
+  });
+
+  it("preserves all per-episode fields from the source rows", () => {
+    const [group] = groupRowsByFeed([
+      row({
+        episode_id: "ep-9",
+        episode_title: "Nine",
+        audio_url: "https://ex/9.mp3",
+        audio_local_path: "/data/audio/raw/9.mp3",
+        episode_url: "https://ex/9",
+      }),
+    ]);
+    const ep = group.episodes[0];
+    expect(ep.episodeId).toBe("ep-9");
+    expect(ep.episodeTitle).toBe("Nine");
+    expect(ep.audioUrl).toBe("https://ex/9.mp3");
+    expect(ep.audioLocalPath).toBe("/data/audio/raw/9.mp3");
+    expect(ep.episodeUrl).toBe("https://ex/9");
+  });
+});

--- a/apps/web/tests/unit/search-no-results.test.tsx
+++ b/apps/web/tests/unit/search-no-results.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import SearchNoResults from "@/components/SearchNoResults";
+
+describe("<SearchNoResults>", () => {
+  it("renders the user's query in curly quotes", () => {
+    render(<SearchNoResults query="jazz" />);
+    expect(screen.getByText(/No results for/)).toHaveTextContent(
+      "No results for \u201Cjazz\u201D"
+    );
+  });
+
+  it("renders the search-tip line", () => {
+    render(<SearchNoResults query="x" />);
+    expect(
+      screen.getByText(/Try checking your spelling, or use broader search terms\./)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/skeleton.test.tsx
+++ b/apps/web/tests/unit/skeleton.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+describe("<Skeleton>", () => {
+  it("renders a div with default animate-pulse classes", () => {
+    const { container } = render(<Skeleton data-testid="sk" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.tagName).toBe("DIV");
+    expect(el.className).toContain("animate-pulse");
+    expect(el.className).toContain("rounded-md");
+    expect(el.className).toContain("bg-muted");
+  });
+
+  it("merges custom className with defaults", () => {
+    const { container } = render(<Skeleton className="w-10 h-4" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("w-10");
+    expect(el.className).toContain("h-4");
+    expect(el.className).toContain("animate-pulse");
+  });
+
+  it("forwards extra props (e.g. aria-label) to the underlying div", () => {
+    const { container } = render(<Skeleton aria-label="loading" role="status" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("loading");
+    expect(el.getAttribute("role")).toBe("status");
+  });
+});


### PR DESCRIPTION
## Summary

Fifth slice of #489. Covers 5 low-hanging 0%-coverage files: two small components, two pages (one redirect, one markdown-rendering server component), and a pure grouping helper.

## Files covered

| File | Kind | Notes |
|---|---|---|
| `components/ui/skeleton.tsx` | shadcn primitive | class merging, prop forwarding |
| `components/SearchNoResults.tsx` | static UI | query echoed in curly quotes |
| `app/notifications/page.tsx` | redirect page | verifies `redirect("/settings")` |
| `app/about/page.tsx` | server component | fs.readFile success + fallback; external vs relative link rules |
| `lib/search/grouping.ts` | pure helper | empty input, multi-feed aggregation, rank coercion, null-feed `__manual__` bucket, field preservation |

## Note on about-page

`react-markdown`, `remark-gfm`, and `rehype-raw` are ESM-only and crash Jest's CJS transform when loaded for real. The test stubs them via `jest.mock("react-markdown", () => ..., { virtual: true })` so the page's own logic (link mapper that sets `target=_blank` + `rel=noopener noreferrer` for external URLs and leaves relative hrefs untouched) gets exercised without pulling the ESM runtime in.

## Coverage impact

Overall web suite:
- **Lines**: 60.59% → 61.57%
- **Statements**: 58.65% → 59.54%
- Full suite: 272/272 pass (was 258)

Refs #489