### PR TITLE
feat(inference): ship en_core_web_trf and flip default (#523 A2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ ZOMBIE_MIN_TIMEOUT_MINUTES=60  # floor when audio duration is unknown
 # -- Ollama (RAG) --
 OLLAMA_URL=http://ollama:11434  # Ollama API endpoint for LLM inference
 
+# -- Host/guest inference (PRD-04) --
+# INFERENCE_ENABLED=true                # Set to false to skip speaker-name inference
+# SPACY_MODEL=en_core_web_trf           # trf (default, ~500 MB, better accuracy) | lg (~200 MB, constrained hosts)
+
 # -- Hardware profile override for cost estimates (optional) --
 # Auto-detected from /proc/cpuinfo + GPU check if omitted.
 # Options: cpu-only-4core, cpu-only-8core, cpu-only-16core, gpu-rtx3060, gpu-rtx3080

--- a/apps/pipeline/Dockerfile.worker
+++ b/apps/pipeline/Dockerfile.worker
@@ -18,6 +18,7 @@ RUN pip install --no-cache-dir poetry \
        else \
          poetry install --with ml --without dev --no-root --no-interaction --no-ansi; \
        fi \
+    && python -m spacy download en_core_web_trf \
     && python -m spacy download en_core_web_lg
 
 COPY . .

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -47,7 +47,9 @@ class Settings(BaseSettings):
 
     # Host/guest inference (PRD-04 S9)
     inference_enabled: bool = True
-    spacy_model: str = "en_core_web_lg"
+    # en_core_web_trf is the PRD-04 default (better NER accuracy, ~500 MB).
+    # inference.py falls back to en_core_web_lg if trf is not installed.
+    spacy_model: str = "en_core_web_trf"
 
     # Hardware profile override for cost estimates (Issue #322)
     hardware_profile: str | None = None

--- a/apps/web/src/components/RemoteInferenceSectionParts.tsx
+++ b/apps/web/src/components/RemoteInferenceSectionParts.tsx
@@ -102,7 +102,10 @@ export const PIPELINE_STEPS: PipelineStep[] = [
     disabledReason:
       "Speaker name inference is currently supported locally only.",
     providerField: null,
-    localModels: [{ value: "en_core_web_lg", label: "spaCy en_core_web_lg" }],
+    localModels: [
+      { value: "en_core_web_trf", label: "spaCy en_core_web_trf (default, ~500 MB)" },
+      { value: "en_core_web_lg", label: "spaCy en_core_web_lg (~200 MB, low-memory)" },
+    ],
     remoteModels: [],
     modelField: null,
     remoteModelField: null,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ The worker monitors running jobs and marks them as failed if they exceed expecte
 | Variable | Default | Description |
 |---|---|---|
 | `INFERENCE_ENABLED` | `true` | Whether to run spaCy NER-based speaker name inference after diarization. |
-| `SPACY_MODEL` | `en_core_web_lg` | spaCy model for named entity recognition. `en_core_web_lg` gives best results. |
+| `SPACY_MODEL` | `en_core_web_trf` | spaCy NER model. `en_core_web_trf` (~500 MB, best accuracy) is the default; override to `en_core_web_lg` (~200 MB) on memory-constrained hosts. The worker image ships both and automatically falls back to `en_core_web_lg` at runtime if `trf` is unavailable. |
 
 ## Fireworks Provider
 

--- a/docs/episode-lifecycle.md
+++ b/docs/episode-lifecycle.md
@@ -120,7 +120,7 @@ pending → download → transcribe → diarize → chunk → embed → infer �
 **Status:** `inferring`
 
 **What it does:**
-- Extracts host/guest names from episode title and description using spaCy NER (`en_core_web_lg`)
+- Extracts host/guest names from episode title and description using spaCy NER (`en_core_web_trf` by default, falls back to `en_core_web_lg` if unavailable)
 - Maps names to speaker labels (SPEAKER_00 = host, others = guests)
 - Pre-populates `speaker_names` table with inferred display names
 - Skipped if diarization failed or inference is disabled in config

--- a/prds/PRD-04-host-guest-inference.md
+++ b/prds/PRD-04-host-guest-inference.md
@@ -2,11 +2,12 @@
 
 **Project:** Podlog — Self-hosted Podcast Transcription & Search  
 **Document:** PRD-04 — Host & Guest Inference  
-**Version:** 1.2
+**Version:** 1.3
 **Status:** Active
 **Depends on:** PRD-01 v1.1, PRD-02 v1.1, PRD-03 v1.1
 
 **Changelog:**
+- v1.3 — `Dockerfile.worker` now downloads `en_core_web_trf` in addition to `en_core_web_lg`, and `SPACY_MODEL` default flipped to `en_core_web_trf` to match the spec in §4.1. `en_core_web_lg` remains installed as an automatic fallback and as the recommended override for memory-constrained hosts (issue #523).
 - v1.2 — Marked status Active (feature is shipped: `services/inference.py`, `tasks/infer.py`, `INFERRING` stage, spaCy `en_core_web_lg` bundled in `Dockerfile.worker`). Pipeline stage ordering in §4.6 updated to match actual code path (adds CHUNKING and EMBEDDING between DIARIZING and INFERRING).
 
 ---


### PR DESCRIPTION
## Summary

PR 1 of 5 for #523. Covers option **A2**: PRD-04 §4.1 / §10 specify `en_core_web_trf` as the default spaCy model, but `Dockerfile.worker` only downloaded `en_core_web_lg`, so the spec default never actually ran.

## Changes
- `apps/pipeline/Dockerfile.worker`: download `en_core_web_trf` alongside `en_core_web_lg`.
- `apps/pipeline/app/config.py`: flip `SPACY_MODEL` default from `en_core_web_lg` to `en_core_web_trf`.
- `.env.example`: document `SPACY_MODEL` and `INFERENCE_ENABLED` overrides.
- `prds/PRD-04-host-guest-inference.md`: v1.3 changelog entry.

`apps/pipeline/app/services/inference.py` already falls back to `en_core_web_lg` at runtime if `trf` is not installed, so the change is safe for anyone who builds an old image with the new config.

## Testing
- Existing `tests/unit/test_inference.py` and `tests/unit/test_task_infer.py` still pass (33 passed, 1 warning).
- Verified `Settings.spacy_model` resolves to `en_core_web_trf` by default.
- Image rebuild + runtime load will be verified in the Docker phase after merge.

## Follow-ups
- PR 2: B1 + B3 + E1 + E2 (RSS `itunes:author`/`itunes:owner`/`dc:creator` parsing + episode-title heuristic polish)
- PR 3: B2 (`podcast:person`)
- PR 4: A1 (recurring host rule)
- PR 5: C1 + C2 (per-feed name cache, auto-populate on rename)

Part of #523. Deferred options (D + E3 + F) tracked in #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)