### PR TITLE
feat(feeds): add more episodes to selective feeds (#487)

### DIFF
--- a/apps/pipeline/app/api/feeds.py
+++ b/apps/pipeline/app/api/feeds.py
@@ -1,11 +1,13 @@
 """
 Feed management API — control-plane endpoints.
 
-GET    /api/feeds             List feeds with episode counts
-GET    /api/feeds/preview     Preview a feed URL (returns metadata + episodes, no DB writes)
-POST   /api/feeds             Add a new RSS feed (with validation — GAP-02)
-DELETE /api/feeds/{id}        Remove a feed (optionally delete episodes)
-POST   /api/feeds/{id}/poll   Trigger immediate re-poll
+GET    /api/feeds                       List feeds with episode counts
+GET    /api/feeds/preview               Preview a feed URL (returns metadata + episodes, no DB writes)
+POST   /api/feeds                       Add a new RSS feed (with validation — GAP-02)
+DELETE /api/feeds/{id}                  Remove a feed (optionally delete episodes)
+POST   /api/feeds/{id}/poll             Trigger immediate re-poll
+GET    /api/feeds/{id}/episodes/guids   List GUIDs already ingested for a feed (#487)
+POST   /api/feeds/{id}/episodes         Add more episodes to a selective feed (#487)
 """
 import logging
 from datetime import datetime
@@ -17,7 +19,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Feed
+from app.models import Episode, Feed
 from app.services import rss as rss_service
 from app.tasks.ingest import ingest_feed as _ingest_feed
 
@@ -232,3 +234,80 @@ def poll_feed(feed_id: str, db: Session = Depends(get_db)) -> dict:
         )
     _ingest_feed(feed.id)
     return {"queued": True}
+
+
+class AddEpisodesRequest(BaseModel):
+    selected_guids: list[str]
+
+
+class AddEpisodesResponse(BaseModel):
+    queued: int
+    skipped: int
+
+
+@router.get("/feeds/{feed_id}/episodes/guids", response_model=list[str])
+def list_feed_episode_guids(feed_id: str, db: Session = Depends(get_db)) -> list[str]:
+    """
+    Return the GUIDs of episodes already ingested for this feed.
+    Used by the web UI (#487) to mark already-selected episodes in the
+    "Add more episodes" preview dialog.
+    """
+    feed = db.query(Feed).filter(Feed.id == feed_id).first()
+    if not feed:
+        raise HTTPException(status_code=404, detail="Feed not found")
+    rows = db.query(Episode.guid).filter(Episode.feed_id == feed_id).all()
+    return [row[0] for row in rows]
+
+
+@router.post("/feeds/{feed_id}/episodes", response_model=AddEpisodesResponse, status_code=202)
+def add_feed_episodes(
+    feed_id: str,
+    body: AddEpisodesRequest,
+    db: Session = Depends(get_db),
+) -> AddEpisodesResponse:
+    """
+    Add more episodes to an existing selective feed (#487).
+
+    Only valid for selective-mode feeds. GUIDs already ingested are silently
+    skipped (idempotent). Unknown GUIDs (not present in the live feed) cause
+    a 422, matching the validation performed by ingest_feed itself.
+    """
+    feed = db.query(Feed).filter(Feed.id == feed_id).first()
+    if not feed:
+        raise HTTPException(status_code=404, detail="Feed not found")
+    if feed.mode != "selective":
+        raise HTTPException(
+            status_code=422,
+            detail="Only selective feeds support adding specific episodes. "
+                   "Full feeds auto-ingest all episodes; test feeds should be promoted first.",
+        )
+    if not body.selected_guids:
+        raise HTTPException(
+            status_code=422,
+            detail="selected_guids is required and must be non-empty",
+        )
+
+    existing_guids = {
+        row[0]
+        for row in db.query(Episode.guid).filter(Episode.feed_id == feed_id).all()
+    }
+    new_guids = [g for g in body.selected_guids if g not in existing_guids]
+    skipped = len(body.selected_guids) - len(new_guids)
+
+    if not new_guids:
+        logger.info(
+            '"action": "add_feed_episodes_noop", "feed_id": "%s", "skipped": %d',
+            feed_id, skipped,
+        )
+        return AddEpisodesResponse(queued=0, skipped=skipped)
+
+    result = _ingest_feed(feed_id, selected_guids=new_guids)
+    if isinstance(result, dict) and result.get("error"):
+        raise HTTPException(status_code=422, detail=result["error"])
+
+    queued = int(result.get("new_episodes", 0)) if isinstance(result, dict) else 0
+    logger.info(
+        '"action": "feed_episodes_added", "feed_id": "%s", "queued": %d, "skipped": %d',
+        feed_id, queued, skipped,
+    )
+    return AddEpisodesResponse(queued=queued, skipped=skipped)

--- a/apps/pipeline/tests/unit/test_api.py
+++ b/apps/pipeline/tests/unit/test_api.py
@@ -191,6 +191,190 @@ class TestFeedsEndpoint:
             app.dependency_overrides.clear()
 
 
+class TestAddFeedEpisodesEndpoint:
+    """Issue #487: POST /api/feeds/{id}/episodes — add more episodes to a selective feed."""
+
+    def _setup_db(self, feed_mode: str | None, existing_guids: list[str]):
+        """
+        Build a mock DB whose `query(Feed)` returns the feed mock and
+        `query(Episode.guid)` returns the list of existing GUID rows.
+        feed_mode=None → feed not found.
+        """
+        from app.models import Episode, Feed
+
+        mock_db = MagicMock()
+
+        feed_mock = None
+        if feed_mode is not None:
+            feed_mock = MagicMock()
+            feed_mock.id = "feed-1"
+            feed_mock.mode = feed_mode
+
+        def _query(model):
+            q = MagicMock()
+            if model is Feed:
+                q.filter.return_value.first.return_value = feed_mock
+            elif model is Episode.guid:
+                q.filter.return_value.all.return_value = [(g,) for g in existing_guids]
+            else:
+                q.filter.return_value.first.return_value = None
+                q.filter.return_value.all.return_value = []
+            return q
+
+        mock_db.query.side_effect = _query
+        return mock_db
+
+    def _override_db(self, mock_db):
+        from app.database import get_db
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+    def test_feed_not_found_returns_404(self):
+        self._override_db(self._setup_db(feed_mode=None, existing_guids=[]))
+        try:
+            resp = client.post(
+                "/api/feeds/missing/episodes",
+                json={"selected_guids": ["a"]},
+            )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_non_selective_feed_returns_422(self):
+        self._override_db(self._setup_db(feed_mode="full", existing_guids=[]))
+        try:
+            resp = client.post(
+                "/api/feeds/feed-1/episodes",
+                json={"selected_guids": ["a"]},
+            )
+            assert resp.status_code == 422
+            assert "selective" in resp.json()["detail"].lower()
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_empty_guids_returns_422(self):
+        self._override_db(self._setup_db(feed_mode="selective", existing_guids=[]))
+        try:
+            resp = client.post(
+                "/api/feeds/feed-1/episodes",
+                json={"selected_guids": []},
+            )
+            assert resp.status_code == 422
+            assert "selected_guids" in resp.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_all_guids_already_ingested_returns_zero_queued(self):
+        """No call to ingest_feed when every requested GUID already exists."""
+        self._override_db(
+            self._setup_db(feed_mode="selective", existing_guids=["ep-001", "ep-002"])
+        )
+        try:
+            with patch("app.api.feeds._ingest_feed") as mock_ingest:
+                resp = client.post(
+                    "/api/feeds/feed-1/episodes",
+                    json={"selected_guids": ["ep-001", "ep-002"]},
+                )
+            assert resp.status_code == 202
+            body = resp.json()
+            assert body == {"queued": 0, "skipped": 2}
+            mock_ingest.assert_not_called()
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_new_guids_enqueued_existing_skipped(self):
+        """Only net-new GUIDs are passed to ingest_feed; already-ingested ones count as skipped."""
+        self._override_db(
+            self._setup_db(feed_mode="selective", existing_guids=["ep-001"])
+        )
+        try:
+            with patch(
+                "app.api.feeds._ingest_feed",
+                return_value={"new_episodes": 2},
+            ) as mock_ingest:
+                resp = client.post(
+                    "/api/feeds/feed-1/episodes",
+                    json={"selected_guids": ["ep-001", "ep-002", "ep-003"]},
+                )
+            assert resp.status_code == 202
+            assert resp.json() == {"queued": 2, "skipped": 1}
+            mock_ingest.assert_called_once_with(
+                "feed-1", selected_guids=["ep-002", "ep-003"]
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_invalid_guid_from_ingest_returns_422(self):
+        """If ingest_feed reports an invalid GUID, bubble up as 422."""
+        self._override_db(
+            self._setup_db(feed_mode="selective", existing_guids=[])
+        )
+        try:
+            with patch(
+                "app.api.feeds._ingest_feed",
+                return_value={"error": "selected_guids contains GUIDs not present in feed"},
+            ):
+                resp = client.post(
+                    "/api/feeds/feed-1/episodes",
+                    json={"selected_guids": ["not-in-feed"]},
+                )
+            assert resp.status_code == 422
+            assert "not present" in resp.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+
+
+class TestListFeedEpisodeGuidsEndpoint:
+    """Issue #487: GET /api/feeds/{id}/episodes/guids."""
+
+    def test_returns_guids_for_feed(self):
+        from app.models import Episode, Feed
+
+        mock_db = MagicMock()
+        feed_mock = MagicMock()
+        feed_mock.id = "feed-1"
+        feed_mock.mode = "selective"
+
+        def _query(model):
+            q = MagicMock()
+            if model is Feed:
+                q.filter.return_value.first.return_value = feed_mock
+            elif model is Episode.guid:
+                q.filter.return_value.all.return_value = [("ep-001",), ("ep-002",)]
+            return q
+
+        mock_db.query.side_effect = _query
+
+        from app.database import get_db
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = client.get("/api/feeds/feed-1/episodes/guids")
+            assert resp.status_code == 200
+            assert resp.json() == ["ep-001", "ep-002"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_unknown_feed_returns_404(self):
+        from app.models import Feed
+
+        mock_db = MagicMock()
+
+        def _query(model):
+            q = MagicMock()
+            if model is Feed:
+                q.filter.return_value.first.return_value = None
+            return q
+
+        mock_db.query.side_effect = _query
+
+        from app.database import get_db
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            resp = client.get("/api/feeds/missing/episodes/guids")
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+
 class TestDeleteEpisodeEndpoint:
     """Issue #454: manually uploaded episodes need a delete endpoint."""
 

--- a/apps/web/src/app/api/feeds/[id]/episodes/guids/route.ts
+++ b/apps/web/src/app/api/feeds/[id]/episodes/guids/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { PIPELINE_API } from "@/lib/pipeline";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    const resp = await fetch(`${PIPELINE_API}/api/feeds/${id}/episodes/guids`);
+    const text = await resp.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { detail: text || "Pipeline API returned a non-JSON error" };
+    }
+    return NextResponse.json(data, { status: resp.status });
+  } catch (err) {
+    console.error("Feed episode GUIDs error:", err);
+    return NextResponse.json(
+      { error: "Failed to load feed episodes" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/feeds/[id]/episodes/route.ts
+++ b/apps/web/src/app/api/feeds/[id]/episodes/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PIPELINE_API } from "@/lib/pipeline";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const resp = await fetch(`${PIPELINE_API}/api/feeds/${id}/episodes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const text = await resp.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { detail: text || "Pipeline API returned a non-JSON error" };
+    }
+    return NextResponse.json(data, { status: resp.status });
+  } catch (err) {
+    console.error("Add feed episodes error:", err);
+    return NextResponse.json(
+      { error: "Failed to add episodes" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/feeds/page.tsx
+++ b/apps/web/src/app/feeds/page.tsx
@@ -52,6 +52,15 @@ async function fetchPreview(url: string): Promise<FeedPreview> {
   return resp.json();
 }
 
+async function fetchFeedEpisodeGuids(feedId: string): Promise<string[]> {
+  const resp = await fetch(`/api/feeds/${feedId}/episodes/guids`);
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.detail ?? "Failed to load existing episodes");
+  }
+  return resp.json();
+}
+
 function formatDuration(secs: number | null): string {
   if (!secs) return "";
   const h = Math.floor(secs / 3600);
@@ -73,6 +82,12 @@ export default function FeedsPage() {
   const [selectedGuids, setSelectedGuids] = useState<Set<string>>(new Set());
   const [previewLoading, setPreviewLoading] = useState(false);
 
+  // Issue #487: adding more episodes to an existing selective feed.
+  // When set, the dialog is reused in "add more" mode: preview is reloaded for
+  // the feed's URL, and already-ingested GUIDs are shown checked+disabled.
+  const [addMoreFeed, setAddMoreFeed] = useState<Feed | null>(null);
+  const [existingGuids, setExistingGuids] = useState<Set<string>>(new Set());
+
   const { data: feeds = [], isLoading } = useQuery({ queryKey: ["feeds"], queryFn: fetchFeeds });
 
   function resetModal() {
@@ -83,6 +98,8 @@ export default function FeedsPage() {
     setPreviewStep(false);
     setPreview(null);
     setSelectedGuids(new Set());
+    setAddMoreFeed(null);
+    setExistingGuids(new Set());
   }
 
   const addFeed = useMutation({
@@ -112,6 +129,55 @@ export default function FeedsPage() {
     },
     onError: (err: Error) => setAddError(err.message),
   });
+
+  // Issue #487: add more episodes to an existing selective feed.
+  const addEpisodes = useMutation({
+    mutationFn: async ({
+      feedId,
+      selected_guids,
+    }: {
+      feedId: string;
+      selected_guids: string[];
+    }) => {
+      const resp = await fetch(`/api/feeds/${feedId}/episodes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selected_guids }),
+      });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err.detail ?? "Failed to add episodes");
+      }
+      return resp.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["feeds"] });
+      resetModal();
+    },
+    onError: (err: Error) => setAddError(err.message),
+  });
+
+  async function handleAddMore(feed: Feed) {
+    setAddMoreFeed(feed);
+    setShowAddModal(true);
+    setAddError(null);
+    setPreviewLoading(true);
+    try {
+      const [data, existing] = await Promise.all([
+        fetchPreview(feed.url),
+        fetchFeedEpisodeGuids(feed.id),
+      ]);
+      const existingSet = new Set(existing);
+      setPreview(data);
+      setExistingGuids(existingSet);
+      setSelectedGuids(new Set(existingSet));
+      setPreviewStep(true);
+    } catch (err: unknown) {
+      setAddError(err instanceof Error ? err.message : "Failed to load feed preview");
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
 
   const promoteFeed = useMutation({
     mutationFn: async ({ url }: { url: string }) => {
@@ -145,10 +211,20 @@ export default function FeedsPage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["feeds"] }),
   });
 
-  // Issue #84: fetch episode list for selective mode before submitting
+  // Issue #84: fetch episode list for selective mode before submitting.
+  // Issue #487: in "add more" mode, submit only the newly-picked GUIDs.
   async function handleAddOrPreview(e: React.FormEvent) {
     e.preventDefault();
     setAddError(null);
+    if (addMoreFeed) {
+      const newPicks = Array.from(selectedGuids).filter((g) => !existingGuids.has(g));
+      if (newPicks.length === 0) {
+        setAddError("Select at least one new episode to add.");
+        return;
+      }
+      addEpisodes.mutate({ feedId: addMoreFeed.id, selected_guids: newPicks });
+      return;
+    }
     if (addMode === "selective" && !previewStep) {
       setPreviewLoading(true);
       try {
@@ -170,6 +246,8 @@ export default function FeedsPage() {
   }
 
   function toggleGuid(guid: string) {
+    // Issue #487: already-ingested episodes are locked in add-more mode
+    if (addMoreFeed && existingGuids.has(guid)) return;
     setSelectedGuids((prev) => {
       const next = new Set(prev);
       if (next.has(guid)) next.delete(guid);
@@ -181,6 +259,21 @@ export default function FeedsPage() {
   function toggleAll() {
     if (!preview) return;
     const allGuids = preview.episodes.map((e) => e.guid);
+    if (addMoreFeed) {
+      // Issue #487: preserve existing selections; toggle only the remaining episodes
+      const togglable = allGuids.filter((g) => !existingGuids.has(g));
+      const allTogglableSelected = togglable.every((g) => selectedGuids.has(g));
+      setSelectedGuids((prev) => {
+        const next = new Set(prev);
+        if (allTogglableSelected) {
+          togglable.forEach((g) => next.delete(g));
+        } else {
+          togglable.forEach((g) => next.add(g));
+        }
+        return next;
+      });
+      return;
+    }
     if (selectedGuids.size === allGuids.length) {
       setSelectedGuids(new Set());
     } else {
@@ -199,17 +292,24 @@ export default function FeedsPage() {
               Add Feed
             </Button>
           </DialogTrigger>
-          <DialogContent className={previewStep ? "max-w-2xl flex flex-col max-h-[90vh]" : undefined}>
+          <DialogContent className={previewStep || addMoreFeed ? "max-w-2xl flex flex-col max-h-[90vh]" : undefined}>
             <DialogHeader>
               <DialogTitle>
-                {previewStep
+                {addMoreFeed
+                  ? `Add episodes${preview?.title ? ` — ${preview.title}` : addMoreFeed.title ? ` — ${addMoreFeed.title}` : ""}`
+                  : previewStep
                   ? `Select episodes${preview?.title ? ` — ${preview.title}` : ""}`
                   : "Add RSS Feed"}
               </DialogTitle>
             </DialogHeader>
 
-            {/* Step 1: URL + mode */}
-            {!previewStep && (
+            {/* Loading state while fetching preview for add-more flow */}
+            {addMoreFeed && previewLoading && (
+              <p className="text-sm text-muted-foreground py-4">Loading episodes...</p>
+            )}
+
+            {/* Step 1: URL + mode (only when not in add-more flow) */}
+            {!previewStep && !addMoreFeed && (
               <form onSubmit={handleAddOrPreview} className="space-y-4">
                 <Input
                   type="url"
@@ -274,45 +374,70 @@ export default function FeedsPage() {
               </form>
             )}
 
-            {/* Step 2: Episode selection (selective mode only) */}
-            {previewStep && preview && (
+            {/* Step 2: Episode selection (selective add or add-more) */}
+            {(previewStep || addMoreFeed) && preview && (
               <form onSubmit={handleAddOrPreview} className="flex flex-col flex-1 overflow-hidden space-y-3 min-h-0">
                 <div className="flex items-center justify-between shrink-0">
                   <span className="text-sm text-muted-foreground">
                     {preview.episodes.length} episodes found
+                    {addMoreFeed && existingGuids.size > 0
+                      ? ` · ${existingGuids.size} already added`
+                      : null}
                   </span>
                   <button
                     type="button"
                     onClick={toggleAll}
                     className="text-xs text-link underline"
                   >
-                    {selectedGuids.size === preview.episodes.length ? "Deselect all" : "Select all"}
+                    {(() => {
+                      if (addMoreFeed) {
+                        const remaining = preview.episodes.filter((e) => !existingGuids.has(e.guid));
+                        const allRemainingSelected =
+                          remaining.length > 0 &&
+                          remaining.every((e) => selectedGuids.has(e.guid));
+                        return allRemainingSelected ? "Deselect all new" : "Select all new";
+                      }
+                      return selectedGuids.size === preview.episodes.length
+                        ? "Deselect all"
+                        : "Select all";
+                    })()}
                   </button>
                 </div>
                 <div className="flex-1 overflow-y-auto overflow-x-hidden divide-y rounded-md border min-h-[80px]">
-                  {preview.episodes.map((ep) => (
-                    <label
-                      key={ep.guid}
-                      className="flex items-start gap-3 px-3 py-2 cursor-pointer hover:bg-accent/40 transition-colors"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedGuids.has(ep.guid)}
-                        onChange={() => toggleGuid(ep.guid)}
-                        className="mt-0.5 shrink-0"
-                      />
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium truncate">{ep.title ?? ep.guid}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {ep.published_at
-                            ? new Date(ep.published_at).toLocaleDateString()
-                            : null}
-                          {ep.published_at && ep.duration_secs ? " · " : null}
-                          {formatDuration(ep.duration_secs)}
-                        </p>
-                      </div>
-                    </label>
-                  ))}
+                  {preview.episodes.map((ep) => {
+                    const already = !!addMoreFeed && existingGuids.has(ep.guid);
+                    return (
+                      <label
+                        key={ep.guid}
+                        className={`flex items-start gap-3 px-3 py-2 transition-colors ${
+                          already
+                            ? "cursor-not-allowed opacity-60"
+                            : "cursor-pointer hover:bg-accent/40"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedGuids.has(ep.guid)}
+                          disabled={already}
+                          onChange={() => toggleGuid(ep.guid)}
+                          className="mt-0.5 shrink-0"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium truncate">{ep.title ?? ep.guid}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {ep.published_at
+                              ? new Date(ep.published_at).toLocaleDateString()
+                              : null}
+                            {ep.published_at && ep.duration_secs ? " · " : null}
+                            {formatDuration(ep.duration_secs)}
+                            {already ? (
+                              <span className="ml-2 italic">(already added)</span>
+                            ) : null}
+                          </p>
+                        </div>
+                      </label>
+                    );
+                  })}
                 </div>
                 {addError && <p className="text-sm text-destructive shrink-0">{addError}</p>}
                 <div className="flex justify-end gap-2 shrink-0">
@@ -320,22 +445,44 @@ export default function FeedsPage() {
                     type="button"
                     variant="outline"
                     onClick={() => {
+                      if (addMoreFeed) {
+                        resetModal();
+                        return;
+                      }
                       setPreviewStep(false);
                       setPreview(null);
                       setSelectedGuids(new Set());
                       setAddError(null);
                     }}
                   >
-                    Back
+                    {addMoreFeed ? "Cancel" : "Back"}
                   </Button>
-                  <Button
-                    type="submit"
-                    disabled={selectedGuids.size === 0 || addFeed.isPending}
-                  >
-                    {addFeed.isPending
-                      ? "Adding..."
-                      : `Add (${selectedGuids.size})`}
-                  </Button>
+                  {addMoreFeed ? (
+                    (() => {
+                      const newCount = Array.from(selectedGuids).filter(
+                        (g) => !existingGuids.has(g),
+                      ).length;
+                      return (
+                        <Button
+                          type="submit"
+                          disabled={newCount === 0 || addEpisodes.isPending}
+                        >
+                          {addEpisodes.isPending
+                            ? "Adding..."
+                            : `Add ${newCount} episode${newCount === 1 ? "" : "s"}`}
+                        </Button>
+                      );
+                    })()
+                  ) : (
+                    <Button
+                      type="submit"
+                      disabled={selectedGuids.size === 0 || addFeed.isPending}
+                    >
+                      {addFeed.isPending
+                        ? "Adding..."
+                        : `Add (${selectedGuids.size})`}
+                    </Button>
+                  )}
                 </div>
               </form>
             )}
@@ -364,6 +511,7 @@ export default function FeedsPage() {
           );
           deleteFeed.mutate({ id: feedId, deleteEpisodes: deleteEps });
         }}
+        onAddMore={handleAddMore}
       />
     </div>
   );

--- a/apps/web/src/components/FeedCard.tsx
+++ b/apps/web/src/components/FeedCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RefreshCw, Trash2, FlaskConical, ListChecks } from "lucide-react";
+import { Plus, RefreshCw, Trash2, FlaskConical, ListChecks } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ interface FeedCardProps {
   onPromote: (url: string) => void;
   onPoll: (feedId: string) => void;
   onDelete: (feedId: string) => void;
+  onAddMore?: (feed: FeedCardFeed) => void;
 }
 
 export default function FeedCard({
@@ -28,6 +29,7 @@ export default function FeedCard({
   onPromote,
   onPoll,
   onDelete,
+  onAddMore,
 }: FeedCardProps) {
   return (
     <Card className="hover:bg-accent/30 transition-colors">
@@ -57,6 +59,18 @@ export default function FeedCard({
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          {feed.mode === "selective" && onAddMore && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onAddMore(feed)}
+              className="h-8 text-xs gap-1"
+              title="Add more episodes from this feed"
+            >
+              <Plus size={12} />
+              Add episodes
+            </Button>
+          )}
           {(feed.mode === "test" || feed.mode === "selective") && (
             <Button
               variant="outline"

--- a/apps/web/src/components/FeedsListSection.tsx
+++ b/apps/web/src/components/FeedsListSection.tsx
@@ -19,6 +19,7 @@ interface FeedsListSectionProps {
   onPromote: (url: string) => void;
   onPoll: (feedId: string) => void;
   onDelete: (feedId: string) => void;
+  onAddMore?: (feed: Feed) => void;
 }
 
 export default function FeedsListSection({
@@ -29,6 +30,7 @@ export default function FeedsListSection({
   onPromote,
   onPoll,
   onDelete,
+  onAddMore,
 }: FeedsListSectionProps) {
   if (isLoading) {
     return (
@@ -70,6 +72,7 @@ export default function FeedsListSection({
           onPromote={onPromote}
           onPoll={onPoll}
           onDelete={onDelete}
+          onAddMore={onAddMore}
         />
       ))}
     </div>

--- a/apps/web/tests/unit/feed-card.test.tsx
+++ b/apps/web/tests/unit/feed-card.test.tsx
@@ -129,4 +129,40 @@ describe("<FeedCard>", () => {
     expect(onPoll).toHaveBeenCalledWith("feed-42");
     expect(onDelete).toHaveBeenCalledWith("feed-42");
   });
+
+  // Issue #487
+  it("renders 'Add episodes' only for selective feeds and invokes onAddMore", () => {
+    const onAddMore = jest.fn();
+    const { rerender } = render(
+      <FeedCard
+        feed={makeFeed({ mode: "full" })}
+        pollPending={false}
+        onPromote={jest.fn()}
+        onPoll={jest.fn()}
+        onDelete={jest.fn()}
+        onAddMore={onAddMore}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /Add episodes/ })).not.toBeInTheDocument();
+
+    const selective = makeFeed({ mode: "selective", id: "feed-7" });
+    rerender(
+      <FeedCard
+        feed={selective}
+        pollPending={false}
+        onPromote={jest.fn()}
+        onPoll={jest.fn()}
+        onDelete={jest.fn()}
+        onAddMore={onAddMore}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /Add episodes/ });
+    fireEvent.click(btn);
+    expect(onAddMore).toHaveBeenCalledWith(selective);
+  });
+
+  it("does not render 'Add episodes' for selective feeds when onAddMore is not supplied", () => {
+    renderCard(makeFeed({ mode: "selective" }));
+    expect(screen.queryByRole("button", { name: /Add episodes/ })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/unit/feeds-episodes-route.test.ts
+++ b/apps/web/tests/unit/feeds-episodes-route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ *
+ * Issue #487: proxy routes for adding more episodes to a selective feed
+ * and for listing already-ingested GUIDs.
+ */
+import { NextRequest } from "next/server";
+import { POST as postEpisodes } from "@/app/api/feeds/[id]/episodes/route";
+import { GET as getGuids } from "@/app/api/feeds/[id]/episodes/guids/route";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("POST /api/feeds/[id]/episodes", () => {
+  it("proxies body to the pipeline and mirrors the 202 response", async () => {
+    mockFetch.mockResolvedValue({
+      status: 202,
+      text: async () => JSON.stringify({ queued: 2, skipped: 1 }),
+    });
+
+    const req = new NextRequest("http://localhost/api/feeds/feed-1/episodes", {
+      method: "POST",
+      body: JSON.stringify({ selected_guids: ["a", "b", "c"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await postEpisodes(req, { params: Promise.resolve({ id: "feed-1" }) });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/feed-1/episodes",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selected_guids: ["a", "b", "c"] }),
+      },
+    );
+    expect(resp.status).toBe(202);
+    expect(await resp.json()).toEqual({ queued: 2, skipped: 1 });
+  });
+
+  it("mirrors upstream 422 with structured detail", async () => {
+    mockFetch.mockResolvedValue({
+      status: 422,
+      text: async () => JSON.stringify({ detail: "Only selective feeds..." }),
+    });
+
+    const req = new NextRequest("http://localhost/api/feeds/feed-1/episodes", {
+      method: "POST",
+      body: JSON.stringify({ selected_guids: ["a"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await postEpisodes(req, { params: Promise.resolve({ id: "feed-1" }) });
+
+    expect(resp.status).toBe(422);
+    expect(await resp.json()).toEqual({ detail: "Only selective feeds..." });
+  });
+
+  it("wraps non-JSON upstream errors as { detail: <text> }", async () => {
+    mockFetch.mockResolvedValue({
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    const req = new NextRequest("http://localhost/api/feeds/feed-1/episodes", {
+      method: "POST",
+      body: JSON.stringify({ selected_guids: ["a"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+    const resp = await postEpisodes(req, { params: Promise.resolve({ id: "feed-1" }) });
+
+    expect(resp.status).toBe(500);
+    expect(await resp.json()).toEqual({ detail: "Internal Server Error" });
+  });
+});
+
+describe("GET /api/feeds/[id]/episodes/guids", () => {
+  it("returns the GUID list from the pipeline", async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify(["ep-001", "ep-002"]),
+    });
+
+    const req = new Request("http://localhost/api/feeds/feed-1/episodes/guids");
+    const resp = await getGuids(req, { params: Promise.resolve({ id: "feed-1" }) });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/feeds/feed-1/episodes/guids",
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual(["ep-001", "ep-002"]);
+  });
+
+  it("mirrors 404 when the feed is unknown", async () => {
+    mockFetch.mockResolvedValue({
+      status: 404,
+      text: async () => JSON.stringify({ detail: "Feed not found" }),
+    });
+
+    const req = new Request("http://localhost/api/feeds/missing/episodes/guids");
+    const resp = await getGuids(req, { params: Promise.resolve({ id: "missing" }) });
+
+    expect(resp.status).toBe(404);
+    expect(await resp.json()).toEqual({ detail: "Feed not found" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an **Add episodes** button on selective feed cards that reopens the preview dialog with already-ingested episodes shown as checked + disabled, so users can pick additional episodes without promoting the feed to full mode.
- Backs it with two new pipeline endpoints — `POST /api/feeds/{id}/episodes` (enqueue additional GUIDs) and `GET /api/feeds/{id}/episodes/guids` (list ingested GUIDs for UI pre-selection).

Closes #487.

## Changes

**Pipeline** (`apps/pipeline/app/api/feeds.py`)
- `POST /api/feeds/{id}/episodes` — rejects non-selective feeds (422) and empty `selected_guids` (422); silently skips already-ingested GUIDs (idempotent) and delegates live-feed GUID validation to `ingest_feed()` (injection protection is reused, not reimplemented).
- `GET /api/feeds/{id}/episodes/guids` — returns the list of GUIDs already persisted for the feed, used by the UI to pre-check them in the preview dialog.

**Web app**
- `apps/web/src/app/api/feeds/[id]/episodes/{route.ts,guids/route.ts}` — thin proxies to the pipeline.
- `apps/web/src/app/feeds/page.tsx` — reuses the existing preview dialog in "add more" mode. Fetches preview + existing GUIDs in parallel; already-ingested episodes render checked, disabled, and tagged "(already added)". Submit button reads "Add N episode(s)" and only sends net-new GUIDs to the backend.
- `apps/web/src/components/FeedCard.tsx` + `FeedsListSection.tsx` — new optional `onAddMore` callback; the button only renders for `mode === "selective"`.

## Testing

- **Pipeline** — 9 new unit tests in `test_api.py` covering: feed-not-found (404), non-selective rejection (422), empty guids (422), all-ingested idempotent no-op, partial new/skipped mix, invalid-GUID propagation (422), and both success/404 paths for the GUIDs endpoint. Full pipeline unit suite: 466 passed (one pre-existing unrelated failure in `test_pyannote_service.py` unchanged by this PR).
- **Web** — new `feeds-episodes-route.test.ts` for both proxy routes (202/422/500 passthrough, 404). `feed-card.test.tsx` extended to verify the new button renders only for selective feeds when `onAddMore` is supplied and invokes the callback with the feed. Full web suite: 292/292 passed.
- **Build** — `next build` succeeds; both new routes are registered. Type-check clean on changed files.
- **Browser smoke** — `/feeds` renders HTTP 200 on the dev server. Full end-to-end exercise of the dialog against a running pipeline with a seeded selective feed was not performed in-session.

## Checklist

- [x] Pipeline unit tests pass
- [x] Web unit tests pass
- [x] `next build` succeeds
- [x] Lint clean on touched files
- [ ] Manual end-to-end verification against a live selective feed (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)