### PR TITLE
fix(inference): reconcile confidence in merge_candidates (#530)

### DIFF
--- a/apps/pipeline/app/services/inference.py
+++ b/apps/pipeline/app/services/inference.py
@@ -505,18 +505,45 @@ def extract_metadata_candidates(
 def merge_candidates(
     metadata_candidates: list[CandidateName],
     ner_candidates: list[CandidateName],
+    feed_title: Optional[str] = None,
 ) -> list[CandidateName]:
     """Combine metadata and NER candidates, deduping by normalized name.
 
     A name present in both lists keeps the metadata entry (already carries
     stronger role/confidence). The metadata list is returned first so the
     classifier handles those before heuristics.
+
+    Confidence reconciliation (issue #530): when a dropped NER duplicate would
+    have classified at HIGH via feed_title match (the canonical HIGH host
+    signal in classify_candidates), promote the retained metadata entry to
+    HIGH so the dedup does not shadow the stronger corroborating signal.
+    Without this, a MEDIUM recurring_host candidate for the same name writes
+    a MEDIUM speaker_names row, which then fails the HIGH-only filter in
+    get_recurring_host_name and causes the rule to oscillate as the window
+    fills with self-generated MEDIUM rows. Only applied when roles align
+    (metadata host + feed_title match always implies host) — cross-role
+    NER-HIGH paths (name_after_colon_in_title → guest HIGH) do not reconcile.
     """
-    seen = {normalize_name(c.name) for c in metadata_candidates}
-    out = list(metadata_candidates)
+    f_title_lower = feed_title.lower() if feed_title else None
+    metadata_by_norm: dict[str, CandidateName] = {}
+    out: list[CandidateName] = []
+    for c in metadata_candidates:
+        norm = normalize_name(c.name)
+        metadata_by_norm[norm] = c
+        out.append(c)
+    seen = set(metadata_by_norm.keys())
     for c in ner_candidates:
         norm = normalize_name(c.name)
         if norm in seen:
+            meta = metadata_by_norm.get(norm)
+            if (
+                meta is not None
+                and meta.role == "host"
+                and meta.confidence != "HIGH"
+                and f_title_lower
+                and c.name.lower() in f_title_lower
+            ):
+                meta.confidence = "HIGH"
             continue
         seen.add(norm)
         out.append(c)

--- a/apps/pipeline/app/tasks/infer.py
+++ b/apps/pipeline/app/tasks/infer.py
@@ -114,7 +114,9 @@ def infer_speakers(episode_id: str) -> str:
             finally:
                 unload_spacy_model()
 
-            candidates = merge_candidates(metadata_candidates, ner_candidates)
+            candidates = merge_candidates(
+                metadata_candidates, ner_candidates, feed_title=feed_title
+            )
 
             if not candidates:
                 # No names found -- still remap speaker slots by first appearance

--- a/apps/pipeline/tests/unit/test_inference.py
+++ b/apps/pipeline/tests/unit/test_inference.py
@@ -873,6 +873,88 @@ class TestMergeCandidates:
     def test_empty_lists(self):
         assert merge_candidates([], []) == []
 
+    def test_promotes_medium_host_when_ner_dupe_in_feed_title(self):
+        """Issue #530: metadata MEDIUM host promoted to HIGH when a dropped
+        NER dup for the same name appears in feed_title (the canonical HIGH
+        host signal). Blocks the confidence-oscillation cycle where a
+        recurring_host MEDIUM row shadows a would-be HIGH feed_title match."""
+        metadata = [
+            CandidateName(
+                name="Jane Smith", source="recurring_host", role="host", confidence="MEDIUM"
+            )
+        ]
+        ner = [CandidateName(name="Jane Smith", source="feed_title")]
+        merged = merge_candidates(metadata, ner, feed_title="The Jane Smith Show")
+        assert len(merged) == 1
+        assert merged[0].source == "recurring_host"
+        assert merged[0].confidence == "HIGH"
+
+    def test_no_promotion_when_name_absent_from_feed_title(self):
+        """Roles agree but feed_title does not corroborate — confidence stays."""
+        metadata = [
+            CandidateName(
+                name="Jane Smith", source="recurring_host", role="host", confidence="MEDIUM"
+            )
+        ]
+        ner = [CandidateName(name="Jane Smith", source="episode_description")]
+        merged = merge_candidates(metadata, ner, feed_title="Unrelated Show Name")
+        assert merged[0].confidence == "MEDIUM"
+
+    def test_no_promotion_without_feed_title_arg(self):
+        """Default call (no feed_title) preserves prior dedup semantics."""
+        metadata = [
+            CandidateName(
+                name="Jane Smith", source="recurring_host", role="host", confidence="MEDIUM"
+            )
+        ]
+        ner = [CandidateName(name="Jane Smith", source="feed_title")]
+        merged = merge_candidates(metadata, ner)
+        assert merged[0].confidence == "MEDIUM"
+
+    def test_no_promotion_for_guest_role_metadata(self):
+        """feed_title match implies host; never promote a metadata guest
+        candidate even if its name appears there."""
+        metadata = [
+            CandidateName(
+                name="Jane Smith",
+                source="podcast_person_episode",
+                role="guest",
+                confidence="MEDIUM",
+            )
+        ]
+        ner = [CandidateName(name="Jane Smith", source="feed_title")]
+        merged = merge_candidates(metadata, ner, feed_title="The Jane Smith Show")
+        assert merged[0].role == "guest"
+        assert merged[0].confidence == "MEDIUM"
+
+    def test_promotion_matches_case_insensitively(self):
+        """Feed title comparison is case-insensitive (classify_candidates
+        lowercases f_title before the `in` check — keep parity here)."""
+        metadata = [
+            CandidateName(
+                name="JANE SMITH", source="recurring_host", role="host", confidence="MEDIUM"
+            )
+        ]
+        ner = [CandidateName(name="JANE SMITH", source="feed_title")]
+        merged = merge_candidates(metadata, ner, feed_title="the jane smith show")
+        assert merged[0].confidence == "HIGH"
+
+    def test_already_high_metadata_unchanged(self):
+        """Promotion is a no-op when the metadata entry is already HIGH —
+        covers feed_speaker_cache and podcast:person (both HIGH host)."""
+        metadata = [
+            CandidateName(
+                name="Jane Smith",
+                source="feed_speaker_cache",
+                role="host",
+                confidence="HIGH",
+            )
+        ]
+        ner = [CandidateName(name="Jane Smith", source="feed_title")]
+        merged = merge_candidates(metadata, ner, feed_title="The Jane Smith Show")
+        assert merged[0].confidence == "HIGH"
+        assert merged[0].source == "feed_speaker_cache"
+
 
 # --- strip_episode_prefix (PRD-04 E2) ---
 


### PR DESCRIPTION
## Summary

Fixes the confidence-oscillation cycle flagged in the PR #529 second-pass review (issue #530). `merge_candidates` now promotes a retained metadata host candidate to HIGH when the dropped NER duplicate for the same name would have classified at HIGH via `feed_title` match.

## Problem

`merge_candidates` dedups by normalized name, always keeping the metadata entry. When `recurring_host` (MEDIUM, per PRD-04 A1) collided with a NER candidate whose name appeared in `feed_title` (would be HIGH host in `classify_candidates`), the HIGH signal was silently dropped. The resulting `SpeakerName` row was written at MEDIUM, which then failed the HIGH-only filter in `get_recurring_host_name` — the rule starved, stopped firing, and only resumed once the window rotated enough for an independent HIGH row to appear, oscillating thereafter.

## Changes

### `apps/pipeline/app/services/inference.py`
- `merge_candidates` gains an optional `feed_title` parameter.
- When a NER duplicate's name appears in `feed_title` AND the retained metadata entry is a host below HIGH, its confidence is promoted to HIGH (case-insensitive substring match, mirroring `classify_candidates`'s `f_title` check).
- Scoped narrowly to `role == "host"` — cross-role NER-HIGH paths (`name_after_colon_in_title` → guest HIGH) don't reconcile because the metadata side is always host here.

### `apps/pipeline/app/tasks/infer.py`
- `infer_speakers` forwards `feed_title` to `merge_candidates`.

### `apps/pipeline/tests/unit/test_inference.py`
Six new `TestMergeCandidates` cases:
- `test_promotes_medium_host_when_ner_dupe_in_feed_title` — the bug path
- `test_no_promotion_when_name_absent_from_feed_title`
- `test_no_promotion_without_feed_title_arg` (backward compat)
- `test_no_promotion_for_guest_role_metadata`
- `test_promotion_matches_case_insensitively`
- `test_already_high_metadata_unchanged`

## Why it matters

Covers the oscillation case documented in [PR #529 second-pass review](https://github.com/brlauuu/podlog/pull/529#issuecomment-4293578593). Without this, feeds where `feed_title` mentions the host (a common pattern — "The Jane Smith Show", "X with Y") have their recurring-host rule degrade over time as self-generated MEDIUM rows crowd out the HIGH filter.

The MEDIUM-emission self-reinforcement guard in `extract_metadata_candidates` is preserved: `recurring_host` still starts at MEDIUM. Promotion only happens when there is an **independent** HIGH corroboration (NER hit on `feed_title`), which is exactly when self-reinforcement is not a concern.

## Test plan

- [x] `docker compose -f docker-compose.test.yml run --rm test pytest tests/unit/` — 573 passed, 1 skipped (unchanged from baseline)
- [x] `tests/unit/test_inference.py` — 115 passed (was 109; +6 new)
- [ ] Re-infer an episode on a feed whose `feed_title` contains the recurring host's name — verify the `SpeakerName` row is now written at HIGH, and subsequent episodes' `get_recurring_host_name` call is fed HIGH rows
- [ ] Verify no regression on feeds where `feed_title` does NOT mention the host (recurring_host should still emit at MEDIUM)

Closes #530

## References
- PRD-04 §11 (v1.6 changelog) — MEDIUM-emission rationale
- PR #529 — recurring-host rule (PRD-04 A1)
- PR #531 — feed_speaker_cache (already safe at HIGH; not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)