### PR TITLE
feat(notifications): provider-scoped averages + per-episode factor (#518)

### DIFF
--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -12,6 +12,7 @@ from app.services.notification_events import EpisodeDoneEvent, EpisodeFailedEven
 from app.services.digest_formatters import format_digest_html, format_digest_telegram
 from app.services.notification_runtime import (
     compute_avg_duration,
+    compute_avg_processing_factor,
     compute_avg_processing_stats,
     estimate_queue_status,
 )
@@ -70,6 +71,20 @@ class DigestItem:
     retry_count: int | None
     retry_max: int | None
     diarize_step_durations: dict[str, float] | None = None
+    inference_provider_used: str | None = None
+    episode_processing_factor: float | None = None
+
+
+@dataclass
+class ProviderAverages:
+    """Averages scoped to episodes processed by a single inference provider."""
+
+    provider: str  # "local", "fireworks", etc.
+    avg_transcribe_secs: float | None = None
+    avg_diarize_secs: float | None = None
+    avg_total_secs: float | None = None
+    avg_duration_secs: float | None = None
+    processing_factor: float | None = None
 
 
 @dataclass
@@ -84,6 +99,7 @@ class DigestData:
     avg_total_secs: float | None = None
     avg_duration_secs: float | None = None
     processing_factor: float | None = None
+    provider_averages: list[ProviderAverages] = field(default_factory=list)
 
 
 def _serialize_event(event: Event) -> str:
@@ -173,8 +189,12 @@ def send_digest_if_due(now: datetime | None = None) -> None:
         avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         avg_dur = compute_avg_duration(db)
         items = []
+        providers_seen: list[str] = []
         for row in unsent:
             payload = json.loads(row.payload)
+            provider = payload.get("inference_provider_used")
+            if provider and provider not in providers_seen:
+                providers_seen.append(provider)
             items.append(DigestItem(
                 event_type=row.event_type,
                 episode_title=payload.get("episode_title", ""),
@@ -185,6 +205,25 @@ def send_digest_if_due(now: datetime | None = None) -> None:
                 error_class=payload.get("error_class"),
                 retry_count=payload.get("retry_count"),
                 retry_max=payload.get("retry_max"),
+                inference_provider_used=provider,
+                episode_processing_factor=payload.get("episode_processing_factor"),
+            ))
+
+        provider_averages: list[ProviderAverages] = []
+        for provider in providers_seen:
+            p_t, p_d, p_total = compute_avg_processing_stats(db, provider=provider)
+            p_dur = compute_avg_duration(db, provider=provider)
+            p_factor = compute_avg_processing_factor(db, provider=provider)
+            if (p_t is None and p_d is None and p_total is None
+                    and p_dur is None and p_factor is None):
+                continue
+            provider_averages.append(ProviderAverages(
+                provider=provider,
+                avg_transcribe_secs=p_t,
+                avg_diarize_secs=p_d,
+                avg_total_secs=p_total,
+                avg_duration_secs=p_dur,
+                processing_factor=p_factor,
             ))
 
         if frequency == "weekly":
@@ -205,6 +244,7 @@ def send_digest_if_due(now: datetime | None = None) -> None:
             avg_total_secs=avg_total,
             avg_duration_secs=avg_dur,
             processing_factor=factor,
+            provider_averages=provider_averages,
         )
 
         _send_digest(digest, ns)

--- a/apps/pipeline/app/services/digest_formatters.py
+++ b/apps/pipeline/app/services/digest_formatters.py
@@ -8,6 +8,7 @@ from app.services.notifications import (
     _fmt_short_duration,
     _fmt_estimate,
     _fmt_factor,
+    _provider_label,
 )
 from app.services.timing_labels import humanize_timing_key
 
@@ -22,6 +23,72 @@ def _fmt_diarization_steps(step_durations: dict[str, float] | None) -> str:
     return f"Diarization steps: {'; '.join(parts)}"
 
 
+def _render_avg_table_html(
+    heading: str,
+    avg_transcribe_secs: float | None,
+    avg_diarize_secs: float | None,
+    avg_total_secs: float | None,
+    avg_duration_secs: float | None,
+    processing_factor: float | None,
+) -> str:
+    """Render a single Avg Processing Time table (HTML)."""
+    if (avg_transcribe_secs is None and avg_diarize_secs is None
+            and avg_total_secs is None and avg_duration_secs is None
+            and processing_factor is None):
+        return ""
+    avg_duration_row = ""
+    if avg_duration_secs is not None:
+        avg_duration_row = f"""\
+    <tr><td style="padding: 4px 12px; color: #666;">Avg episode length</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(avg_duration_secs)}</td></tr>"""
+    factor_row = ""
+    if processing_factor is not None:
+        factor_row = f"""\
+    <tr style="background: #f9f9f9;">
+        <td style="padding: 4px 12px; color: #666;">Avg processing factor</td>
+        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_factor(processing_factor)}</td></tr>"""
+    return f"""\
+  <h3 style="margin-top: 20px; margin-bottom: 8px;">{escape(heading)}</h3>
+  <table style="border-collapse: collapse; width: 100%;">
+    <tr><td style="padding: 4px 12px; color: #666;">Avg transcription</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(avg_transcribe_secs)}</td></tr>
+    <tr style="background: #f9f9f9;">
+        <td style="padding: 4px 12px; color: #666;">Avg diarization</td>
+        <td style="padding: 4px 12px;">{_fmt_short_duration(avg_diarize_secs)}</td></tr>
+    <tr><td style="padding: 4px 12px; color: #666;">Avg per episode</td>
+        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(avg_total_secs)}</td></tr>
+{avg_duration_row}
+{factor_row}
+  </table>
+"""
+
+
+def _render_avg_block_telegram(
+    heading: str,
+    avg_transcribe_secs: float | None,
+    avg_diarize_secs: float | None,
+    avg_total_secs: float | None,
+    avg_duration_secs: float | None,
+    processing_factor: float | None,
+) -> str:
+    """Render a single Avg Processing Time block (Telegram Markdown)."""
+    if (avg_transcribe_secs is None and avg_diarize_secs is None
+            and avg_total_secs is None and avg_duration_secs is None
+            and processing_factor is None):
+        return ""
+    block = (
+        f"\n*{heading}*\n"
+        f"`Avg transcribe:  {_fmt_short_duration(avg_transcribe_secs)}`\n"
+        f"`Avg diarize:     {_fmt_short_duration(avg_diarize_secs)}`\n"
+        f"`Avg per episode: {_fmt_short_duration(avg_total_secs)}`"
+    )
+    if avg_duration_secs is not None:
+        block += f"\n`Avg ep. length:  {_fmt_short_duration(avg_duration_secs)}`"
+    if processing_factor is not None:
+        block += f"\n`Avg processing factor: {_fmt_factor(processing_factor)}`"
+    return block
+
+
 def format_digest_html(data) -> str:
     freq_label = "Daily" if data.frequency == "daily" else "Weekly"
     done_count = sum(1 for i in data.items if i.event_type == "episode.done")
@@ -33,6 +100,8 @@ def format_digest_html(data) -> str:
         if item.event_type == "episode.done":
             icon = "&#9989;"
             detail = f"processed in {_fmt_short_duration(item.total_duration_secs)}"
+            if item.episode_processing_factor is not None:
+                detail = f"{detail} ({_fmt_factor(item.episode_processing_factor)})"
             step_detail = _fmt_diarization_steps(item.diarize_step_durations)
             if step_detail:
                 detail = f"{detail}. {step_detail}"
@@ -50,36 +119,28 @@ def format_digest_html(data) -> str:
 
     est = _fmt_estimate(data.queue_estimated_secs)
 
-    avg_html = ""
-    has_any_avg = (data.avg_transcribe_secs is not None or data.avg_diarize_secs is not None
-                   or data.avg_total_secs is not None or data.avg_duration_secs is not None
-                   or data.processing_factor is not None)
-    if has_any_avg:
-        avg_duration_row = ""
-        if data.avg_duration_secs is not None:
-            avg_duration_row = f"""\
-    <tr><td style="padding: 4px 12px; color: #666;">Avg episode length</td>
-        <td style="padding: 4px 12px;">{_fmt_short_duration(data.avg_duration_secs)}</td></tr>"""
-        factor_row = ""
-        if data.processing_factor is not None:
-            factor_row = f"""\
-    <tr style="background: #f9f9f9;">
-        <td style="padding: 4px 12px; color: #666;">Processing factor</td>
-        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_factor(data.processing_factor)}</td></tr>"""
-        avg_html = f"""\
-  <h3 style="margin-top: 20px; margin-bottom: 8px;">Avg Processing Time (all episodes)</h3>
-  <table style="border-collapse: collapse; width: 100%;">
-    <tr><td style="padding: 4px 12px; color: #666;">Avg transcription</td>
-        <td style="padding: 4px 12px;">{_fmt_short_duration(data.avg_transcribe_secs)}</td></tr>
-    <tr style="background: #f9f9f9;">
-        <td style="padding: 4px 12px; color: #666;">Avg diarization</td>
-        <td style="padding: 4px 12px;">{_fmt_short_duration(data.avg_diarize_secs)}</td></tr>
-    <tr><td style="padding: 4px 12px; color: #666;">Avg per episode</td>
-        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(data.avg_total_secs)}</td></tr>
-{avg_duration_row}
-{factor_row}
-  </table>
-"""
+    provider_avgs_html = ""
+    for pa in getattr(data, "provider_averages", []) or []:
+        heading = f"Avg Processing Time ({_provider_label(pa.provider)})"
+        provider_avgs_html += _render_avg_table_html(
+            heading,
+            pa.avg_transcribe_secs,
+            pa.avg_diarize_secs,
+            pa.avg_total_secs,
+            pa.avg_duration_secs,
+            pa.processing_factor,
+        )
+
+    avg_html = provider_avgs_html
+    if not avg_html:
+        avg_html = _render_avg_table_html(
+            "Avg Processing Time (all episodes)",
+            data.avg_transcribe_secs,
+            data.avg_diarize_secs,
+            data.avg_total_secs,
+            data.avg_duration_secs,
+            data.processing_factor,
+        )
 
     return f"""\
 <html>
@@ -115,6 +176,8 @@ def format_digest_telegram(data) -> str:
         duration = _fmt_duration(item.duration_secs)
         if item.event_type == "episode.done":
             detail = f"processed in {_fmt_short_duration(item.total_duration_secs)}"
+            if item.episode_processing_factor is not None:
+                detail = f"{detail} ({_fmt_factor(item.episode_processing_factor)})"
             step_detail = _fmt_diarization_steps(item.diarize_step_durations)
             if step_detail:
                 detail = f"{detail}. {step_detail}"
@@ -125,21 +188,34 @@ def format_digest_telegram(data) -> str:
                 f"{item.error_class} after {item.retry_count}/{item.retry_max} retries"
             )
 
-    has_any_avg_tg = (data.avg_transcribe_secs is not None or data.avg_diarize_secs is not None
-                      or data.avg_total_secs is not None or data.avg_duration_secs is not None
-                      or data.processing_factor is not None)
-    if has_any_avg_tg:
-        avg_block = (
-            f"\n*Avg Processing Time (all episodes)*\n"
-            f"`Avg transcribe:  {_fmt_short_duration(data.avg_transcribe_secs)}`\n"
-            f"`Avg diarize:     {_fmt_short_duration(data.avg_diarize_secs)}`\n"
-            f"`Avg per episode: {_fmt_short_duration(data.avg_total_secs)}`"
+    provider_blocks = []
+    for pa in getattr(data, "provider_averages", []) or []:
+        heading = f"Avg Processing Time ({_provider_label(pa.provider)})"
+        block = _render_avg_block_telegram(
+            heading,
+            pa.avg_transcribe_secs,
+            pa.avg_diarize_secs,
+            pa.avg_total_secs,
+            pa.avg_duration_secs,
+            pa.processing_factor,
         )
-        if data.avg_duration_secs is not None:
-            avg_block += f"\n`Avg ep. length:  {_fmt_short_duration(data.avg_duration_secs)}`"
-        if data.processing_factor is not None:
-            avg_block += f"\n`Processing factor: {_fmt_factor(data.processing_factor)}`"
-        lines.append(avg_block)
+        if block:
+            provider_blocks.append(block)
+
+    if provider_blocks:
+        for block in provider_blocks:
+            lines.append(block)
+    else:
+        fallback = _render_avg_block_telegram(
+            "Avg Processing Time (all episodes)",
+            data.avg_transcribe_secs,
+            data.avg_diarize_secs,
+            data.avg_total_secs,
+            data.avg_duration_secs,
+            data.processing_factor,
+        )
+        if fallback:
+            lines.append(fallback)
 
     est = _fmt_estimate(data.queue_estimated_secs)
     lines.append(f"\n*Queue:* {data.queue_remaining} remaining · Est. {est}")

--- a/apps/pipeline/app/services/notification_events.py
+++ b/apps/pipeline/app/services/notification_events.py
@@ -16,6 +16,8 @@ class EpisodeDoneEvent(Event):
     diarize_duration_secs: float | None = None
     diarize_step_durations: dict[str, float] | None = None
     total_duration_secs: float | None = None
+    inference_provider_used: str | None = None
+    episode_processing_factor: float | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
     avg_transcribe_secs: float | None = None
@@ -36,6 +38,7 @@ class EpisodeFailedEvent(Event):
     error_message: str = ""
     retry_count: int = 0
     retry_max: int = 3
+    inference_provider_used: str | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
     avg_transcribe_secs: float | None = None

--- a/apps/pipeline/app/services/notification_runtime.py
+++ b/apps/pipeline/app/services/notification_runtime.py
@@ -6,16 +6,20 @@ from app.services.events import bus
 from app.services.notification_events import EpisodeDoneEvent, EpisodeFailedEvent
 
 
-def compute_avg_processing_stats(db: Session) -> tuple[float | None, float | None, float | None]:
-    """Compute average processing times across all completed episodes."""
-    done_episodes = (
-        db.query(Episode)
-        .filter(
-            Episode.status == "done",
-            Episode.processed_at.isnot(None),
-        )
-        .all()
+def compute_avg_processing_stats(
+    db: Session, provider: str | None = None
+) -> tuple[float | None, float | None, float | None]:
+    """Compute average processing times across done episodes.
+
+    If provider is set, only includes episodes with that inference_provider_used value.
+    """
+    q = db.query(Episode).filter(
+        Episode.status == "done",
+        Episode.processed_at.isnot(None),
     )
+    if provider is not None:
+        q = q.filter(Episode.inference_provider_used == provider)
+    done_episodes = q.all()
 
     if not done_episodes:
         return None, None, None
@@ -35,23 +39,58 @@ def compute_avg_processing_stats(db: Session) -> tuple[float | None, float | Non
     return avg_t, avg_d, avg_total
 
 
-def compute_avg_duration(db: Session) -> float | None:
-    """Compute average episode audio duration across all completed episodes."""
-    done_episodes = (
-        db.query(Episode)
-        .filter(
-            Episode.status == "done",
-            Episode.duration_secs.isnot(None),
-        )
-        .all()
+def compute_avg_duration(db: Session, provider: str | None = None) -> float | None:
+    """Compute average episode audio duration across done episodes.
+
+    If provider is set, only includes episodes with that inference_provider_used value.
+    """
+    q = db.query(Episode).filter(
+        Episode.status == "done",
+        Episode.duration_secs.isnot(None),
     )
+    if provider is not None:
+        q = q.filter(Episode.inference_provider_used == provider)
+    done_episodes = q.all()
     if not done_episodes:
         return None
     return sum(ep.duration_secs for ep in done_episodes) / len(done_episodes)
 
 
+def compute_avg_processing_factor(db: Session, provider: str | None = None) -> float | None:
+    """Compute avg processing factor (processing_secs / audio_secs) across done episodes.
+
+    If provider is set, only includes episodes with that inference_provider_used value.
+    """
+    q = db.query(Episode).filter(
+        Episode.status == "done",
+        Episode.processed_at.isnot(None),
+        Episode.duration_secs.isnot(None),
+    )
+    if provider is not None:
+        q = q.filter(Episode.inference_provider_used == provider)
+    done_episodes = q.all()
+
+    total_processing = 0.0
+    total_audio = 0.0
+    for ep in done_episodes:
+        processing_secs = (ep.transcribe_duration_secs or 0) + (ep.diarize_duration_secs or 0)
+        if processing_secs <= 0 or not ep.duration_secs:
+            continue
+        total_processing += processing_secs
+        total_audio += ep.duration_secs
+
+    if total_audio == 0:
+        return None
+    return total_processing / total_audio
+
+
 def estimate_queue_status(db: Session) -> tuple[int, float | None, float | None]:
-    """Return (remaining_count, estimated_seconds_to_complete, processing_factor)."""
+    """Return (remaining_count, estimated_seconds_to_complete, processing_factor).
+
+    processing_factor here reflects the duration-weighted rate of the 10 most
+    recent completed episodes regardless of provider — used for the queue ETA,
+    which processes whatever comes next.
+    """
     remaining = (
         db.query(Episode)
         .filter(Episode.status.in_(["pending", "downloading", "transcribing", "diarizing", "archiving"]))
@@ -107,12 +146,28 @@ def _compute_total_processing_duration_secs(episode: Episode) -> float | None:
     return sum(measured_durations) if measured_durations else None
 
 
+def _compute_episode_processing_factor(
+    total_processing_secs: float | None, duration_secs: int | None
+) -> float | None:
+    """Return processing_secs / audio_secs for a single episode."""
+    if total_processing_secs is None or not duration_secs:
+        return None
+    return total_processing_secs / duration_secs
+
+
 def emit_episode_done_event(db: Session, episode: Episode) -> None:
-    """Emit EpisodeDoneEvent using runtime queue/average stats."""
-    remaining, estimated, factor = estimate_queue_status(db)
-    avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
-    avg_dur = compute_avg_duration(db)
+    """Emit EpisodeDoneEvent using runtime queue/average stats.
+
+    Averages are scoped to the episode's inference provider so that fast remote
+    runs don't skew the average shown next to a slow local run (or vice versa).
+    """
+    provider = episode.inference_provider_used
+    remaining, estimated, _ = estimate_queue_status(db)
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db, provider=provider)
+    avg_dur = compute_avg_duration(db, provider=provider)
+    avg_factor = compute_avg_processing_factor(db, provider=provider)
     total_secs = _compute_total_processing_duration_secs(episode)
+    episode_factor = _compute_episode_processing_factor(total_secs, episode.duration_secs)
     bus.emit(
         EpisodeDoneEvent(
             episode_id=episode.id,
@@ -124,13 +179,15 @@ def emit_episode_done_event(db: Session, episode: Episode) -> None:
             diarize_duration_secs=episode.diarize_duration_secs,
             diarize_step_durations=episode.diarize_step_durations,
             total_duration_secs=total_secs,
+            inference_provider_used=provider,
+            episode_processing_factor=episode_factor,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
             avg_transcribe_secs=avg_t,
             avg_diarize_secs=avg_d,
             avg_total_secs=avg_total,
             avg_duration_secs=avg_dur,
-            processing_factor=factor,
+            processing_factor=avg_factor,
         )
     )
 
@@ -143,9 +200,11 @@ def emit_episode_failed_event(
     error_message: str,
 ) -> None:
     """Emit EpisodeFailedEvent using runtime queue/average stats."""
-    remaining, estimated, factor = estimate_queue_status(db)
-    avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
-    avg_dur = compute_avg_duration(db)
+    provider = episode.inference_provider_used
+    remaining, estimated, _ = estimate_queue_status(db)
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db, provider=provider)
+    avg_dur = compute_avg_duration(db, provider=provider)
+    avg_factor = compute_avg_processing_factor(db, provider=provider)
     bus.emit(
         EpisodeFailedEvent(
             episode_id=episode.id,
@@ -157,12 +216,13 @@ def emit_episode_failed_event(
             error_message=error_message,
             retry_count=episode.retry_count,
             retry_max=episode.retry_max,
+            inference_provider_used=provider,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
             avg_transcribe_secs=avg_t,
             avg_diarize_secs=avg_d,
             avg_total_secs=avg_total,
             avg_duration_secs=avg_dur,
-            processing_factor=factor,
+            processing_factor=avg_factor,
         )
     )

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -55,6 +55,17 @@ def _fmt_factor(factor: float | None) -> str:
     return f"{factor:.1f}x"
 
 
+def _provider_label(provider: str | None) -> str:
+    """Human label for an inference provider, used in averages section headers."""
+    if provider == "local":
+        return "local episodes"
+    if provider == "fireworks":
+        return "remote episodes"
+    if provider:
+        return f"{provider} episodes"
+    return "all episodes"
+
+
 def _fmt_diarize_steps_html(step_durations: dict[str, float] | None) -> str:
     if not step_durations:
         return ""
@@ -98,10 +109,11 @@ def _fmt_avg_section_html(event) -> str:
     if event.processing_factor is not None:
         factor_row = f"""\
     <tr style="background: #f9f9f9;">
-        <td style="padding: 4px 12px; color: #666;">Processing factor</td>
+        <td style="padding: 4px 12px; color: #666;">Avg processing factor</td>
         <td style="padding: 4px 12px; font-weight: 600;">{_fmt_factor(event.processing_factor)}</td></tr>"""
+    scope_label = _provider_label(getattr(event, "inference_provider_used", None))
     return f"""\
-  <h3 style="margin-top: 20px; margin-bottom: 8px;">Avg Processing Time (all episodes)</h3>
+  <h3 style="margin-top: 20px; margin-bottom: 8px;">Avg Processing Time ({scope_label})</h3>
   <table style="border-collapse: collapse; width: 100%;">
     <tr><td style="padding: 4px 12px; color: #666;">Avg transcription</td>
         <td style="padding: 4px 12px;">{_fmt_short_duration(event.avg_transcribe_secs)}</td></tr>
@@ -121,8 +133,9 @@ def _fmt_avg_section_telegram(event) -> str:
             and event.avg_total_secs is None and event.avg_duration_secs is None
             and event.processing_factor is None):
         return ""
+    scope_label = _provider_label(getattr(event, "inference_provider_used", None))
     lines = (
-        f"\n*Avg Processing Time (all episodes)*\n"
+        f"\n*Avg Processing Time ({scope_label})*\n"
         f"`Avg transcribe:  {_fmt_short_duration(event.avg_transcribe_secs)}`\n"
         f"`Avg diarize:     {_fmt_short_duration(event.avg_diarize_secs)}`\n"
         f"`Avg per episode: {_fmt_short_duration(event.avg_total_secs)}`\n"
@@ -130,13 +143,19 @@ def _fmt_avg_section_telegram(event) -> str:
     if event.avg_duration_secs is not None:
         lines += f"`Avg ep. length:  {_fmt_short_duration(event.avg_duration_secs)}`\n"
     if event.processing_factor is not None:
-        lines += f"`Processing factor: {_fmt_factor(event.processing_factor)}`\n"
+        lines += f"`Avg processing factor: {_fmt_factor(event.processing_factor)}`\n"
     return lines
 
 
 def format_done_html(event: EpisodeDoneEvent) -> str:
     avg_html = _fmt_avg_section_html(event)
     diarize_steps_html = _fmt_diarize_steps_html(event.diarize_step_durations)
+    episode_factor_row = ""
+    if event.episode_processing_factor is not None:
+        episode_factor_row = f"""\
+    <tr style="background: #f9f9f9;">
+        <td style="padding: 4px 12px; color: #666;">Processing factor</td>
+        <td style="padding: 4px 12px; font-weight: 600;">{_fmt_factor(event.episode_processing_factor)}</td></tr>"""
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 520px; margin: 0 auto; padding: 16px;">
@@ -162,6 +181,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
         <td style="padding: 4px 12px;">{_fmt_short_duration(event.diarize_duration_secs)}</td></tr>
     <tr><td style="padding: 4px 12px; color: #666;">Total</td>
         <td style="padding: 4px 12px; font-weight: 600;">{_fmt_short_duration(event.total_duration_secs)}</td></tr>
+{episode_factor_row}
   </table>
 {diarize_steps_html}
 {avg_html}
@@ -182,6 +202,11 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
 def format_done_telegram(event: EpisodeDoneEvent) -> str:
     avg_section = _fmt_avg_section_telegram(event)
     diarize_steps_section = _fmt_diarize_steps_telegram(event.diarize_step_durations)
+    episode_factor_line = ""
+    if event.episode_processing_factor is not None:
+        episode_factor_line = (
+            f"`Processing factor: {_fmt_factor(event.episode_processing_factor)}`\n"
+        )
     return (
         f"*✅ Episode Processed*\n\n"
         f"*Podcast:* {event.podcast_title}\n"
@@ -192,6 +217,7 @@ def format_done_telegram(event: EpisodeDoneEvent) -> str:
         f"`Transcription:  {_fmt_short_duration(event.transcribe_duration_secs)}`\n"
         f"`Diarization:    {_fmt_short_duration(event.diarize_duration_secs)}`\n"
         f"`Total:          {_fmt_short_duration(event.total_duration_secs)}`\n"
+        f"{episode_factor_line}"
         f"{diarize_steps_section}"
         f"{avg_section}\n"
         f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"

--- a/apps/pipeline/tests/unit/test_digest.py
+++ b/apps/pipeline/tests/unit/test_digest.py
@@ -230,7 +230,13 @@ def test_send_digest_skips_when_no_unsent_events(mock_get_ns, mock_estimate, moc
     send_digest_if_due(now=now)
 
 
-from app.services.digest import format_digest_html, format_digest_telegram, DigestData
+from app.services.digest import (
+    DigestData,
+    DigestItem,
+    ProviderAverages,
+    format_digest_html,
+    format_digest_telegram,
+)
 
 
 def test_digest_html_shows_new_metrics_when_legacy_absent():
@@ -248,7 +254,7 @@ def test_digest_html_shows_new_metrics_when_legacy_absent():
     html = format_digest_html(data)
     assert "Avg episode length" in html
     assert "40m 00s" in html
-    assert "Processing factor" in html
+    assert "Avg processing factor" in html
     assert "1.5x" in html
 
 
@@ -267,7 +273,7 @@ def test_digest_telegram_shows_new_metrics_when_legacy_absent():
     md = format_digest_telegram(data)
     assert "Avg ep. length" in md
     assert "40m 00s" in md
-    assert "Processing factor" in md
+    assert "Avg processing factor" in md
     assert "1.5x" in md
 
 @patch("app.services.digest.SessionLocal")
@@ -319,3 +325,156 @@ def test_send_digest_maps_diarize_step_durations(
         "provider_diarization_secs": 42.0,
         "speaker_assignment_secs": 13.0,
     }
+
+
+def test_digest_html_renders_per_provider_averages():
+    """When provider_averages is populated, digest renders one table per provider."""
+    data = DigestData(
+        frequency="daily",
+        date_label="Apr 06, 2026",
+        items=[],
+        provider_averages=[
+            ProviderAverages(
+                provider="local",
+                avg_transcribe_secs=600.0,
+                avg_diarize_secs=300.0,
+                avg_total_secs=900.0,
+                avg_duration_secs=1800.0,
+                processing_factor=0.5,
+            ),
+            ProviderAverages(
+                provider="fireworks",
+                avg_transcribe_secs=60.0,
+                avg_diarize_secs=30.0,
+                avg_total_secs=90.0,
+                avg_duration_secs=1800.0,
+                processing_factor=0.05,
+            ),
+        ],
+    )
+    html = format_digest_html(data)
+    assert "Avg Processing Time (local episodes)" in html
+    assert "Avg Processing Time (remote episodes)" in html
+    assert "0.5x" in html
+    assert "0.1x" in html  # 0.05 rounds to 0.1x in _fmt_factor
+
+
+def test_digest_telegram_renders_per_provider_averages():
+    data = DigestData(
+        frequency="daily",
+        date_label="Apr 06, 2026",
+        items=[],
+        provider_averages=[
+            ProviderAverages(
+                provider="local",
+                avg_transcribe_secs=600.0,
+                avg_total_secs=900.0,
+                processing_factor=0.5,
+            ),
+            ProviderAverages(
+                provider="fireworks",
+                avg_transcribe_secs=60.0,
+                avg_total_secs=90.0,
+                processing_factor=0.05,
+            ),
+        ],
+    )
+    md = format_digest_telegram(data)
+    assert "Avg Processing Time (local episodes)" in md
+    assert "Avg Processing Time (remote episodes)" in md
+
+
+def test_digest_html_renders_per_item_processing_factor():
+    """Done items include the per-episode processing factor next to the detail text."""
+    data = DigestData(
+        frequency="daily",
+        date_label="Apr 06, 2026",
+        items=[
+            DigestItem(
+                event_type="episode.done",
+                episode_title="Ep1",
+                podcast_title="Pod",
+                duration_secs=1800,
+                total_duration_secs=900.0,
+                error_class=None,
+                retry_count=None,
+                retry_max=None,
+                inference_provider_used="local",
+                episode_processing_factor=0.5,
+            ),
+        ],
+    )
+    html = format_digest_html(data)
+    assert "0.5x" in html
+
+
+@patch("app.services.digest.SessionLocal")
+@patch("app.services.digest._send_digest")
+@patch("app.services.digest.compute_avg_duration", return_value=None)
+@patch("app.services.digest.compute_avg_processing_stats", return_value=(None, None, None))
+@patch("app.services.digest.compute_avg_processing_factor", return_value=0.5)
+@patch("app.services.digest.estimate_queue_status", return_value=(0, None, None))
+@patch("app.services.digest.get_notification_settings")
+def test_send_digest_builds_per_provider_averages(
+    mock_get_ns,
+    mock_estimate,
+    mock_avg_factor,
+    mock_avg_stats,
+    mock_avg_dur,
+    mock_send_digest,
+    mock_session_cls,
+):
+    mock_get_ns.return_value = {
+        "notification_frequency": "daily",
+        "email_configured": False,
+        "telegram_configured": False,
+    }
+    db = MagicMock()
+    mock_session_cls.return_value = db
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    # Two events: one local, one fireworks — digest should compute a ProviderAverages
+    # entry for each provider.
+    row_local = MagicMock()
+    row_local.event_type = "episode.done"
+    row_local.payload = json.dumps({
+        "episode_title": "Local Ep",
+        "podcast_title": "Pod",
+        "duration_secs": 1800,
+        "total_duration_secs": 900.0,
+        "inference_provider_used": "local",
+        "episode_processing_factor": 0.5,
+    })
+    row_local.sent = False
+
+    row_remote = MagicMock()
+    row_remote.event_type = "episode.done"
+    row_remote.payload = json.dumps({
+        "episode_title": "Remote Ep",
+        "podcast_title": "Pod",
+        "duration_secs": 1800,
+        "total_duration_secs": 90.0,
+        "inference_provider_used": "fireworks",
+        "episode_processing_factor": 0.05,
+    })
+    row_remote.sent = False
+
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        row_local, row_remote
+    ]
+
+    # compute_avg_processing_stats returns (None, None, None) → provider_averages
+    # entries will be dropped because every field is None. Override with non-None
+    # stats so the entries survive.
+    mock_avg_stats.return_value = (100.0, 50.0, 150.0)
+
+    now = datetime(2026, 3, 15, 8, 30, tzinfo=timezone.utc)
+    send_digest_if_due(now=now)
+
+    digest = mock_send_digest.call_args[0][0]
+    assert [pa.provider for pa in digest.provider_averages] == ["local", "fireworks"]
+    # Per-item provider + per-episode factor are carried through.
+    assert digest.items[0].inference_provider_used == "local"
+    assert digest.items[0].episode_processing_factor == 0.5
+    assert digest.items[1].inference_provider_used == "fireworks"
+    assert digest.items[1].episode_processing_factor == 0.05

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -209,7 +209,7 @@ def test_format_done_html_shows_new_metrics_when_legacy_absent():
     html = format_done_html(event)
     assert "Avg episode length" in html
     assert "40m 00s" in html  # 2400s
-    assert "Processing factor" in html
+    assert "Avg processing factor" in html
     assert "1.5x" in html
 
 
@@ -224,5 +224,46 @@ def test_format_done_telegram_shows_new_metrics_when_legacy_absent():
     md = format_done_telegram(event)
     assert "Avg ep. length" in md
     assert "40m 00s" in md
-    assert "Processing factor" in md
+    assert "Avg processing factor" in md
     assert "1.5x" in md
+
+
+def test_format_done_html_shows_provider_scoped_label_local():
+    event = _make_done_event()
+    event.inference_provider_used = "local"
+    event.avg_transcribe_secs = 100.0
+    html = format_done_html(event)
+    assert "Avg Processing Time (local episodes)" in html
+
+
+def test_format_done_html_shows_provider_scoped_label_remote():
+    event = _make_done_event()
+    event.inference_provider_used = "fireworks"
+    event.avg_transcribe_secs = 100.0
+    html = format_done_html(event)
+    assert "Avg Processing Time (remote episodes)" in html
+
+
+def test_format_done_telegram_shows_provider_scoped_label_local():
+    event = _make_done_event()
+    event.inference_provider_used = "local"
+    event.avg_transcribe_secs = 100.0
+    md = format_done_telegram(event)
+    assert "Avg Processing Time (local episodes)" in md
+
+
+def test_format_done_html_shows_episode_processing_factor():
+    """Per-episode processing factor appears alongside the per-episode times."""
+    event = _make_done_event()
+    event.episode_processing_factor = 0.3
+    html = format_done_html(event)
+    assert "Processing factor" in html
+    assert "0.3x" in html
+
+
+def test_format_done_telegram_shows_episode_processing_factor():
+    event = _make_done_event()
+    event.episode_processing_factor = 1.2
+    md = format_done_telegram(event)
+    assert "Processing factor" in md
+    assert "1.2x" in md

--- a/apps/pipeline/tests/unit/test_notifications.py
+++ b/apps/pipeline/tests/unit/test_notifications.py
@@ -8,6 +8,10 @@ from app.services.notifications import (
     compute_avg_processing_stats,
     estimate_queue_status,
 )
+from app.services.notification_runtime import (
+    _compute_episode_processing_factor,
+    compute_avg_processing_factor,
+)
 
 
 def test_episode_done_event_fields():
@@ -179,6 +183,65 @@ def test_compute_avg_processing_stats_partial_data():
     assert avg_t == 100.0
     assert avg_d is None  # no diarize data at all
     assert avg_total == 100.0  # transcribe only (diarize treated as 0)
+
+
+def test_compute_avg_processing_stats_filters_by_provider():
+    """When provider is passed, only matching episodes contribute to the avg."""
+    db = MagicMock()
+
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+
+    # Simulate: one local ep (100/50), one remote ep (10/5). Asking for local → 100/50 only.
+    query_mock.all.return_value = [MagicMock(transcribe_duration_secs=100.0, diarize_duration_secs=50.0)]
+    db.query.return_value = query_mock
+
+    avg_t, avg_d, avg_total = compute_avg_processing_stats(db, provider="local")
+    assert avg_t == 100.0
+    assert avg_d == 50.0
+    assert avg_total == 150.0
+
+    # The filter should have been called with an extra clause when provider is set.
+    # (we just verify it was called at least twice — once for status, once for provider)
+    assert query_mock.filter.call_count >= 2
+
+
+def test_compute_avg_processing_factor_returns_ratio():
+    """processing_secs / audio_secs is averaged across done episodes."""
+    db = MagicMock()
+
+    ep1 = MagicMock(
+        transcribe_duration_secs=600.0, diarize_duration_secs=300.0, duration_secs=1800
+    )  # 900 processing / 1800 audio = 0.5
+    ep2 = MagicMock(
+        transcribe_duration_secs=300.0, diarize_duration_secs=150.0, duration_secs=1800
+    )  # 450 / 1800 = 0.25
+
+    q = MagicMock()
+    q.filter.return_value = q
+    q.all.return_value = [ep1, ep2]
+    db.query.return_value = q
+
+    factor = compute_avg_processing_factor(db)
+    # duration-weighted: (900 + 450) / (1800 + 1800) = 1350 / 3600 = 0.375
+    assert factor == 0.375
+
+
+def test_compute_avg_processing_factor_no_data():
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.all.return_value = []
+    db.query.return_value = q
+    assert compute_avg_processing_factor(db) is None
+
+
+def test_episode_processing_factor_helper():
+    """Per-episode factor is processing / duration, or None if missing."""
+    assert _compute_episode_processing_factor(900.0, 1800) == 0.5
+    assert _compute_episode_processing_factor(None, 1800) is None
+    assert _compute_episode_processing_factor(900.0, None) is None
+    assert _compute_episode_processing_factor(900.0, 0) is None
 
 
 def test_estimate_queue_status_no_history():


### PR DESCRIPTION
## Summary
Notifications now compute averages separately for local vs remote-processed episodes (remote Fireworks inference is much faster, so mixing them skewed the averages shown next to local runs). Also adds a per-episode processing factor alongside the existing average processing factor.

Closes #518.

## Changes
- `notification_events.py`: add `inference_provider_used` and `episode_processing_factor` to `EpisodeDoneEvent`; add `inference_provider_used` to `EpisodeFailedEvent`.
- `notification_runtime.py`: `compute_avg_processing_stats` / `compute_avg_duration` now accept an optional `provider` filter; new `compute_avg_processing_factor` helper; emitters pass `episode.inference_provider_used` and compute a per-episode factor.
- `notifications.py`: averages section header now shows scope (`(local episodes)` / `(remote episodes)`); per-episode section gets a "Processing factor" row; averages-block factor relabeled "Avg processing factor" for clarity.
- `digest.py` / `digest_formatters.py`: `DigestItem` carries provider + per-episode factor; `DigestData` gains `provider_averages: list[ProviderAverages]`; digest renders one averages table per provider seen in the batch.

## Testing
- Unit tests for provider filtering, per-episode factor helper, provider-scoped section labels, per-provider digest sections, and per-item factor rendering.
- Full pipeline unit suite passes (486 tests).

## Checklist
- [x] Tests pass
- [x] Code follows project conventions
- [ ] Documentation updated (not needed — internal notification rendering only)