### PR TITLE
feat(pipeline): add pyannote_cloud_cost_usd column (#516 A/4)

### DIFF
--- a/apps/pipeline/alembic/versions/016_add_pyannote_cloud_cost_column.py
+++ b/apps/pipeline/alembic/versions/016_add_pyannote_cloud_cost_column.py
@@ -1,0 +1,24 @@
+"""Add pyannote cloud cost column to episodes.
+
+Tracks per-episode estimated cost when diarization runs via pyannote.ai's
+hosted precision-2 provider. Mirrors the Fireworks observability pattern
+(see migration 010). Cloud is opt-in; column is nullable and stays NULL
+for episodes processed with the local community-1 model.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "016"
+down_revision = "015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("episodes", sa.Column("pyannote_cloud_cost_usd", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("episodes", "pyannote_cloud_cost_usd")

--- a/apps/pipeline/app/models.py
+++ b/apps/pipeline/app/models.py
@@ -121,6 +121,9 @@ class Episode(Base):
     fireworks_stt_cost_per_minute_usd: Mapped[float | None] = mapped_column(Float)
     fireworks_stt_cost_usd: Mapped[float | None] = mapped_column(Float)
 
+    # pyannote cloud (precision-2) observability (Issue #516)
+    pyannote_cloud_cost_usd: Mapped[float | None] = mapped_column(Float)
+
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
         default=lambda: datetime.now(timezone.utc),


### PR DESCRIPTION
## Summary

First of 4 sequential PRs for #516 (pyannote.ai precision-2 cloud diarization provider). Adds the episode-level cost observability column up front so the subsequent backend and UI PRs can land without schema-ordering concerns — same approach used for #523 and #521.

## Changes

- **`apps/pipeline/alembic/versions/016_add_pyannote_cloud_cost_column.py`** — migration adds a nullable `FLOAT` column `episodes.pyannote_cloud_cost_usd`. Downgrade drops it. Mirrors the Fireworks cost column pattern from migration 010.
- **`apps/pipeline/app/models.py`** — `Episode.pyannote_cloud_cost_usd` mapped column added so future reads/writes are typed.

## Out of scope

- Nothing writes to the column yet — it stays `NULL` for every episode until PR B wires the cloud diarization service.
- No UI, no service, no new config. Those are PRs B, C, D.

## Testing

- Pipeline unit suite: `577 passed, 1 skipped` — no regressions.
- Migration smoke-tested on `db_test`:
  - Clean-slate upgrade `001 → 016` succeeds.
  - Downgrade `016 → 015` removes only the new column (other columns intact).
  - Re-upgrade `015 → 016` restores it.
- Verified column exists in `\d episodes`:
  ```
  fireworks_stt_cost_usd            | double precision
  pyannote_cloud_cost_usd           | double precision
  ```

## Test plan

- [x] Migration applies on a fresh DB
- [x] Downgrade round-trips
- [x] Unit tests pass
- [ ] Merge-time: `docker compose up -d pipeline` applies 016 against the running dev DB (will happen in Phase 9 of this workflow)

## Related

- Part of #516 (4-PR split): **A** migration / B backend / C web UI / D docs
- Pattern: #521's migration 015 landed the same way before its feature code (#538)

🤖 Generated with [Claude Code](https://claude.com/claude-code)