### PR TITLE
feat(web): add Explore button to landing page (#528)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { Search, BrainCircuit } from "lucide-react";
+import { Search, BrainCircuit, Book } from "lucide-react";
 
 export default function HomePage() {
   return (
@@ -28,21 +28,28 @@ export default function HomePage() {
         </p>
       </div>
 
-      {/* Quick links */}
-      <div className="flex gap-4">
+      {/* Quick links — width pinned to logo so three buttons don't outgrow it */}
+      <div className="flex gap-4 w-[280px] sm:w-[420px]">
         <Link
           href="/search"
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors"
+          className="flex-1 inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors"
         >
           <Search size={16} />
           Search
         </Link>
         <Link
           href="/ask"
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors"
+          className="flex-1 inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors"
         >
           <BrainCircuit size={16} />
           Ask
+        </Link>
+        <Link
+          href="/podcasts"
+          className="flex-1 inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-input bg-background text-foreground font-medium text-sm hover:bg-accent transition-colors"
+        >
+          <Book size={16} />
+          Explore
         </Link>
       </div>
     </div>

--- a/apps/web/tests/unit/home-page.test.tsx
+++ b/apps/web/tests/unit/home-page.test.tsx
@@ -53,6 +53,29 @@ describe("HomePage issue 274", () => {
     expect(screen.queryByText(/RAG-powered AI answers/i)).toBeNull();
   });
 
+  test("renders Explore button linking to /podcasts in matching style (issue #528)", () => {
+    render(<HomePage />);
+
+    const exploreLink = screen.getByRole("link", { name: "Explore" });
+    expect(exploreLink).toHaveAttribute("href", "/podcasts");
+    expect(exploreLink.className).toContain("border border-input bg-background text-foreground");
+  });
+
+  test("button group is width-pinned to logo so three buttons cannot outgrow it (issue #528)", () => {
+    const { container } = render(<HomePage />);
+    const searchLink = screen.getByRole("link", { name: "Search" });
+    const buttonRow = searchLink.parentElement as HTMLElement;
+
+    expect(buttonRow.className).toContain("w-[280px]");
+    expect(buttonRow.className).toContain("sm:w-[420px]");
+    expect(searchLink.className).toContain("flex-1");
+    expect(screen.getByRole("link", { name: "Ask" }).className).toContain("flex-1");
+    expect(screen.getByRole("link", { name: "Explore" }).className).toContain("flex-1");
+
+    // Button row should be a direct child of the HomePage root (the logo's container)
+    expect(container.contains(buttonRow)).toBe(true);
+  });
+
   test("uses main-area centering without hardcoded viewport subtraction", () => {
     const { container } = render(<HomePage />);
     const root = container.firstElementChild as HTMLElement;


### PR DESCRIPTION
## Summary

Adds a third quick-link button to the landing page: **Explore** (book icon) → `/podcasts` (the page the Navbar labels "Sources"). Style matches the existing Search and Ask buttons, and the three-button row is pinned to the logo's width so it can never outgrow it.

## Changes

### \`apps/web/src/app/page.tsx\`
- Import lucide \`Book\` icon.
- Wrap the button row in \`w-[280px] sm:w-[420px]\` (mirroring the logo's responsive width) and make each button \`flex-1 justify-center\` so the three buttons share that width equally.
- Add \`<Link href=\"/podcasts\">\` with \`Book\` icon labeled \"Explore\".

### \`apps/web/tests/unit/home-page.test.tsx\`
Two new tests:
- \`renders Explore button linking to /podcasts in matching style\` — existence, href, shared styling classes.
- \`button group is width-pinned to logo so three buttons cannot outgrow it\` — asserts the wrapper has \`w-[280px]\` / \`sm:w-[420px]\` and all three buttons have \`flex-1\`.

## Why the layout change

Before this PR, the two buttons used a plain \`flex gap-4\` with no width constraint. Adding a third button at the default \`px-5\` padding would have pushed the row past the 280px mobile logo width. Pinning the row to the logo's width with \`flex-1\` buttons keeps the visual balance the issue asks for (\"should not be wider than the logo\") and avoids per-button padding tweaks that would drift away from the existing button style.

## Test plan

- [x] \`docker compose -f docker-compose.test.yml run --rm web_test npm test\` — 319 tests passed, 68 suites
- [x] \`home-page.test.tsx\` — 6 passed (+2 new)
- [x] Rendered HTML verified via \`curl http://localhost:3000/\` — three \`<a>\` elements with \`flex-1 inline-flex items-center justify-center ...\` classes, icons \`lucide-search\` / \`lucide-brain-circuit\` / \`lucide-book\`, hrefs \`/search\` / \`/ask\` / \`/podcasts\`.
- [ ] **Could not run visual Playwright check** — Chromium not installed on this host. Review recommended for visual fit on mobile (280px logo → ~85px per button with ~8px gaps).

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)