### PR TITLE
fix(ask): recover from Ollama memory-cap OOMs

### DIFF
--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -31,6 +31,15 @@ MODEL_NUM_CTX = {
 }
 DEFAULT_NUM_CTX = 8192
 
+# Substring Ollama includes in its 500 body when its cgroup memory cap is
+# saturated (often by page cache of inactive model blobs). We detect this to
+# trigger a single unload+retry before surfacing a user-facing message.
+OLLAMA_OOM_MARKER = "requires more system memory"
+
+
+class OllamaOutOfMemory(RuntimeError):
+    """Preflight memory check in Ollama refused the request."""
+
 SYSTEM_PROMPT = """You are a helpful assistant that answers questions about podcast transcripts.
 
 RULES:
@@ -184,11 +193,36 @@ def chunks_to_sources(chunks: list[ChunkResult]) -> list[dict]:
     ]
 
 
-async def stream_ollama_response(
-    messages: list[dict],
-    model: str = DEFAULT_MODEL,
-):
-    """Stream chat completion from Ollama. Yields token strings."""
+async def _unload_loaded_ollama_models() -> None:
+    """Best-effort unload of currently resident Ollama models to free RAM."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{settings.ollama_url}/api/ps")
+            if resp.status_code != 200:
+                return
+            loaded = [m.get("name") for m in resp.json().get("models", []) if m.get("name")]
+            if not loaded:
+                return
+            for name in loaded:
+                try:
+                    await client.post(
+                        f"{settings.ollama_url}/api/generate",
+                        json={"model": name, "keep_alive": 0},
+                        timeout=30,
+                    )
+                except httpx.HTTPError:
+                    continue
+            logger.info(
+                '"action": "ollama_unload_cached", "count": %d, "models": "%s"',
+                len(loaded),
+                ",".join(loaded),
+            )
+    except httpx.HTTPError as exc:
+        logger.warning('"action": "ollama_unload_failed", "error": "%s"', exc)
+
+
+async def _stream_ollama_once(messages: list[dict], model: str):
+    """One chat attempt. Raises OllamaOutOfMemory on preflight memory refusal."""
     url = f"{settings.ollama_url}/api/chat"
     payload = {
         "model": model,
@@ -202,19 +236,59 @@ async def stream_ollama_response(
             async with client.stream("POST", url, json=payload) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()
-                    raise RuntimeError(f"Ollama returned {resp.status_code}: {body.decode()[:500]}")
+                    detail = body.decode(errors="ignore")[:500]
+                    if OLLAMA_OOM_MARKER in detail:
+                        raise OllamaOutOfMemory(detail)
+                    raise RuntimeError(f"Ollama returned {resp.status_code}: {detail}")
                 async for line in resp.aiter_lines():
                     if not line:
                         continue
                     data = json.loads(line)
-                    if data.get("error"):
-                        raise RuntimeError(f"Ollama error: {data['error']}")
+                    if err := data.get("error"):
+                        if OLLAMA_OOM_MARKER in err:
+                            raise OllamaOutOfMemory(err)
+                        raise RuntimeError(f"Ollama error: {err}")
                     if content := data.get("message", {}).get("content"):
                         yield content
                     if data.get("done"):
                         return
     except httpx.HTTPError as exc:
         raise RuntimeError(f"Ollama connection error: {type(exc).__name__}: {exc}") from exc
+
+
+async def stream_ollama_response(
+    messages: list[dict],
+    model: str = DEFAULT_MODEL,
+):
+    """Stream chat from Ollama; on memory-cap OOM, unload cached models and retry once."""
+    yielded_any = False
+    try:
+        async for token in _stream_ollama_once(messages, model):
+            yielded_any = True
+            yield token
+        return
+    except OllamaOutOfMemory as exc:
+        if yielded_any:
+            raise RuntimeError(
+                "Ollama ran out of memory mid-response. Run "
+                "`docker restart podlog-ollama-1` to free its memory cap, then try again."
+            ) from exc
+        logger.warning(
+            '"action": "ollama_oom_retry", "model": "%s", "detail": "%s"',
+            model,
+            str(exc)[:200],
+        )
+
+    await _unload_loaded_ollama_models()
+
+    try:
+        async for token in _stream_ollama_once(messages, model):
+            yield token
+    except OllamaOutOfMemory as exc:
+        raise RuntimeError(
+            "Ollama is out of memory. Run `docker restart podlog-ollama-1` "
+            "to free its memory cap, then try again."
+        ) from exc
 
 
 def _runtime_inference_value(runtime: dict | None, key: str, default):

--- a/apps/pipeline/tests/unit/test_rag_streaming.py
+++ b/apps/pipeline/tests/unit/test_rag_streaming.py
@@ -254,6 +254,165 @@ class TestOllamaStreaming:
             asyncio.run(run())
 
 
+class TestOllamaOOMRetry:
+    """On preflight OOM, rag.py unloads resident models and retries once."""
+
+    @staticmethod
+    def _resp(status_code: int, body: bytes, stream_lines: list[str] | None = None):
+        class _Resp:
+            def __init__(self):
+                self.status_code = status_code
+
+            async def aread(self):
+                return body
+
+            async def aiter_lines(self):
+                for line in stream_lines or []:
+                    yield line
+
+        return _Resp()
+
+    @staticmethod
+    def _client(responses):
+        """Factory returning an httpx.AsyncClient double that yields `responses` in order."""
+        iterator = iter(responses)
+
+        class _StreamCtx:
+            def __init__(self, resp):
+                self._resp = resp
+
+            async def __aenter__(self):
+                return self._resp
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class _Client:
+            def stream(self, *args, **kwargs):
+                return _StreamCtx(next(iterator))
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Client()
+
+    def test_oom_then_success_retries_once_after_unload(self):
+        from app.services.rag import stream_ollama_response
+
+        oom_body = b'{"error":"model requires more system memory (1.9 GiB) than is available (555.8 MiB)"}'
+        first = self._resp(500, oom_body)
+        second = self._resp(
+            200,
+            b"",
+            stream_lines=['{"message":{"content":"ok"}}', '{"done": true}'],
+        )
+        client = self._client([first, second])
+
+        unload_calls = 0
+
+        async def _fake_unload():
+            nonlocal unload_calls
+            unload_calls += 1
+
+        async def run():
+            out = []
+            with (
+                patch("app.services.rag.httpx.AsyncClient", return_value=client),
+                patch("app.services.rag._unload_loaded_ollama_models", _fake_unload),
+            ):
+                async for token in stream_ollama_response(
+                    [{"role": "user", "content": "q"}], model="qwen2.5:3b"
+                ):
+                    out.append(token)
+            return out
+
+        assert asyncio.run(run()) == ["ok"]
+        assert unload_calls == 1
+
+    def test_oom_on_both_attempts_raises_actionable_message(self):
+        from app.services.rag import stream_ollama_response
+
+        oom_body = b'{"error":"model requires more system memory (1.9 GiB) than is available (555.8 MiB)"}'
+        client = self._client([self._resp(500, oom_body), self._resp(500, oom_body)])
+
+        async def _fake_unload():
+            return None
+
+        async def run():
+            with (
+                patch("app.services.rag.httpx.AsyncClient", return_value=client),
+                patch("app.services.rag._unload_loaded_ollama_models", _fake_unload),
+            ):
+                async for _ in stream_ollama_response(
+                    [{"role": "user", "content": "q"}], model="qwen2.5:3b"
+                ):
+                    pass
+
+        with pytest.raises(RuntimeError, match=r"docker restart podlog-ollama-1"):
+            asyncio.run(run())
+
+    def test_non_oom_500_does_not_retry(self):
+        from app.services.rag import stream_ollama_response
+
+        # 500 without the OOM marker → immediate raise, no retry.
+        client = self._client([self._resp(500, b'{"error":"internal server error"}')])
+
+        unload_calls = 0
+
+        async def _fake_unload():
+            nonlocal unload_calls
+            unload_calls += 1
+
+        async def run():
+            with (
+                patch("app.services.rag.httpx.AsyncClient", return_value=client),
+                patch("app.services.rag._unload_loaded_ollama_models", _fake_unload),
+            ):
+                async for _ in stream_ollama_response([{"role": "user", "content": "q"}]):
+                    pass
+
+        with pytest.raises(RuntimeError, match="Ollama returned 500"):
+            asyncio.run(run())
+        assert unload_calls == 0
+
+    def test_oom_mid_stream_does_not_retry(self):
+        """If tokens have already streamed, a mid-stream OOM surfaces directly."""
+        from app.services.rag import stream_ollama_response
+
+        mid_stream_oom = self._resp(
+            200,
+            b"",
+            stream_lines=[
+                '{"message":{"content":"hello"}}',
+                '{"error":"model requires more system memory"}',
+            ],
+        )
+        client = self._client([mid_stream_oom])
+
+        unload_calls = 0
+
+        async def _fake_unload():
+            nonlocal unload_calls
+            unload_calls += 1
+
+        async def run():
+            out = []
+            with (
+                patch("app.services.rag.httpx.AsyncClient", return_value=client),
+                patch("app.services.rag._unload_loaded_ollama_models", _fake_unload),
+            ):
+                async for token in stream_ollama_response([{"role": "user", "content": "q"}]):
+                    out.append(token)
+            return out
+
+        with pytest.raises(RuntimeError, match="mid-response"):
+            asyncio.run(run())
+        assert unload_calls == 0
+
+
 class TestProviderRouting:
     def test_stream_response_routes_to_fireworks(self):
         from app.services.rag import stream_response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 10g
+          memory: 20g
 
   web:
     build: ./apps/web


### PR DESCRIPTION
## Summary

- Raise Ollama container memory cap from **10g → 20g** in `docker-compose.yml`. With three RAG models (`qwen2.5:3b`, `phi3:mini`, `gemma4:e4b`) all caching blob files into the cgroup, the 10g cap left Ollama's preflight check with under 600 MiB "free" even when no model was loaded.
- Detect the OOM marker (`"requires more system memory"`) in `rag.py`, unload any resident models via `/api/ps` + `POST /api/generate {keep_alive: 0}`, and retry the chat once. If the retry also fails (or OOM arrives mid-stream), surface an actionable error to the UI:
  > Ollama is out of memory. Run `docker restart podlog-ollama-1` to free its memory cap, then try again.
- 4 new unit tests in `TestOllamaOOMRetry`: retry-then-succeed, retry-then-fail-with-message, non-OOM 500 does not retry, mid-stream OOM does not retry.

## Background

Triggered by this error from the episode-page Ask feature:

```
Error generating answer: Ollama returned 500:
{"error":"model requires more system memory (1.9 GiB) than is available (555.8 MiB)"}
```

Root cause was cgroup page-cache saturation, not in-memory model residency — confirmed via `cat /sys/fs/cgroup/memory.stat` inside the Ollama container showing `inactive_file: 9.32 GiB` out of a 10 GiB cap. The kernel could reclaim it under pressure, but Ollama's preflight doesn't subtract reclaimable cache.

The retry+unload path handles the simpler "another model still resident" variant automatically and invisibly. The page-cache variant surfaces a clear one-line remediation instead of raw Ollama output.

## Test plan

- [x] Unit tests pass: `docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/test_rag_streaming.py -v` → 13/13
- [ ] Manual: ask a question on an episode page and confirm it streams normally
- [ ] Manual (harder to reproduce): trigger an OOM and confirm the UI shows the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)