### PR TITLE
feat(podcasts): view-mode toggle for Sources page tiles (#488)

### DIFF
--- a/apps/web/src/app/podcasts/page.tsx
+++ b/apps/web/src/app/podcasts/page.tsx
@@ -1,30 +1,17 @@
 import Link from "next/link";
-import Image from "next/image";
-import { FlaskConical, Rss } from "lucide-react";
 import pool from "@/lib/db";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import UploadsSection, { type UploadedEpisode } from "@/components/UploadsSection";
+import PodcastsList, { type PodcastsListFeed } from "@/components/PodcastsList";
 
 export const dynamic = "force-dynamic";
 
-interface Feed {
-  id: string;
-  title: string | null;
-  image_url: string | null;
-  mode: string;
-  episode_count: number;
-  processed_count: number;
-  last_polled_at: string | null;
-}
-
-async function getFeeds(): Promise<Feed[]> {
+async function getFeeds(): Promise<PodcastsListFeed[]> {
   const result = await pool.query(`
     SELECT
       f.id,
       f.title,
+      f.description,
       f.image_url,
       f.mode,
       f.last_polled_at,
@@ -92,69 +79,9 @@ async function getUploadedEpisodes(): Promise<{
 export default async function SourcesPage() {
   const [feeds, uploads] = await Promise.all([getFeeds(), getUploadedEpisodes()]);
 
-  const feedEpisodeTotal = feeds.reduce((sum, f) => sum + f.episode_count, 0);
-  const feedEpisodeProcessed = feeds.reduce((sum, f) => sum + f.processed_count, 0);
-
   return (
     <div className="space-y-6">
-      {/* Podcasts section */}
-      {feeds.length > 0 && (
-        <div>
-          <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
-            <h2 className="text-xl font-semibold">
-              Podcasts
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                ({feedEpisodeTotal > 0 && feedEpisodeProcessed < feedEpisodeTotal
-                  ? `${feedEpisodeProcessed} / ${feedEpisodeTotal} episodes processed`
-                  : `${feeds.length} podcast${feeds.length !== 1 ? "s" : ""}`})
-              </span>
-            </h2>
-            <Button className="h-7 px-2.5 text-xs gap-1.5 [&_svg]:size-3" asChild>
-              <Link href="/feeds">
-                <Rss />
-                Manage feeds
-              </Link>
-            </Button>
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-            {feeds.map((feed) => (
-              <Link key={feed.id} href={`/podcasts/${feed.id}`}>
-                <Card className="overflow-hidden hover:bg-accent/30 transition-colors h-full">
-                  {feed.image_url ? (
-                    <Image
-                      src={feed.image_url}
-                      alt={feed.title ?? "Podcast"}
-                      width={300}
-                      height={300}
-                      className="w-full aspect-square object-cover"
-                    />
-                  ) : (
-                    <div className="w-full aspect-square bg-muted flex items-center justify-center text-4xl">
-                      🎙
-                    </div>
-                  )}
-                  <CardContent className="p-3 space-y-1">
-                    <div className="flex items-center gap-1.5">
-                      <p className="text-sm font-medium line-clamp-2">{feed.title ?? "Untitled"}</p>
-                      {feed.mode === "test" && (
-                        <Badge variant="outline" className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0">
-                          <FlaskConical size={9} />
-                          Test
-                        </Badge>
-                      )}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {feed.processed_count === feed.episode_count
-                        ? `${feed.episode_count} episodes`
-                        : `${feed.processed_count} / ${feed.episode_count} episodes processed`}
-                    </p>
-                  </CardContent>
-                </Card>
-              </Link>
-            ))}
-          </div>
-        </div>
-      )}
+      {feeds.length > 0 && <PodcastsList feeds={feeds} />}
 
       {feeds.length === 0 && uploads.total === 0 && (
         <div className="text-center py-12 space-y-3">

--- a/apps/web/src/components/PodcastsList.tsx
+++ b/apps/web/src/components/PodcastsList.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  FlaskConical,
+  LayoutGrid,
+  List,
+  ListChecks,
+  Podcast,
+  Rows3,
+  Rss,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface PodcastsListFeed {
+  id: string;
+  title: string | null;
+  description: string | null;
+  image_url: string | null;
+  mode: string;
+  episode_count: number;
+  processed_count: number;
+  last_polled_at: string | null;
+}
+
+type ViewMode = "list" | "grid" | "large";
+
+const STORAGE_KEY = "podlog-podcasts-view";
+const DEFAULT_VIEW: ViewMode = "grid";
+
+function isViewMode(v: unknown): v is ViewMode {
+  return v === "list" || v === "grid" || v === "large";
+}
+
+interface Props {
+  feeds: PodcastsListFeed[];
+  /** Optional initial mode override — primarily for tests to avoid localStorage dance. */
+  initialView?: ViewMode;
+}
+
+export default function PodcastsList({ feeds, initialView }: Props) {
+  const [view, setView] = useState<ViewMode>(initialView ?? DEFAULT_VIEW);
+
+  useEffect(() => {
+    if (initialView) return;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (isViewMode(stored)) setView(stored);
+    } catch {}
+  }, [initialView]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, view);
+    } catch {}
+  }, [view]);
+
+  const feedEpisodeTotal = feeds.reduce((sum, f) => sum + f.episode_count, 0);
+  const feedEpisodeProcessed = feeds.reduce((sum, f) => sum + f.processed_count, 0);
+
+  return (
+    <div data-view={view}>
+      <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+        <h2 className="text-xl font-semibold">
+          Podcasts
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            ({feedEpisodeTotal > 0 && feedEpisodeProcessed < feedEpisodeTotal
+              ? `${feedEpisodeProcessed} / ${feedEpisodeTotal} episodes processed`
+              : `${feeds.length} podcast${feeds.length !== 1 ? "s" : ""}`})
+          </span>
+        </h2>
+        <div className="flex items-center gap-2">
+          <ViewToggle view={view} onChange={setView} />
+          <Button className="h-7 px-2.5 text-xs gap-1.5 [&_svg]:size-3" asChild>
+            <Link href="/feeds">
+              <Rss />
+              Manage feeds
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {view === "list" && <FeedListRows feeds={feeds} />}
+      {view === "grid" && <FeedGrid feeds={feeds} density="default" />}
+      {view === "large" && <FeedGrid feeds={feeds} density="large" />}
+    </div>
+  );
+}
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ViewMode;
+  onChange: (v: ViewMode) => void;
+}) {
+  const options: { mode: ViewMode; label: string; icon: React.ReactNode }[] = [
+    { mode: "list", label: "List view", icon: <List size={14} /> },
+    { mode: "grid", label: "Grid view", icon: <LayoutGrid size={14} /> },
+    { mode: "large", label: "Large tiles", icon: <Rows3 size={14} /> },
+  ];
+  return (
+    <div
+      role="group"
+      aria-label="Podcast view mode"
+      className="inline-flex rounded-md border bg-background overflow-hidden"
+    >
+      {options.map((opt) => {
+        const active = view === opt.mode;
+        return (
+          <button
+            key={opt.mode}
+            type="button"
+            aria-label={opt.label}
+            aria-pressed={active}
+            onClick={() => onChange(opt.mode)}
+            className={`h-7 w-8 flex items-center justify-center transition-colors ${
+              active
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent/60"
+            }`}
+          >
+            {opt.icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ModeBadges({ mode }: { mode: string }) {
+  return (
+    <>
+      {mode === "test" && (
+        <Badge
+          variant="outline"
+          className="shrink-0 text-violet-700 border-violet-300 dark:text-violet-300 dark:border-violet-700 gap-0.5 text-[10px] px-1 py-0"
+        >
+          <FlaskConical size={9} />
+          Test
+        </Badge>
+      )}
+      {mode === "selective" && (
+        <Badge
+          variant="outline"
+          className="shrink-0 text-sky-700 border-sky-300 dark:text-sky-300 dark:border-sky-700 gap-0.5 text-[10px] px-1 py-0"
+        >
+          <ListChecks size={9} />
+          Selective
+        </Badge>
+      )}
+    </>
+  );
+}
+
+function EpisodeCounter({ feed }: { feed: PodcastsListFeed }) {
+  return (
+    <p className="text-xs text-muted-foreground">
+      {feed.processed_count === feed.episode_count
+        ? `${feed.episode_count} episodes`
+        : `${feed.processed_count} / ${feed.episode_count} episodes processed`}
+    </p>
+  );
+}
+
+function ImageOrPlaceholder({
+  feed,
+  size,
+}: {
+  feed: PodcastsListFeed;
+  size: number;
+}) {
+  const common = `aspect-square object-cover`;
+  if (feed.image_url) {
+    return (
+      <Image
+        src={feed.image_url}
+        alt={feed.title ?? "Podcast"}
+        width={size}
+        height={size}
+        className={`${common} w-full`}
+      />
+    );
+  }
+  return (
+    <div
+      className={`${common} w-full bg-muted flex items-center justify-center text-muted-foreground`}
+    >
+      <Podcast className="h-1/3 w-1/3" />
+    </div>
+  );
+}
+
+function FeedGrid({
+  feeds,
+  density,
+}: {
+  feeds: PodcastsListFeed[];
+  density: "default" | "large";
+}) {
+  const gridClass =
+    density === "large"
+      ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5"
+      : "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4";
+  const imgSize = density === "large" ? 480 : 300;
+  return (
+    <div className={gridClass}>
+      {feeds.map((feed) => (
+        <Link key={feed.id} href={`/podcasts/${feed.id}`}>
+          <Card className="overflow-hidden hover:bg-accent/30 transition-colors h-full">
+            <ImageOrPlaceholder feed={feed} size={imgSize} />
+            <CardContent
+              className={density === "large" ? "p-4 space-y-1.5" : "p-3 space-y-1"}
+            >
+              <div className="flex items-center gap-1.5">
+                <p
+                  className={`font-medium line-clamp-2 ${
+                    density === "large" ? "text-base" : "text-sm"
+                  }`}
+                >
+                  {feed.title ?? "Untitled"}
+                </p>
+                <ModeBadges mode={feed.mode} />
+              </div>
+              <EpisodeCounter feed={feed} />
+              {density === "large" && feed.description && (
+                <p className="text-xs text-muted-foreground line-clamp-2">
+                  {feed.description}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function FeedListRows({ feeds }: { feeds: PodcastsListFeed[] }) {
+  return (
+    <div className="divide-y rounded-md border">
+      {feeds.map((feed) => (
+        <Link
+          key={feed.id}
+          href={`/podcasts/${feed.id}`}
+          className="flex items-center gap-3 p-3 hover:bg-accent/30 transition-colors"
+        >
+          <div className="w-12 shrink-0">
+            <ImageOrPlaceholder feed={feed} size={96} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <p className="text-sm font-medium truncate">
+                {feed.title ?? "Untitled"}
+              </p>
+              <ModeBadges mode={feed.mode} />
+            </div>
+            <EpisodeCounter feed={feed} />
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/tests/unit/podcasts-list.test.tsx
+++ b/apps/web/tests/unit/podcasts-list.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import PodcastsList, {
+  type PodcastsListFeed,
+} from "@/components/PodcastsList";
+
+// next/image complains in a jsdom environment about width/height vs fill; stub it.
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} />
+  ),
+}));
+
+const STORAGE_KEY = "podlog-podcasts-view";
+
+function makeFeed(overrides: Partial<PodcastsListFeed> = {}): PodcastsListFeed {
+  return {
+    id: "feed-1",
+    title: "Example Podcast",
+    description: "A pod about things.",
+    image_url: "https://example.com/art.jpg",
+    mode: "full",
+    episode_count: 10,
+    processed_count: 10,
+    last_polled_at: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("<PodcastsList>", () => {
+  it("renders grid view by default and shows the Manage feeds link", () => {
+    render(<PodcastsList feeds={[makeFeed()]} />);
+    const root = screen.getByText("Example Podcast").closest("[data-view]");
+    expect(root?.getAttribute("data-view")).toBe("grid");
+    expect(screen.getByRole("link", { name: /Manage feeds/ })).toHaveAttribute(
+      "href",
+      "/feeds",
+    );
+  });
+
+  it("hydrates the view from localStorage on mount", () => {
+    window.localStorage.setItem(STORAGE_KEY, "list");
+    render(<PodcastsList feeds={[makeFeed()]} />);
+    const root = screen.getByText("Example Podcast").closest("[data-view]");
+    expect(root?.getAttribute("data-view")).toBe("list");
+  });
+
+  it("ignores garbage values in localStorage and falls back to grid", () => {
+    window.localStorage.setItem(STORAGE_KEY, "carousel");
+    render(<PodcastsList feeds={[makeFeed()]} />);
+    const root = screen.getByText("Example Podcast").closest("[data-view]");
+    expect(root?.getAttribute("data-view")).toBe("grid");
+  });
+
+  it("persists the selected view to localStorage on toggle", () => {
+    render(<PodcastsList feeds={[makeFeed()]} />);
+    fireEvent.click(screen.getByRole("button", { name: "List view" }));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("list");
+    fireEvent.click(screen.getByRole("button", { name: "Large tiles" }));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("large");
+  });
+
+  it("marks the active toggle with aria-pressed", () => {
+    render(<PodcastsList feeds={[makeFeed()]} initialView="grid" />);
+    expect(screen.getByRole("button", { name: "Grid view" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "List view" }));
+    expect(screen.getByRole("button", { name: "List view" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Grid view" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("renders the feed title in every view", () => {
+    const feed = makeFeed({ title: "Unique Title" });
+    for (const view of ["list", "grid", "large"] as const) {
+      const { unmount } = render(
+        <PodcastsList feeds={[feed]} initialView={view} />,
+      );
+      expect(screen.getByText("Unique Title")).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("renders the description only in large view", () => {
+    const feed = makeFeed({ description: "Look, a description!" });
+    const { unmount: u1 } = render(
+      <PodcastsList feeds={[feed]} initialView="grid" />,
+    );
+    expect(screen.queryByText("Look, a description!")).not.toBeInTheDocument();
+    u1();
+
+    const { unmount: u2 } = render(
+      <PodcastsList feeds={[feed]} initialView="list" />,
+    );
+    expect(screen.queryByText("Look, a description!")).not.toBeInTheDocument();
+    u2();
+
+    render(<PodcastsList feeds={[feed]} initialView="large" />);
+    expect(screen.getByText("Look, a description!")).toBeInTheDocument();
+  });
+
+  it("shows the processed/total counter when not all episodes are done", () => {
+    render(
+      <PodcastsList
+        feeds={[makeFeed({ episode_count: 10, processed_count: 3 })]}
+      />,
+    );
+    // Appears in both the header aggregate and the feed card — assert at least one.
+    expect(
+      screen.getAllByText(/3 \/ 10 episodes processed/).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows only total when all episodes are processed", () => {
+    render(
+      <PodcastsList
+        feeds={[makeFeed({ episode_count: 5, processed_count: 5 })]}
+      />,
+    );
+    expect(screen.getAllByText(/^5 episodes$/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the Test and Selective badges based on mode", () => {
+    const { rerender } = render(
+      <PodcastsList feeds={[makeFeed({ mode: "test" })]} />,
+    );
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.queryByText("Selective")).not.toBeInTheDocument();
+
+    rerender(<PodcastsList feeds={[makeFeed({ mode: "selective" })]} />);
+    expect(screen.getByText("Selective")).toBeInTheDocument();
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+
+    rerender(<PodcastsList feeds={[makeFeed({ mode: "full" })]} />);
+    expect(screen.queryByText("Test")).not.toBeInTheDocument();
+    expect(screen.queryByText("Selective")).not.toBeInTheDocument();
+  });
+
+  it("renders each feed as a link to its detail page", () => {
+    render(
+      <PodcastsList
+        feeds={[makeFeed({ id: "a" }), makeFeed({ id: "b", title: "Pod B" })]}
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    expect(
+      links.some((l) => l.getAttribute("href") === "/podcasts/a"),
+    ).toBe(true);
+    expect(
+      links.some((l) => l.getAttribute("href") === "/podcasts/b"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **List / Grid / Large** view-mode toggle to the Sources page (`/podcasts`).
- Preference persists per-browser via `localStorage["podlog-podcasts-view"]`.
- Default (Grid) preserves the existing 2/3/4-column tile layout — no visual regression for existing users.
- Manual uploads section is **intentionally untouched**, per the issue.

Closes #488.

## Changes

- **`apps/web/src/components/PodcastsList.tsx`** (new, client component)
  - Owns the view-mode state, hydrates from localStorage on mount, persists on change.
  - `ViewToggle` renders three icon buttons (`List`, `LayoutGrid`, `Rows3`) with `aria-pressed` / `aria-label`.
  - **List**: horizontal rows with a 48px thumbnail, title + mode badges, episode counter.
  - **Grid** (default): 2/3/4 columns, identical to the previous layout.
  - **Large**: 1/2/3 columns, bigger card, shows feed description (newly surfaced).
  - Replaces the 🎙 emoji placeholder with a Lucide `Podcast` icon (consistent with project's icon library).

- **`apps/web/src/app/podcasts/page.tsx`**
  - Extracts feed rendering into `<PodcastsList feeds={feeds} />`.
  - SQL now selects `f.description` so Large mode can surface it. No schema change — column already existed.
  - `UploadsSection` left entirely alone.

- **`apps/web/tests/unit/podcasts-list.test.tsx`** (new): 11 tests covering default view, localStorage hydrate/persist, garbage-value fallback, `aria-pressed` state, title-in-every-view, description-only-in-large, processed/total counter, mode badges, and per-feed detail links.

## Testing

- **Web unit**: `303/303 passed` (292 previous + 11 new).
- **Build**: `next build` succeeds.
- **Lint**: clean on new files; `EpisodesList.tsx` already carries the same `react-hooks/set-state-in-effect` warning — consistent with the project's localStorage hydration pattern.
- **Browser smoke**: `/podcasts` page compiles (confirmed against dev server). Full end-to-end run against a seeded DB was not performed locally (no Postgres available in-session).

## Checklist

- [x] Web unit tests pass
- [x] `next build` succeeds
- [x] Lint clean on touched files
- [x] Uploads section untouched (per issue)
- [ ] Manual visual check against a local instance with seeded feeds (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)