### PR TITLE
fix(web): preserve unicode characters in export filenames (#537)

### DIFF
--- a/apps/web/src/components/DownloadReportButton.tsx
+++ b/apps/web/src/components/DownloadReportButton.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { SearchResult, GroupedSearchResult } from "@/lib/search";
 import { formatTimestamp } from "@/lib/timestamp";
+import { sanitizeFilename } from "@/lib/filename";
 
 interface DownloadReportButtonProps {
   query: string;
@@ -21,10 +22,6 @@ interface DownloadReportButtonProps {
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "");
-}
-
-function sanitizeFilename(query: string): string {
-  return query.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 50);
 }
 
 function downloadFile(content: string, filename: string, mimeType: string) {
@@ -152,7 +149,7 @@ export default function DownloadReportButton({
       return;
     }
 
-    const safeQuery = sanitizeFilename(query);
+    const safeQuery = sanitizeFilename(query, { maxLength: 50, fallback: "query" });
 
     // Always fetch complete flat results for file exports
     // so both MD and TXT include full segment content

--- a/apps/web/src/components/EpisodeChat.tsx
+++ b/apps/web/src/components/EpisodeChat.tsx
@@ -12,6 +12,7 @@ import {
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
 import { renderAnswerWithCitations, type Source, type OnCitationClick } from "@/lib/citations";
 import { formatTimestamp } from "@/lib/timestamp";
+import { sanitizeFilename } from "@/lib/filename";
 import {
   RAG_MODELS,
   DEFAULT_RAG_MODEL,
@@ -35,10 +36,6 @@ interface EpisodeChatProps {
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
-}
-
-function sanitizeFilename(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 50) || "episode";
 }
 
 function downloadFile(content: string, filename: string, mimeType: string) {
@@ -290,7 +287,7 @@ export default function EpisodeChat({ episodeId, episodeTitle, feedTitle, episod
   const handleExport = useCallback(
     (format: "markdown" | "text") => {
       const meta: ConversationMeta = { feedTitle, episodeTitle, episodeDescription };
-      const safe = sanitizeFilename(episodeTitle);
+      const safe = sanitizeFilename(episodeTitle, { maxLength: 50, fallback: "episode" });
       if (format === "markdown") {
         const content = generateConversationMarkdown(meta, messages);
         downloadFile(content, `podlog-ask-${safe}.md`, "text/markdown;charset=utf-8");

--- a/apps/web/src/components/TranscriptExportButton.tsx
+++ b/apps/web/src/components/TranscriptExportButton.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { Segment } from "@/lib/types";
 import { formatTimestamp } from "@/lib/timestamp";
+import { sanitizeFilename } from "@/lib/filename";
 
 interface Props {
   episodeTitle: string;
@@ -31,14 +32,6 @@ function formatDuration(secs: number): string {
   const m = Math.floor((secs % 3600) / 60);
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
-}
-
-function sanitizeFilename(name: string): string {
-  return name
-    .replace(/[/\\:*?"<>|]/g, "")
-    .replace(/\s+/g, "-")
-    .toLowerCase()
-    .slice(0, 100);
 }
 
 function buildExportText(props: Props): string {

--- a/apps/web/src/lib/filename.ts
+++ b/apps/web/src/lib/filename.ts
@@ -1,0 +1,61 @@
+/**
+ * Unicode-safe filename sanitization for client-side exports.
+ *
+ * Strips only filesystem-reserved characters; preserves letters and digits
+ * from all scripts (đ, Đ, ć, č, š, ž, ü, ö, etc.) so exported filenames
+ * match the source title for non-English content.
+ *
+ * Used by TranscriptExportButton, EpisodeChat (conversation export), and
+ * DownloadReportButton (search report export). If a Python counterpart is
+ * ever added (none today — pipeline writes `{uuid}.txt`), mirror the rules
+ * here to keep cross-runtime filenames consistent.
+ */
+
+export interface SanitizeFilenameOptions {
+  maxLength?: number;
+  separator?: string;
+  fallback?: string;
+}
+
+// Excludes \t (\x09), \n (\x0a), \r (\x0d) so they survive long enough
+// to be collapsed into the separator by the next pass.
+const RESERVED_CHARS_RE = /[/\\:*?"<>|\x00-\x08\x0b\x0c\x0e-\x1f]/g;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+}
+
+function trimEdges(value: string, separator: string): string {
+  const isTrimChar = (ch: string): boolean =>
+    ch === "." || ch === " " || ch === "\t" || ch === separator;
+  let start = 0;
+  let end = value.length;
+  while (start < end && isTrimChar(value[start])) start++;
+  while (end > start && isTrimChar(value[end - 1])) end--;
+  return value.slice(start, end);
+}
+
+export function sanitizeFilename(
+  name: string,
+  options: SanitizeFilenameOptions = {},
+): string {
+  const maxLength = options.maxLength ?? 100;
+  const separator = options.separator ?? "-";
+  const fallback = options.fallback ?? "untitled";
+
+  let result = (name ?? "").normalize("NFC");
+  result = result.replace(RESERVED_CHARS_RE, "");
+  result = result.replace(/\s+/g, separator);
+  if (separator.length > 0) {
+    const sepRunRe = new RegExp(`(?:${escapeRegex(separator)}){2,}`, "g");
+    result = result.replace(sepRunRe, separator);
+  }
+  result = trimEdges(result, separator);
+
+  const chars = Array.from(result);
+  if (chars.length > maxLength) {
+    result = trimEdges(chars.slice(0, maxLength).join(""), separator);
+  }
+
+  return result || fallback;
+}

--- a/apps/web/tests/unit/filename.test.ts
+++ b/apps/web/tests/unit/filename.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ *
+ * Covers issue #537: non-ASCII letters like đ/Đ/ć/č/š/ž must survive
+ * export filename sanitization instead of being replaced with "_".
+ */
+import { sanitizeFilename } from "@/lib/filename";
+
+describe("sanitizeFilename", () => {
+  describe("unicode preservation (issue #537)", () => {
+    test("preserves Latin Extended letters (đ, Đ, ć, č, š, ž)", () => {
+      expect(sanitizeFilename("Đorđe")).toBe("Đorđe");
+      expect(sanitizeFilename("Relić")).toBe("Relić");
+      expect(sanitizeFilename("čšž")).toBe("čšž");
+    });
+
+    test("preserves case (does not force lowercase)", () => {
+      expect(sanitizeFilename("Đorđe Relić")).toBe("Đorđe-Relić");
+    });
+
+    test("preserves accented Latin letters", () => {
+      expect(sanitizeFilename("Café résumé naïve")).toBe("Café-résumé-naïve");
+    });
+
+    test("preserves non-Latin scripts", () => {
+      expect(sanitizeFilename("日本語タイトル")).toBe("日本語タイトル");
+      expect(sanitizeFilename("Русский заголовок")).toBe("Русский-заголовок");
+    });
+  });
+
+  describe("filesystem-reserved character stripping", () => {
+    test("strips Windows-reserved characters", () => {
+      expect(sanitizeFilename('a/b\\c:d*e?f"g<h>i|j')).toBe("abcdefghij");
+    });
+
+    test("strips ASCII control characters", () => {
+      expect(sanitizeFilename("foo\x00\x01\x1fbar")).toBe("foobar");
+    });
+
+    test("preserves common safe punctuation", () => {
+      expect(sanitizeFilename("Episode #12 (part 1) - final")).toBe(
+        "Episode-#12-(part-1)-final",
+      );
+      expect(sanitizeFilename("A & B's discussion")).toBe("A-&-B's-discussion");
+    });
+  });
+
+  describe("whitespace collapsing", () => {
+    test("collapses runs of whitespace to a single separator", () => {
+      expect(sanitizeFilename("a   b\tc\n\nd")).toBe("a-b-c-d");
+    });
+
+    test("honors custom separator", () => {
+      expect(sanitizeFilename("a b c", { separator: "_" })).toBe("a_b_c");
+    });
+  });
+
+  describe("edge trimming", () => {
+    test("trims leading and trailing dots and spaces", () => {
+      expect(sanitizeFilename("  ...hello...  ")).toBe("hello");
+    });
+
+    test("trims leading and trailing separators", () => {
+      expect(sanitizeFilename(" hello ")).toBe("hello");
+      expect(sanitizeFilename("---hello---")).toBe("hello");
+    });
+
+    test("re-trims after truncation to avoid trailing separator", () => {
+      // "Hello World!" → collapsed to "Hello-World!" (12 chars)
+      // Slice to 6 → "Hello-" → trimmed → "Hello"
+      expect(sanitizeFilename("Hello World!", { maxLength: 6 })).toBe("Hello");
+    });
+  });
+
+  describe("truncation", () => {
+    test("truncates by code points, not UTF-16 code units", () => {
+      // Each emoji is a surrogate pair (2 UTF-16 code units). With a naive
+      // .slice(0, N) on strings, truncating between halves would corrupt the
+      // output. Array.from splits by code points, giving us safe truncation.
+      const eight = "🎙️".repeat(8);
+      const result = sanitizeFilename(eight, { maxLength: 4 });
+      // The variation selector (U+FE0F) is a separate code point from the
+      // microphone, so 4 code points = 2 full emoji glyphs.
+      expect(Array.from(result).length).toBe(4);
+    });
+
+    test("default maxLength is 100", () => {
+      const long = "a".repeat(200);
+      expect(sanitizeFilename(long).length).toBe(100);
+    });
+
+    test("respects custom maxLength", () => {
+      expect(sanitizeFilename("abcdefghij", { maxLength: 5 })).toBe("abcde");
+    });
+  });
+
+  describe("fallback", () => {
+    test("returns default fallback when input is empty", () => {
+      expect(sanitizeFilename("")).toBe("untitled");
+    });
+
+    test("returns default fallback when input is whitespace only", () => {
+      expect(sanitizeFilename("   ")).toBe("untitled");
+    });
+
+    test("returns default fallback when input is only reserved chars", () => {
+      expect(sanitizeFilename('/\\:*?"<>|')).toBe("untitled");
+    });
+
+    test("honors custom fallback", () => {
+      expect(sanitizeFilename("", { fallback: "episode" })).toBe("episode");
+    });
+  });
+
+  describe("unicode normalization", () => {
+    test("normalizes to NFC form", () => {
+      // "é" can be encoded as a single char (U+00E9) or as e + combining
+      // acute accent (U+0065 U+0301). NFC canonicalizes to the composed form.
+      const decomposed = "e\u0301";
+      const composed = "\u00e9";
+      expect(sanitizeFilename(decomposed)).toBe(composed);
+    });
+  });
+});

--- a/apps/web/tests/unit/transcript-export-button.test.tsx
+++ b/apps/web/tests/unit/transcript-export-button.test.tsx
@@ -89,6 +89,31 @@ describe("TranscriptExportButton", () => {
     });
   });
 
+  // Issue #537: non-ASCII characters like đ/Đ/ć must survive into the
+  // download filename instead of being stripped or lowercased.
+  it("preserves unicode characters in the export filename", async () => {
+    const user = userEvent.setup();
+    const downloadValues: string[] = [];
+    const anchorDownloadSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, "download", "set")
+      .mockImplementation(function (this: HTMLAnchorElement, value: string) {
+        downloadValues.push(value);
+      });
+
+    render(
+      <TranscriptExportButton {...baseProps} episodeTitle="Đorđe Relić podcast" />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Markdown (.md)"));
+
+    await waitFor(() => {
+      expect(downloadValues).toContain("Đorđe-Relić-podcast_transcript.md");
+    });
+
+    anchorDownloadSpy.mockRestore();
+  });
+
   it("opens print window for pdf export path", async () => {
     const user = userEvent.setup();
     const print = jest.fn();


### PR DESCRIPTION
## Summary

Closes #537. Export filenames now preserve non-ASCII letters (đ, Đ, ć, č, š, ž, ñ, 日本語, etc.) instead of replacing them with `_`.

## Changes

- **New `apps/web/src/lib/filename.ts`** — shared `sanitizeFilename(name, options?)` helper with unicode-safe rules: strips only filesystem-reserved characters (`/\:*?"<>|` + ASCII control chars), collapses whitespace to separator, collapses separator runs, trims edges, truncates by code point (safe for surrogate-pair emoji), NFC-normalizes input.
- **`TranscriptExportButton.tsx`** — uses the shared helper. Now case-preserving (dropped forced `.toLowerCase()`): `"Đorđe Relić"` → `Đorđe-Relić_transcript.md` instead of `đorđe-relić_transcript.md`.
- **`EpisodeChat.tsx`** (Ask AI conversation export) — was the worst offender: `/[^a-zA-Z0-9_-]/g` nuked every non-ASCII letter. Now preserves unicode, keeps `maxLength: 50` + `fallback: "episode"` for behavioral parity.
- **`DownloadReportButton.tsx`** (search report export) — same bug class, same fix. Keeps `maxLength: 50`, adds `fallback: "query"` so empty queries no longer produce `podlog-search-.md`.

Before/after for `"Đorđe Relić podcast #12"`:

| Call site | Before | After |
|---|---|---|
| TranscriptExport | `đorđe-relić-podcast-#12` | `Đorđe-Relić-podcast-#12` |
| EpisodeChat | `_or_e_Reli__podcast__12` | `Đorđe-Relić-podcast-#12` |
| DownloadReport | `_or_e_Reli__podcast__12` | `Đorđe-Relić-podcast-#12` |

## Testing

- **New:** `apps/web/tests/unit/filename.test.ts` — 20 tests covering unicode preservation (Latin Extended, non-Latin scripts, case), reserved-char stripping, whitespace/separator collapsing, edge trimming, code-point-aware truncation, fallback behavior, NFC normalization.
- **Updated:** `apps/web/tests/unit/transcript-export-button.test.tsx` — asserts `a.download` contains `Đorđe-Relić-podcast` for a Đ-titled episode.
- Full jest suite: **340 passed, 0 failed**.
- Lint clean on touched files; no new TS errors introduced.

## Notes

- Pipeline side uses `{episode.id}.txt` (UUID filename), so no Python change needed. If a Python counterpart is ever added, mirror the rules in this TS helper — noted in the file's docstring.
- Behavior change on TranscriptExport: filenames are now case-preserving. Any previously exported `đorđe-relić_transcript.md` files remain untouched; only new exports differ.

## Checklist

- [x] Tests pass
- [x] Code follows project conventions
- [x] No documentation updates needed (helper docstring covers it)

Closes #537