### PR TITLE
test(web): cover FeedCard and FeedsListSection (#489)

### DIFF
--- a/apps/web/tests/unit/feed-card.test.tsx
+++ b/apps/web/tests/unit/feed-card.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import FeedCard from "@/components/FeedCard";
+
+type Feed = Parameters<typeof FeedCard>[0]["feed"];
+
+function makeFeed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    id: "feed-1",
+    url: "https://example.com/rss.xml",
+    title: "Example Feed",
+    mode: "full",
+    last_polled_at: null,
+    episode_count: 12,
+    ...overrides,
+  };
+}
+
+function renderCard(feed: Feed, pollPending = false) {
+  const onPromote = jest.fn();
+  const onPoll = jest.fn();
+  const onDelete = jest.fn();
+  const result = render(
+    <FeedCard
+      feed={feed}
+      pollPending={pollPending}
+      onPromote={onPromote}
+      onPoll={onPoll}
+      onDelete={onDelete}
+    />
+  );
+  return { onPromote, onPoll, onDelete, ...result };
+}
+
+describe("<FeedCard>", () => {
+  it("renders the feed title when present, otherwise the URL", () => {
+    const { rerender } = renderCard(makeFeed({ title: "My Podcast" }));
+    expect(screen.getByText("My Podcast")).toBeInTheDocument();
+
+    rerender(
+      <FeedCard
+        feed={makeFeed({ title: null, url: "https://ex.com/x.xml" })}
+        pollPending={false}
+        onPromote={jest.fn()}
+        onPoll={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    expect(screen.getAllByText("https://ex.com/x.xml")[0]).toBeInTheDocument();
+  });
+
+  it("shows 'Never polled' when last_polled_at is null", () => {
+    renderCard(makeFeed({ last_polled_at: null, episode_count: 5 }));
+    expect(screen.getByText(/5 episodes · Never polled/)).toBeInTheDocument();
+  });
+
+  it("formats last_polled_at with toLocaleString when set", () => {
+    const when = "2026-04-18T10:30:00Z";
+    renderCard(makeFeed({ last_polled_at: when, episode_count: 1 }));
+    const expected = new Date(when).toLocaleString();
+    expect(screen.getByText(new RegExp(`Last polled ${expected.replace(/[\\/.*+?^${}()|[\]]/g, "\\$&")}`))).toBeInTheDocument();
+  });
+
+  it("renders Test badge only when mode=test", () => {
+    renderCard(makeFeed({ mode: "test" }));
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.queryByText("Selective")).not.toBeInTheDocument();
+  });
+
+  it("renders Selective badge only when mode=selective", () => {
+    renderCard(makeFeed({ mode: "selective" }));
+    expect(screen.getByText("Selective")).toBeInTheDocument();
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+  });
+
+  it("shows Promote button only for test and selective modes", () => {
+    const { rerender } = renderCard(makeFeed({ mode: "full" }));
+    expect(screen.queryByRole("button", { name: /Promote to Full/ })).not.toBeInTheDocument();
+
+    for (const mode of ["test", "selective"]) {
+      rerender(
+        <FeedCard
+          feed={makeFeed({ mode })}
+          pollPending={false}
+          onPromote={jest.fn()}
+          onPoll={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      );
+      expect(
+        screen.getByRole("button", { name: /Promote to Full/ })
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("hides Poll button for selective mode; shows it otherwise", () => {
+    const { rerender } = renderCard(makeFeed({ mode: "selective" }));
+    expect(screen.queryByRole("button", { name: "Poll now" })).not.toBeInTheDocument();
+
+    rerender(
+      <FeedCard
+        feed={makeFeed({ mode: "full" })}
+        pollPending={false}
+        onPromote={jest.fn()}
+        onPoll={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Poll now" })).toBeInTheDocument();
+  });
+
+  it("disables poll button and spins icon when pollPending", () => {
+    renderCard(makeFeed({ mode: "full" }), true);
+    const pollBtn = screen.getByRole("button", { name: "Poll now" });
+    expect(pollBtn).toBeDisabled();
+    expect(pollBtn.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+      "animate-spin"
+    );
+  });
+
+  it("invokes the callbacks with the right arguments", () => {
+    const { onPromote, onPoll, onDelete } = renderCard(
+      makeFeed({ mode: "test", url: "https://ex.com/y.xml", id: "feed-42" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Promote to Full/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Poll now" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove feed" }));
+
+    expect(onPromote).toHaveBeenCalledWith("https://ex.com/y.xml");
+    expect(onPoll).toHaveBeenCalledWith("feed-42");
+    expect(onDelete).toHaveBeenCalledWith("feed-42");
+  });
+});

--- a/apps/web/tests/unit/feeds-list-section.test.tsx
+++ b/apps/web/tests/unit/feeds-list-section.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import FeedsListSection from "@/components/FeedsListSection";
+
+type Feed = Parameters<typeof FeedsListSection>[0]["feeds"][number];
+
+function feed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    id: "feed-1",
+    url: "https://ex.com/rss.xml",
+    title: "F1",
+    mode: "full",
+    last_polled_at: null,
+    episode_count: 1,
+    ...overrides,
+  };
+}
+
+function renderSection(overrides: Partial<React.ComponentProps<typeof FeedsListSection>> = {}) {
+  const onAddFirstFeed = jest.fn();
+  const onPromote = jest.fn();
+  const onPoll = jest.fn();
+  const onDelete = jest.fn();
+
+  const result = render(
+    <FeedsListSection
+      isLoading={false}
+      feeds={[]}
+      pollPendingId={null}
+      onAddFirstFeed={onAddFirstFeed}
+      onPromote={onPromote}
+      onPoll={onPoll}
+      onDelete={onDelete}
+      {...overrides}
+    />
+  );
+  return { onAddFirstFeed, onPromote, onPoll, onDelete, ...result };
+}
+
+describe("<FeedsListSection>", () => {
+  it("renders skeleton rows when loading", () => {
+    const { container } = renderSection({ isLoading: true });
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBe(9);
+  });
+
+  it("renders an empty state + 'Add your first RSS feed' button when no feeds", () => {
+    const { onAddFirstFeed } = renderSection({ feeds: [] });
+    expect(screen.getByText(/No feeds yet\./)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Add your first RSS feed/ }));
+    expect(onAddFirstFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a FeedCard for each feed", () => {
+    renderSection({
+      feeds: [feed({ id: "a", title: "A" }), feed({ id: "b", title: "B" })],
+    });
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("passes pollPending=true only for the feed whose id matches pollPendingId", () => {
+    renderSection({
+      feeds: [
+        feed({ id: "a", title: "A", mode: "full" }),
+        feed({ id: "b", title: "B", mode: "full" }),
+      ],
+      pollPendingId: "a",
+    });
+    const pollButtons = screen.getAllByRole("button", { name: "Poll now" });
+    expect(pollButtons).toHaveLength(2);
+    expect(pollButtons[0]).toBeDisabled();
+    expect(pollButtons[1]).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Sixth and final slice of #489. Adds tests for two UI components and, together with the prior 5 PRs, pushes web coverage above the 60% audit threshold on both statements **and** lines.

## Components covered

| Component | Coverage points |
|---|---|
| `FeedCard` | Test/Selective badge visibility, Promote-button visibility rule, Poll-button hidden for selective, pollPending disables button + spins icon, Never-polled vs toLocaleString text, callback wiring (`onPromote(url)`, `onPoll(id)`, `onDelete(id)`) |
| `FeedsListSection` | Skeleton rows during load, empty-state CTA wiring, FeedCard per feed, per-feed pollPending routing |

## Coverage impact (full web suite)

|  | Before #489 work | After this PR |
|---|---|---|
| Lines | 53.03% | **62.13%** |
| Statements | 51.56% | **60.05%** |
| Tests | 195 | **285** |

Both statements and lines are now above the 60% threshold called out in the audit.

## Remaining follow-ups

Per the audit, other 0%-coverage files remain (`api/pipeline/ask` SSE, `app/feeds`, `app/queue`, `app/settings`, `app/docs`, `components/AudioUpload`, `components/EpisodeDescription`, `components/TranscriptSection`, `components/UploadsSection`). #489 can be closed on the threshold metric; these are incremental improvements rather than threshold-blocking work.

Refs #489