### PR TITLE
fix(inference): drop ::text cast on feed_speaker_cache uuid insert (#523)

### DIFF
--- a/apps/pipeline/alembic/versions/014_add_feed_speaker_cache.py
+++ b/apps/pipeline/alembic/versions/014_add_feed_speaker_cache.py
@@ -77,7 +77,7 @@ def upgrade() -> None:
             occurrence_count, last_seen_episode_id, last_seen_at, created_at
         )
         SELECT
-            gen_random_uuid()::text,
+            gen_random_uuid(),
             e.feed_id,
             sn.speaker_label,
             (array_agg(sn.display_name ORDER BY e.published_at DESC NULLS LAST, e.id DESC))[1]

--- a/apps/web/src/app/api/episodes/[id]/speakers/route.ts
+++ b/apps/web/src/app/api/episodes/[id]/speakers/route.ts
@@ -44,7 +44,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
            occurrence_count, last_seen_episode_id, last_seen_at, created_at
          )
          SELECT
-           gen_random_uuid()::text,
+           gen_random_uuid(),
            e.feed_id,
            $2,
            $3,


### PR DESCRIPTION
## Summary

- Follow-up to #531. The migration 014 backfill and the web rename route were generating ids as `gen_random_uuid()::text`, but `feed_speaker_cache.id` is PostgreSQL `uuid` (not text). Pipeline boot halted at `alembic upgrade head` with `column "id" is of type uuid but expression is of type text`.
- Drop the `::text` cast in both places so postgres inserts the uuid value directly, matching every other migration in the repo (`server_default = gen_random_uuid()`).

## Verification

- Rebuilt pipeline/worker/web images and restarted services. `SELECT version_num FROM alembic_version` → `014`.
- `SELECT COUNT(*), COUNT(DISTINCT feed_id) FROM feed_speaker_cache` → `28, 4` — matches the earlier dry-run on the dev DB.
- Pipeline + web are healthy, queue idle, worker consuming from the live DB.

## Test plan

- [x] CI: pipeline unit + web unit (should continue green — no test assertions referenced the cast)
- [x] Manual: production migration applies; cache rows backfilled

Closes nothing new. Hotfix for #523 C1/C2.