### PR TITLE
feat(pipeline): pyannote.ai precision-2 cloud diarization service (#516 B/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ WHISPER_MODEL=large-v3-turbo  # tiny|base|small|medium|large-v3|large-v3-turbo
 WHISPER_COMPUTE_TYPE=int8     # int8 (fast, recommended for CPU) | float32 (accurate)
 WHISPER_BATCH_SIZE=16         # WhisperX batched inference batch size
 PYANNOTE_MODEL=pyannote/speaker-diarization-community-1  # HuggingFace ID of the diarization model
+
+# -- Diarization provider (Issue #516) --
+# local = free local pyannote (default); precision2 = pyannote.ai paid cloud API.
+DIARIZATION_PROVIDER=local
+# PYANNOTE_API_KEY=pn_xxxxxxxxxxxxxxxxxxxx         # generate at https://dashboard.pyannote.ai
+# PYANNOTE_CLOUD_BASE_URL=https://api.pyannote.ai/v1
+# PYANNOTE_CLOUD_MODEL=precision-2                 # precision-2 | community-1
+# PYANNOTE_CLOUD_COST_PER_SECOND_USD=0.0           # check dashboard for your tier's rate
+
 DATA_DIR=/data
 ARCHIVE_AUDIO=true
 AUDIO_ARCHIVE_BITRATE=64k

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -16,6 +16,15 @@ class Settings(BaseSettings):
     # pyannote diarization model (gated on HuggingFace — user must accept license)
     pyannote_model: str = "pyannote/speaker-diarization-community-1"
 
+    # pyannote.ai precision-2 cloud provider (Issue #516)
+    diarization_provider: Literal["local", "precision2"] = "local"
+    pyannote_api_key: str | None = None
+    pyannote_cloud_base_url: str = "https://api.pyannote.ai/v1"
+    pyannote_cloud_model: str = "precision-2"
+    # pyannote.ai bills in seconds with a 20s per-request minimum. Check the
+    # dashboard for your tier's rate; default 0 means "no cost estimate".
+    pyannote_cloud_cost_per_second_usd: float = 0.0
+
     # Whisper (WhisperX / CTranslate2 backend)
     whisper_model: str = "large-v3-turbo"
     whisper_compute_type: str = "int8"

--- a/apps/pipeline/app/services/notification_settings.py
+++ b/apps/pipeline/app/services/notification_settings.py
@@ -42,9 +42,19 @@ _FIELDS = [
     "embedding_model",
     "fireworks_embedding_base_url",
     "fireworks_embedding_model",
+    "diarization_provider",
+    "pyannote_api_key",
+    "pyannote_cloud_base_url",
+    "pyannote_cloud_model",
+    "pyannote_cloud_cost_per_second_usd",
 ]
 
-_SENSITIVE_FIELDS = {"telegram_bot_token", "smtp_password", "fireworks_api_key"}
+_SENSITIVE_FIELDS = {
+    "telegram_bot_token",
+    "smtp_password",
+    "fireworks_api_key",
+    "pyannote_api_key",
+}
 
 _NULLABLE_FIELDS = {
     "telegram_bot_token",
@@ -53,11 +63,13 @@ _NULLABLE_FIELDS = {
     "smtp_user",
     "smtp_password",
     "fireworks_api_key",
+    "pyannote_api_key",
 }
 
 _VALID_FREQUENCIES = {"immediate", "daily", "weekly"}
 _VALID_INFERENCE_PROVIDERS = {"local", "fireworks"}
 _VALID_EMBEDDING_PROVIDERS = {"local", "fireworks"}
+_VALID_DIARIZATION_PROVIDERS = {"local", "precision2"}
 _INFERENCE_FIELDS = {
     "inference_provider",
     "fireworks_api_key",
@@ -74,6 +86,13 @@ _EMBEDDING_FIELDS = {
     "fireworks_api_key",
     "fireworks_embedding_base_url",
     "fireworks_embedding_model",
+}
+_DIARIZATION_FIELDS = {
+    "diarization_provider",
+    "pyannote_api_key",
+    "pyannote_cloud_base_url",
+    "pyannote_cloud_model",
+    "pyannote_cloud_cost_per_second_usd",
 }
 
 _EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
@@ -113,6 +132,7 @@ def get_notification_settings(db: Session) -> dict:
     )
     merged["email_configured"] = bool(merged.get("notification_email_to"))
     merged["fireworks_configured"] = bool(merged.get("fireworks_api_key"))
+    merged["pyannote_cloud_configured"] = bool(merged.get("pyannote_api_key"))
     return merged
 
 
@@ -154,6 +174,23 @@ def save_notification_settings(db: Session, updates: dict) -> dict:
                 "fireworks_stt_cost_per_minute_usd must be a non-negative number"
             )
         updates["fireworks_stt_cost_per_minute_usd"] = float(rate)
+    if "diarization_provider" in updates:
+        if updates["diarization_provider"] not in _VALID_DIARIZATION_PROVIDERS:
+            raise ValueError(
+                f"diarization_provider must be one of {_VALID_DIARIZATION_PROVIDERS}, "
+                f"got '{updates['diarization_provider']}'"
+            )
+    if "pyannote_cloud_cost_per_second_usd" in updates:
+        rate = updates["pyannote_cloud_cost_per_second_usd"]
+        if (
+            not isinstance(rate, (int, float))
+            or not math.isfinite(float(rate))
+            or float(rate) < 0
+        ):
+            raise ValueError(
+                "pyannote_cloud_cost_per_second_usd must be a non-negative number"
+            )
+        updates["pyannote_cloud_cost_per_second_usd"] = float(rate)
 
     # Normalize empty/whitespace strings to None for nullable fields
     for key in list(updates.keys()):
@@ -204,6 +241,7 @@ def save_notification_settings(db: Session, updates: dict) -> dict:
     )
     merged["email_configured"] = bool(merged.get("notification_email_to"))
     merged["fireworks_configured"] = bool(merged.get("fireworks_api_key"))
+    merged["pyannote_cloud_configured"] = bool(merged.get("pyannote_api_key"))
     return merged
 
 
@@ -235,3 +273,17 @@ def get_runtime_embedding_settings(db: Session | None = None) -> dict:
     else:
         base = get_notification_settings(db)
     return {key: base.get(key) for key in _EMBEDDING_FIELDS}
+
+
+def get_runtime_diarization_settings(db: Session | None = None) -> dict:
+    """Resolve diarization-provider settings for task execution.
+
+    Controls local vs. pyannote.ai cloud routing (Issue #516). Orthogonal to
+    ``inference_provider`` — Fireworks mode takes precedence and uses its own
+    word-level diarization metadata regardless of this setting.
+    """
+    if db is None:
+        base = _env_defaults()
+    else:
+        base = get_notification_settings(db)
+    return {key: base.get(key) for key in _DIARIZATION_FIELDS}

--- a/apps/pipeline/app/services/pyannote_cloud.py
+++ b/apps/pipeline/app/services/pyannote_cloud.py
@@ -1,0 +1,357 @@
+"""
+pyannote.ai precision-2 cloud diarization service — PRD-01 §5.5, Issue #516.
+
+Thin REST client for https://api.pyannote.ai/v1 that mirrors the error
+classification used by the Fireworks provider so retries behave the same.
+
+Flow:
+  1. ``upload_audio`` — POST /media/input declares a media:// URL, then
+     PUT the file bytes to the presigned URL the API returns.
+  2. ``submit_diarization`` — POST /diarize with the media:// URL and
+     model (``precision-2`` by default).
+  3. ``poll_job`` — GET /jobs/{jobId} until status is terminal
+     (``succeeded``, ``failed``, ``canceled``).
+  4. ``diarize_via_cloud`` composes the three steps and returns the
+     segments in Podlog's internal shape plus billed seconds and an
+     estimated cost.
+
+Pyannote cloud results auto-delete 24h after job completion; we fetch
+the output in the same call, so this is not a concern operationally.
+
+No GPU/RAM dance (PRD-01 §5.4) — the cloud path never loads a local
+pyannote pipeline and can run alongside Whisper unloading without
+coordination.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+_TERMINAL_SUCCESS = "succeeded"
+_TERMINAL_FAILURE = {"failed", "canceled"}
+_NON_TERMINAL = {"pending", "created", "running"}
+
+# Conservative polling: start small to catch fast jobs, cap growth.
+_POLL_INITIAL_SECS = 2.0
+_POLL_MAX_SECS = 10.0
+_POLL_BACKOFF_FACTOR = 1.5
+_POLL_TIMEOUT_SECS = 1800  # 30 minutes — covers long episodes comfortably
+
+# 20-second minimum charge per request (pyannote.ai billing docs).
+_MIN_BILLED_SECS = 20.0
+
+
+class PyannoteCloudError(RuntimeError):
+    """Typed pyannote cloud error carrying retry-class metadata."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_class: str,
+        retryable: bool,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_class = error_class
+        self.retryable = retryable
+        self.status_code = status_code
+
+
+def _classify_http_error(status_code: int) -> tuple[str, bool]:
+    """Map HTTP statuses to Podlog retry classes. Mirrors Fireworks."""
+    if status_code == 429 or 500 <= status_code <= 599:
+        return "TRANSIENT_NETWORK", True
+    return "HTTP_ACCESS", True
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _base(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def _wrap_network_error(action: str, exc: Exception) -> PyannoteCloudError:
+    return PyannoteCloudError(
+        f"pyannote cloud {action} network error: {exc}",
+        error_class="TRANSIENT_NETWORK",
+        retryable=True,
+    )
+
+
+def _wrap_http_error(action: str, exc: httpx.HTTPStatusError) -> PyannoteCloudError:
+    status = exc.response.status_code
+    error_class, retryable = _classify_http_error(status)
+    return PyannoteCloudError(
+        f"pyannote cloud {action} HTTP {status}",
+        error_class=error_class,
+        retryable=retryable,
+        status_code=status,
+    )
+
+
+def verify_api_key(api_key: str, base_url: str) -> bool:
+    """Ping GET /test to verify the API key. Returns True on 2xx, False on 401/403."""
+    if not api_key:
+        return False
+    url = f"{_base(base_url)}/test"
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            resp = client.get(url, headers=_auth_headers(api_key))
+        return 200 <= resp.status_code < 300
+    except httpx.HTTPError:
+        return False
+
+
+def upload_audio(audio_path: str, *, api_key: str, base_url: str) -> str:
+    """Upload a local audio file to pyannote cloud temporary storage.
+
+    Returns the ``media://...`` URL to pass as ``url`` to the diarize endpoint.
+    """
+    path = Path(audio_path)
+    if not path.exists():
+        raise RuntimeError(f"Audio file missing for pyannote cloud upload: {audio_path}")
+
+    # Use a unique media key per upload; the documented path charset is
+    # [alphanumeric, hyphen, underscore, dot, slash].
+    media_key = f"podlog/{uuid.uuid4().hex}{path.suffix.lower() or '.bin'}"
+    media_url = f"media://{media_key}"
+
+    declare_url = f"{_base(base_url)}/media/input"
+    try:
+        with httpx.Client(timeout=httpx.Timeout(connect=30.0, read=60.0, write=60.0, pool=30.0)) as client:
+            resp = client.post(
+                declare_url,
+                headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+                json={"url": media_url},
+            )
+            resp.raise_for_status()
+            payload = resp.json() or {}
+    except httpx.TimeoutException as exc:
+        raise _wrap_network_error("media/input", exc) from exc
+    except httpx.NetworkError as exc:
+        raise _wrap_network_error("media/input", exc) from exc
+    except httpx.HTTPStatusError as exc:
+        raise _wrap_http_error("media/input", exc) from exc
+
+    presigned_url = payload.get("url") or payload.get("presignedUrl") or payload.get("uploadUrl")
+    if not presigned_url:
+        raise PyannoteCloudError(
+            "pyannote cloud media/input returned no presigned URL",
+            error_class="HTTP_ACCESS",
+            retryable=False,
+        )
+
+    # PUT the audio bytes to the presigned URL. No Authorization header —
+    # the presigned URL itself encodes the credential.
+    try:
+        with path.open("rb") as fh:
+            with httpx.Client(timeout=httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=60.0)) as client:
+                put_resp = client.put(presigned_url, content=fh.read())
+                put_resp.raise_for_status()
+    except httpx.TimeoutException as exc:
+        raise _wrap_network_error("media upload", exc) from exc
+    except httpx.NetworkError as exc:
+        raise _wrap_network_error("media upload", exc) from exc
+    except httpx.HTTPStatusError as exc:
+        raise _wrap_http_error("media upload", exc) from exc
+
+    logger.info(
+        '"action": "pyannote_cloud_upload_complete", "media_url": "%s", "bytes": %d',
+        media_url,
+        path.stat().st_size,
+    )
+    return media_url
+
+
+def submit_diarization(
+    media_url: str,
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+) -> str:
+    """Submit a diarization job. Returns the ``jobId``."""
+    url = f"{_base(base_url)}/diarize"
+    body: dict = {"url": media_url, "model": model}
+    try:
+        with httpx.Client(timeout=60.0) as client:
+            resp = client.post(
+                url,
+                headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+                json=body,
+            )
+            resp.raise_for_status()
+            payload = resp.json() or {}
+    except httpx.TimeoutException as exc:
+        raise _wrap_network_error("diarize submit", exc) from exc
+    except httpx.NetworkError as exc:
+        raise _wrap_network_error("diarize submit", exc) from exc
+    except httpx.HTTPStatusError as exc:
+        raise _wrap_http_error("diarize submit", exc) from exc
+
+    job_id = payload.get("jobId") or payload.get("id")
+    if not job_id:
+        raise PyannoteCloudError(
+            f"pyannote cloud diarize submit returned no jobId: {payload}",
+            error_class="HTTP_ACCESS",
+            retryable=False,
+        )
+    logger.info(
+        '"action": "pyannote_cloud_submit_complete", "job_id": "%s", "model": "%s"',
+        job_id,
+        model,
+    )
+    return job_id
+
+
+def poll_job(
+    job_id: str,
+    *,
+    api_key: str,
+    base_url: str,
+    timeout_secs: float = _POLL_TIMEOUT_SECS,
+    initial_interval_secs: float = _POLL_INITIAL_SECS,
+    max_interval_secs: float = _POLL_MAX_SECS,
+    sleep: callable = time.sleep,  # injectable for tests
+) -> dict:
+    """Poll GET /jobs/{id} until terminal. Returns the full payload on success.
+
+    Raises PyannoteCloudError on failure/cancel/timeout.
+    """
+    url = f"{_base(base_url)}/jobs/{job_id}"
+    deadline = time.monotonic() + timeout_secs
+    interval = initial_interval_secs
+
+    while True:
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                resp = client.get(url, headers=_auth_headers(api_key))
+                resp.raise_for_status()
+                payload = resp.json() or {}
+        except httpx.TimeoutException as exc:
+            raise _wrap_network_error(f"jobs/{job_id} poll", exc) from exc
+        except httpx.NetworkError as exc:
+            raise _wrap_network_error(f"jobs/{job_id} poll", exc) from exc
+        except httpx.HTTPStatusError as exc:
+            raise _wrap_http_error(f"jobs/{job_id} poll", exc) from exc
+
+        status = (payload.get("status") or "").lower()
+        if status == _TERMINAL_SUCCESS:
+            return payload
+        if status in _TERMINAL_FAILURE:
+            err_msg = payload.get("error") or payload.get("message") or "<no detail>"
+            raise PyannoteCloudError(
+                f"pyannote cloud job {job_id} ended with status={status}: {err_msg}",
+                error_class="HTTP_ACCESS",
+                retryable=False,
+            )
+        if status not in _NON_TERMINAL:
+            # Unknown status — treat as non-fatal and keep polling, but log.
+            logger.warning(
+                '"action": "pyannote_cloud_unknown_status", "job_id": "%s", "status": "%s"',
+                job_id,
+                status,
+            )
+
+        if time.monotonic() >= deadline:
+            raise PyannoteCloudError(
+                f"pyannote cloud job {job_id} exceeded {timeout_secs}s polling timeout "
+                f"(last status={status!r})",
+                error_class="TRANSIENT_NETWORK",
+                retryable=True,
+            )
+
+        sleep(interval)
+        interval = min(interval * _POLL_BACKOFF_FACTOR, max_interval_secs)
+
+
+def _extract_segments(payload: dict) -> list[dict]:
+    output = payload.get("output") or {}
+    raw = output.get("diarization") or []
+    segments: list[dict] = []
+    for seg in raw:
+        speaker = seg.get("speaker")
+        start = seg.get("start")
+        end = seg.get("end")
+        if speaker is None or start is None or end is None:
+            continue
+        segments.append(
+            {
+                "speaker": _normalize_speaker(str(speaker)),
+                "start": float(start),
+                "end": float(end),
+            }
+        )
+    return segments
+
+
+def _compute_cost(segments: list[dict], cost_per_second_usd: float) -> tuple[float, float]:
+    """Return (billed_secs, cost_usd).
+
+    Billed seconds use the span from earliest start to latest end, floored at
+    the 20-second per-request minimum. If cost_per_second_usd is <= 0, returns
+    0.0 for cost so unconfigured rates don't emit a misleading dollar figure.
+    """
+    if not segments:
+        return (_MIN_BILLED_SECS, 0.0 if cost_per_second_usd <= 0 else _MIN_BILLED_SECS * cost_per_second_usd)
+    span = max(seg["end"] for seg in segments) - min(seg["start"] for seg in segments)
+    billed = max(_MIN_BILLED_SECS, span)
+    cost = billed * cost_per_second_usd if cost_per_second_usd > 0 else 0.0
+    return (billed, cost)
+
+
+def diarize_via_cloud(
+    audio_path: str,
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+    cost_per_second_usd: float,
+) -> tuple[list[dict], float, float]:
+    """Orchestrate upload → submit → poll → extract.
+
+    Returns ``(segments, billed_secs, estimated_cost_usd)`` where segments
+    use Podlog's internal shape ``{"speaker": "SPEAKER_00", "start": float, "end": float}``.
+    """
+    if not api_key:
+        raise PyannoteCloudError(
+            "pyannote cloud provider selected but pyannote_api_key is not set",
+            error_class="HTTP_ACCESS",
+            retryable=False,
+        )
+    media_url = upload_audio(audio_path, api_key=api_key, base_url=base_url)
+    job_id = submit_diarization(media_url, api_key=api_key, base_url=base_url, model=model)
+    payload = poll_job(job_id, api_key=api_key, base_url=base_url)
+    segments = _extract_segments(payload)
+    billed_secs, cost_usd = _compute_cost(segments, cost_per_second_usd)
+    logger.info(
+        '"action": "pyannote_cloud_diarize_complete", "job_id": "%s", "segments": %d, '
+        '"speakers": %d, "billed_secs": %.1f, "cost_usd": %.4f',
+        job_id,
+        len(segments),
+        len({s["speaker"] for s in segments}),
+        billed_secs,
+        cost_usd,
+    )
+    return (segments, billed_secs, cost_usd)
+
+
+def _normalize_speaker(raw_speaker: str) -> str:
+    clean = raw_speaker.strip().replace("-", "_").upper()
+    if clean.startswith("SPEAKER_"):
+        return clean
+    if clean.isdigit():
+        return f"SPEAKER_{int(clean):02d}"
+    if clean.startswith("SPEAKER") and clean[7:].isdigit():
+        return f"SPEAKER_{int(clean[7:]):02d}"
+    return f"SPEAKER_{clean}"

--- a/apps/pipeline/app/tasks/diarize.py
+++ b/apps/pipeline/app/tasks/diarize.py
@@ -17,7 +17,10 @@ from pathlib import Path
 from app.config import settings
 from app.database import SessionLocal
 from app.models import Episode, Segment
-from app.services.notification_settings import get_runtime_inference_settings
+from app.services.notification_settings import (
+    get_runtime_diarization_settings,
+    get_runtime_inference_settings,
+)
 from app.tasks.helpers import update_episode
 from app import job_queue
 
@@ -39,6 +42,8 @@ def diarize_episode(episode_id: str) -> str:
 
         runtime = get_runtime_inference_settings(db)
         provider = runtime.get("inference_provider") or "local"
+        diarization_runtime = get_runtime_diarization_settings(db)
+        diarization_provider = diarization_runtime.get("diarization_provider") or "local"
 
         if provider == "fireworks":
             # Fireworks mode uses remote diarization metadata and never loads pyannote locally.
@@ -135,6 +140,63 @@ def diarize_episode(episode_id: str) -> str:
                     diarize_duration_secs=diarize_secs,
                     diarize_step_durations=step_durations,
                 )
+            except Exception as exc:
+                update_episode(
+                    db, episode_id,
+                    has_diarization=False,
+                    diarization_error=str(exc),
+                    diarize_step_durations=step_durations or None,
+                )
+                logger.warning(
+                    '"action": "diarize_failed_graceful", "episode_id": "%s", "error": "%s"',
+                    episode_id,
+                    str(exc),
+                )
+        elif diarization_provider == "precision2":
+            # pyannote.ai cloud diarization — no local model load/unload needed.
+            audio_path = episode.audio_local_path
+            step_durations: dict[str, float] = {}
+            try:
+                from app.services.pyannote_cloud import diarize_via_cloud
+
+                t0 = time.monotonic()
+                t_provider = time.monotonic()
+                diarization_segments, billed_secs, cost_usd = diarize_via_cloud(
+                    audio_path,
+                    api_key=diarization_runtime.get("pyannote_api_key") or "",
+                    base_url=diarization_runtime.get("pyannote_cloud_base_url")
+                    or "https://api.pyannote.ai/v1",
+                    model=diarization_runtime.get("pyannote_cloud_model") or "precision-2",
+                    cost_per_second_usd=float(
+                        diarization_runtime.get("pyannote_cloud_cost_per_second_usd") or 0.0
+                    ),
+                )
+                step_durations["provider_diarization_secs"] = _elapsed_seconds(t_provider)
+
+                if alignment_path.exists():
+                    step_durations.update(
+                        _diarize_wordlevel(db, episode_id, alignment_path, diarization_segments)
+                    )
+                else:
+                    step_durations.update(_diarize_segment_level(db, episode_id, diarization_segments))
+
+                diarize_secs = round(time.monotonic() - t0, 1)
+                update_episode(
+                    db, episode_id,
+                    has_diarization=True,
+                    diarization_error=None,
+                    diarize_duration_secs=diarize_secs,
+                    diarize_step_durations=step_durations,
+                    pyannote_cloud_cost_usd=cost_usd,
+                )
+                logger.info(
+                    '"action": "diarize_precision2_complete", "episode_id": "%s", '
+                    '"billed_secs": %.1f, "cost_usd": %.4f',
+                    episode_id,
+                    billed_secs,
+                    cost_usd,
+                )
+
             except Exception as exc:
                 update_episode(
                     db, episode_id,

--- a/apps/pipeline/tests/unit/test_notification_settings.py
+++ b/apps/pipeline/tests/unit/test_notification_settings.py
@@ -7,10 +7,11 @@ import pytest
 from app.models import SystemState
 from app.services.notification_settings import (
     get_notification_settings,
-    get_runtime_inference_settings,
+    get_runtime_diarization_settings,
     get_runtime_embedding_settings,
-    save_notification_settings,
+    get_runtime_inference_settings,
     mask_sensitive,
+    save_notification_settings,
     SETTINGS_KEY,
 )
 
@@ -163,10 +164,20 @@ class TestSaveNotificationSettings:
         with pytest.raises(ValueError, match="embedding_provider"):
             save_notification_settings(db, {"embedding_provider": "cloud"})
 
+    def test_rejects_invalid_diarization_provider(self):
+        db = _mock_db(stored_json=None)
+        with pytest.raises(ValueError, match="diarization_provider"):
+            save_notification_settings(db, {"diarization_provider": "cloud"})
+
     def test_rejects_negative_fireworks_cost_rate(self):
         db = _mock_db(stored_json=None)
         with pytest.raises(ValueError, match="fireworks_stt_cost_per_minute_usd"):
             save_notification_settings(db, {"fireworks_stt_cost_per_minute_usd": -0.1})
+
+    def test_rejects_negative_pyannote_cloud_cost_rate(self):
+        db = _mock_db(stored_json=None)
+        with pytest.raises(ValueError, match="pyannote_cloud_cost_per_second_usd"):
+            save_notification_settings(db, {"pyannote_cloud_cost_per_second_usd": -0.01})
 
     def test_empty_string_normalized_to_none(self):
         stored = json.dumps({"notification_email_to": "user@example.com"})
@@ -309,6 +320,14 @@ class TestMaskSensitive:
         assert result["fireworks_api_key"] != "fw_test_1234567890"
         assert "***" in result["fireworks_api_key"]
 
+    def test_masks_pyannote_api_key(self):
+        s = {"pyannote_api_key": "pn_test_1234567890"}
+        result = mask_sensitive(s)
+        assert result["pyannote_api_key"] != "pn_test_1234567890"
+        assert "***" in result["pyannote_api_key"]
+        assert result["pyannote_api_key"].startswith("pn_")
+        assert result["pyannote_api_key"].endswith("890")
+
 
 class TestRuntimeInferenceSettings:
     def test_uses_db_override_when_present(self):
@@ -369,3 +388,35 @@ class TestRuntimeEmbeddingSettings:
             mock_settings.fireworks_embedding_model = "BAAI/bge-small-en-v1.5"
             result = get_runtime_embedding_settings(None)
         assert result["embedding_provider"] == "local"
+
+
+class TestRuntimeDiarizationSettings:
+    def test_uses_db_override_when_present(self):
+        stored = json.dumps({
+            "diarization_provider": "precision2",
+            "pyannote_api_key": "pn_abc",
+            "pyannote_cloud_model": "precision-2",
+            "pyannote_cloud_cost_per_second_usd": 0.001,
+        })
+        db = _mock_db(stored_json=stored)
+        with patch("app.services.notification_settings.settings") as mock_settings:
+            mock_settings.diarization_provider = "local"
+            mock_settings.pyannote_api_key = None
+            mock_settings.pyannote_cloud_base_url = "https://api.pyannote.ai/v1"
+            mock_settings.pyannote_cloud_model = "precision-2"
+            mock_settings.pyannote_cloud_cost_per_second_usd = 0.0
+            result = get_runtime_diarization_settings(db)
+        assert result["diarization_provider"] == "precision2"
+        assert result["pyannote_api_key"] == "pn_abc"
+        assert result["pyannote_cloud_cost_per_second_usd"] == 0.001
+
+    def test_uses_env_defaults_without_db(self):
+        with patch("app.services.notification_settings.settings") as mock_settings:
+            mock_settings.diarization_provider = "local"
+            mock_settings.pyannote_api_key = None
+            mock_settings.pyannote_cloud_base_url = "https://api.pyannote.ai/v1"
+            mock_settings.pyannote_cloud_model = "precision-2"
+            mock_settings.pyannote_cloud_cost_per_second_usd = 0.0
+            result = get_runtime_diarization_settings(None)
+        assert result["diarization_provider"] == "local"
+        assert result["pyannote_api_key"] is None

--- a/apps/pipeline/tests/unit/test_pyannote_cloud_service.py
+++ b/apps/pipeline/tests/unit/test_pyannote_cloud_service.py
@@ -1,0 +1,350 @@
+"""Unit tests for app.services.pyannote_cloud — precision-2 REST client."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services import pyannote_cloud as cloud
+from app.services.pyannote_cloud import (
+    PyannoteCloudError,
+    _classify_http_error,
+    _compute_cost,
+    _extract_segments,
+    _normalize_speaker,
+    diarize_via_cloud,
+    poll_job,
+    submit_diarization,
+    verify_api_key,
+    upload_audio,
+)
+
+
+class TestClassifyHttpError:
+    def test_429_is_transient(self):
+        err_class, retryable = _classify_http_error(429)
+        assert err_class == "TRANSIENT_NETWORK"
+        assert retryable is True
+
+    def test_5xx_is_transient(self):
+        assert _classify_http_error(503) == ("TRANSIENT_NETWORK", True)
+        assert _classify_http_error(500) == ("TRANSIENT_NETWORK", True)
+
+    def test_4xx_is_http_access(self):
+        assert _classify_http_error(401) == ("HTTP_ACCESS", True)
+        assert _classify_http_error(404) == ("HTTP_ACCESS", True)
+
+
+class TestNormalizeSpeaker:
+    def test_keeps_speaker_prefix(self):
+        assert _normalize_speaker("SPEAKER_00") == "SPEAKER_00"
+
+    def test_pads_bare_digit(self):
+        assert _normalize_speaker("3") == "SPEAKER_03"
+
+    def test_fuses_speaker_digits(self):
+        assert _normalize_speaker("SPEAKER1") == "SPEAKER_01"
+
+    def test_hyphen_becomes_underscore(self):
+        assert _normalize_speaker("speaker-00") == "SPEAKER_00"
+
+
+class TestExtractSegments:
+    def test_extracts_diarization_array(self):
+        payload = {
+            "output": {
+                "diarization": [
+                    {"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0},
+                    {"speaker": "1", "start": 5.0, "end": 10.0},
+                ]
+            }
+        }
+        segs = _extract_segments(payload)
+        assert segs == [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0},
+            {"speaker": "SPEAKER_01", "start": 5.0, "end": 10.0},
+        ]
+
+    def test_handles_missing_fields(self):
+        payload = {
+            "output": {
+                "diarization": [
+                    {"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0},
+                    {"speaker": None, "start": 5.0, "end": 10.0},  # dropped
+                    {"start": 10.0, "end": 15.0},  # dropped
+                ]
+            }
+        }
+        segs = _extract_segments(payload)
+        assert len(segs) == 1
+
+    def test_handles_missing_output(self):
+        assert _extract_segments({}) == []
+        assert _extract_segments({"output": {}}) == []
+
+
+class TestComputeCost:
+    def test_applies_minimum_charge(self):
+        # Short clip (5s span) — billed at 20s minimum.
+        segs = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0}]
+        billed, cost = _compute_cost(segs, cost_per_second_usd=0.001)
+        assert billed == 20.0
+        assert cost == pytest.approx(0.020)
+
+    def test_billing_uses_span(self):
+        # 120s span exceeds minimum.
+        segs = [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 60.0},
+            {"speaker": "SPEAKER_01", "start": 60.0, "end": 120.0},
+        ]
+        billed, cost = _compute_cost(segs, cost_per_second_usd=0.001)
+        assert billed == 120.0
+        assert cost == pytest.approx(0.120)
+
+    def test_zero_rate_returns_zero_cost(self):
+        segs = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 30.0}]
+        billed, cost = _compute_cost(segs, cost_per_second_usd=0.0)
+        assert billed == 30.0
+        assert cost == 0.0
+
+    def test_empty_segments_still_billed_at_minimum(self):
+        billed, cost = _compute_cost([], cost_per_second_usd=0.001)
+        assert billed == 20.0
+        assert cost == pytest.approx(0.020)
+
+
+class TestVerifyApiKey:
+    def test_returns_true_on_2xx(self):
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        resp = MagicMock()
+        resp.status_code = 200
+        client_cm.get = MagicMock(return_value=resp)
+
+        with patch.object(cloud.httpx, "Client", return_value=client_cm):
+            assert verify_api_key("fake-key", "https://api.pyannote.ai/v1") is True
+
+    def test_returns_false_on_401(self):
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        resp = MagicMock()
+        resp.status_code = 401
+        client_cm.get = MagicMock(return_value=resp)
+
+        with patch.object(cloud.httpx, "Client", return_value=client_cm):
+            assert verify_api_key("fake-key", "https://api.pyannote.ai/v1") is False
+
+    def test_returns_false_on_empty_key(self):
+        assert verify_api_key("", "https://api.pyannote.ai/v1") is False
+
+
+class TestSubmitDiarization:
+    def _fake_client(self, resp):
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        client_cm.post = MagicMock(return_value=resp)
+        return client_cm
+
+    def test_happy_path(self):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={"jobId": "job-123", "status": "created"})
+        with patch.object(cloud.httpx, "Client", return_value=self._fake_client(resp)):
+            job_id = submit_diarization(
+                "media://key",
+                api_key="k",
+                base_url="https://api.pyannote.ai/v1",
+                model="precision-2",
+            )
+        assert job_id == "job-123"
+
+    def test_401_is_retryable_http_access(self):
+        resp = MagicMock()
+        resp.status_code = 401
+        err = httpx.HTTPStatusError("401", request=MagicMock(), response=resp)
+        resp.raise_for_status = MagicMock(side_effect=err)
+        with patch.object(cloud.httpx, "Client", return_value=self._fake_client(resp)):
+            with pytest.raises(PyannoteCloudError) as exc_info:
+                submit_diarization(
+                    "media://key",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    model="precision-2",
+                )
+        assert exc_info.value.error_class == "HTTP_ACCESS"
+        assert exc_info.value.retryable is True
+
+    def test_503_is_retryable_transient(self):
+        resp = MagicMock()
+        resp.status_code = 503
+        err = httpx.HTTPStatusError("503", request=MagicMock(), response=resp)
+        resp.raise_for_status = MagicMock(side_effect=err)
+        with patch.object(cloud.httpx, "Client", return_value=self._fake_client(resp)):
+            with pytest.raises(PyannoteCloudError) as exc_info:
+                submit_diarization(
+                    "media://key",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    model="precision-2",
+                )
+        assert exc_info.value.error_class == "TRANSIENT_NETWORK"
+
+    def test_network_error(self):
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        client_cm.post = MagicMock(side_effect=httpx.ConnectError("boom"))
+        with patch.object(cloud.httpx, "Client", return_value=client_cm):
+            with pytest.raises(PyannoteCloudError) as exc_info:
+                submit_diarization(
+                    "media://key",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    model="precision-2",
+                )
+        assert exc_info.value.error_class == "TRANSIENT_NETWORK"
+
+    def test_missing_job_id(self):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={})
+        with patch.object(cloud.httpx, "Client", return_value=self._fake_client(resp)):
+            with pytest.raises(PyannoteCloudError, match="no jobId"):
+                submit_diarization(
+                    "media://key",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    model="precision-2",
+                )
+
+
+class TestPollJob:
+    def _make_client(self, responses):
+        """Return a factory that yields a client whose GET returns responses in order."""
+        iterator = iter(responses)
+
+        def client_factory(*args, **kwargs):
+            client_cm = MagicMock()
+            client_cm.__enter__ = MagicMock(return_value=client_cm)
+            client_cm.__exit__ = MagicMock(return_value=False)
+
+            def get(*a, **kw):
+                return next(iterator)
+
+            client_cm.get = MagicMock(side_effect=get)
+            return client_cm
+
+        return client_factory
+
+    def _resp(self, status_code=200, payload=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value=payload or {})
+        return resp
+
+    def test_returns_on_success(self):
+        success = self._resp(payload={"status": "succeeded", "output": {"diarization": []}})
+        with patch.object(cloud.httpx, "Client", side_effect=self._make_client([success])):
+            result = poll_job(
+                "job-1",
+                api_key="k",
+                base_url="https://api.pyannote.ai/v1",
+                sleep=lambda _: None,
+            )
+        assert result["status"] == "succeeded"
+
+    def test_polls_through_running_then_succeeds(self):
+        running = self._resp(payload={"status": "running"})
+        success = self._resp(payload={"status": "succeeded", "output": {"diarization": []}})
+        with patch.object(cloud.httpx, "Client", side_effect=self._make_client([running, success])):
+            result = poll_job(
+                "job-1",
+                api_key="k",
+                base_url="https://api.pyannote.ai/v1",
+                sleep=lambda _: None,
+            )
+        assert result["status"] == "succeeded"
+
+    def test_raises_on_failed(self):
+        failed = self._resp(payload={"status": "failed", "error": "bad audio"})
+        with patch.object(cloud.httpx, "Client", side_effect=self._make_client([failed])):
+            with pytest.raises(PyannoteCloudError, match="status=failed"):
+                poll_job(
+                    "job-1",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    sleep=lambda _: None,
+                )
+
+    def test_raises_on_canceled(self):
+        canceled = self._resp(payload={"status": "canceled"})
+        with patch.object(cloud.httpx, "Client", side_effect=self._make_client([canceled])):
+            with pytest.raises(PyannoteCloudError, match="status=canceled"):
+                poll_job(
+                    "job-1",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    sleep=lambda _: None,
+                )
+
+    def test_timeout_raises_transient(self):
+        # Simulate a running job that never completes — monkey-patch time.monotonic
+        # to push past the deadline after one poll.
+        running = self._resp(payload={"status": "running"})
+        with patch.object(cloud.httpx, "Client", side_effect=self._make_client([running])):
+            with pytest.raises(PyannoteCloudError, match="polling timeout") as exc_info:
+                poll_job(
+                    "job-1",
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                    timeout_secs=0.0,  # already expired
+                    sleep=lambda _: None,
+                )
+        assert exc_info.value.error_class == "TRANSIENT_NETWORK"
+
+
+class TestUploadAudio:
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(RuntimeError, match="missing"):
+            upload_audio(
+                str(tmp_path / "nope.mp3"),
+                api_key="k",
+                base_url="https://api.pyannote.ai/v1",
+            )
+
+    def test_missing_presigned_url_raises(self, tmp_path):
+        audio = tmp_path / "test.mp3"
+        audio.write_bytes(b"fake-mp3-bytes")
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={})
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        client_cm.post = MagicMock(return_value=resp)
+
+        with patch.object(cloud.httpx, "Client", return_value=client_cm):
+            with pytest.raises(PyannoteCloudError, match="no presigned URL"):
+                upload_audio(
+                    str(audio),
+                    api_key="k",
+                    base_url="https://api.pyannote.ai/v1",
+                )
+
+
+class TestDiarizeViaCloud:
+    def test_empty_api_key_raises(self):
+        with pytest.raises(PyannoteCloudError, match="not set"):
+            diarize_via_cloud(
+                "/tmp/a.mp3",
+                api_key="",
+                base_url="https://api.pyannote.ai/v1",
+                model="precision-2",
+                cost_per_second_usd=0.001,
+            )

--- a/apps/pipeline/tests/unit/test_task_diarize.py
+++ b/apps/pipeline/tests/unit/test_task_diarize.py
@@ -210,6 +210,105 @@ class TestDiarizeEpisode:
     @patch("app.tasks.diarize.job_queue")
     @patch("app.tasks.diarize.update_episode")
     @patch("app.tasks.diarize.SessionLocal")
+    def test_precision2_dispatches_to_cloud_service(
+        self, mock_session_cls, mock_update, mock_jq
+    ):
+        ep = _make_episode()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ep
+        segs = [_make_segment()]
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = segs
+        mock_session_cls.return_value = db
+
+        diar_segs = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 30.0}]
+
+        with (
+            patch("app.tasks.diarize.settings") as mock_settings,
+            patch(
+                "app.tasks.diarize.get_runtime_inference_settings",
+                return_value={"inference_provider": "local"},
+            ),
+            patch(
+                "app.tasks.diarize.get_runtime_diarization_settings",
+                return_value={
+                    "diarization_provider": "precision2",
+                    "pyannote_api_key": "pn_test",
+                    "pyannote_cloud_base_url": "https://api.pyannote.ai/v1",
+                    "pyannote_cloud_model": "precision-2",
+                    "pyannote_cloud_cost_per_second_usd": 0.001,
+                },
+            ),
+            patch(
+                "app.services.pyannote_cloud.diarize_via_cloud",
+                return_value=(diar_segs, 30.0, 0.03),
+            ),
+            patch("app.services.alignment.assign_speakers", return_value={1: "SPEAKER_00"}),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            mock_settings.transcript_dir = "/data/transcripts"
+            from app.tasks.diarize import diarize_episode
+
+            result = diarize_episode("ep1")
+
+        assert result == "ep1"
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is True
+            and call.kwargs.get("pyannote_cloud_cost_usd") == pytest.approx(0.03)
+        ]
+        assert matching, "Expected an update with pyannote_cloud_cost_usd written"
+        mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
+
+    @patch("app.tasks.diarize.job_queue")
+    @patch("app.tasks.diarize.update_episode")
+    @patch("app.tasks.diarize.SessionLocal")
+    def test_precision2_failure_is_non_fatal(self, mock_session_cls, mock_update, mock_jq):
+        ep = _make_episode()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ep
+        mock_session_cls.return_value = db
+
+        with (
+            patch("app.tasks.diarize.settings") as mock_settings,
+            patch(
+                "app.tasks.diarize.get_runtime_inference_settings",
+                return_value={"inference_provider": "local"},
+            ),
+            patch(
+                "app.tasks.diarize.get_runtime_diarization_settings",
+                return_value={
+                    "diarization_provider": "precision2",
+                    "pyannote_api_key": "pn_test",
+                    "pyannote_cloud_base_url": "https://api.pyannote.ai/v1",
+                    "pyannote_cloud_model": "precision-2",
+                    "pyannote_cloud_cost_per_second_usd": 0.001,
+                },
+            ),
+            patch(
+                "app.services.pyannote_cloud.diarize_via_cloud",
+                side_effect=RuntimeError("cloud crash"),
+            ),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            mock_settings.transcript_dir = "/data/transcripts"
+            from app.tasks.diarize import diarize_episode
+
+            result = diarize_episode("ep1")
+
+        assert result == "ep1"
+        matching = [
+            call for call in mock_update.call_args_list
+            if call.args[:2] == (db, "ep1")
+            and call.kwargs.get("has_diarization") is False
+            and call.kwargs.get("diarization_error") == "cloud crash"
+        ]
+        assert matching, "Expected graceful-failure update with cloud_crash error"
+        mock_jq.enqueue.assert_called_once_with(db, "ep1", "chunk")
+
+    @patch("app.tasks.diarize.job_queue")
+    @patch("app.tasks.diarize.update_episode")
+    @patch("app.tasks.diarize.SessionLocal")
     def test_fireworks_diarize_disabled_is_noop(self, mock_session_cls, mock_update, mock_jq):
         ep = _make_episode()
         db = MagicMock()


### PR DESCRIPTION
## Summary

Backend half of #516 — wires a new diarization provider option (`precision2` → pyannote.ai cloud) alongside the existing local `community-1` flow. Defaults stay local; cloud is opt-in per settings record or env var. PR C will surface the toggle in the Settings UI; PR D will ship docs.

Depends on #541 (already merged — adds the `pyannote_cloud_cost_usd` column).

## New service

`apps/pipeline/app/services/pyannote_cloud.py`

- `upload_audio` — declares a `media://` URL via `POST /media/input`, PUTs file bytes to the returned presigned URL.
- `submit_diarization` — `POST /diarize` with `{url, model}`, returns jobId.
- `poll_job` — `GET /jobs/{id}` with exponential-ish backoff (2s → 4s … cap 10s) and a 30-min hard timeout. Handles all six documented statuses.
- `diarize_via_cloud` — composes the three steps, returns `(segments, billed_secs, cost_usd)` with the 20-second per-request minimum applied.
- `verify_api_key` — `GET /test` helper for the future Settings-UI "test key" button.
- Error classification mirrors Fireworks: `429`/5xx → `TRANSIENT_NETWORK`, `4xx` → `HTTP_ACCESS`. All errors surface as `PyannoteCloudError` with `error_class` + `retryable` metadata.

## Config

`apps/pipeline/app/config.py` gains:

| Field | Default |
|---|---|
| `diarization_provider: Literal["local", "precision2"]` | `"local"` |
| `pyannote_api_key: str \| None` | `None` |
| `pyannote_cloud_base_url: str` | `"https://api.pyannote.ai/v1"` |
| `pyannote_cloud_model: str` | `"precision-2"` |
| `pyannote_cloud_cost_per_second_usd: float` | `0.0` (user sets per-dashboard rate) |

`.env.example` documents all five.

## Settings plumbing

`notification_settings.py`

- All five fields added to `_FIELDS`; `pyannote_api_key` is sensitive (masked) and nullable.
- `_VALID_DIARIZATION_PROVIDERS = {"local", "precision2"}` enum validation.
- Negative-rate check for `pyannote_cloud_cost_per_second_usd`.
- New `_DIARIZATION_FIELDS` set and `get_runtime_diarization_settings()` accessor — mirrors the inference / embedding pattern.
- Read response gains `pyannote_cloud_configured: bool`.

## Pipeline dispatch

`apps/pipeline/app/tasks/diarize.py` becomes a three-way branch:

1. `inference_provider == "fireworks"` → existing Fireworks word-level diarization path (unchanged).
2. `diarization_provider == "precision2"` → **new cloud path**. No local pyannote load / unload.
3. Else → existing local pyannote path (unchanged).

The cloud path reuses the same word-level / segment-level alignment helpers as local, so speaker boundaries in transcripts look identical regardless of provider. `pyannote_cloud_cost_usd` is written on success; graceful-failure contract (PRD-01 §5.5) preserved.

## Testing

+37 test cases, zero regressions.

- **`test_pyannote_cloud_service.py` (new, 30 cases):** HTTP error classification (429/5xx/4xx), speaker normalization edge cases, segment extraction, cost math including 20-second floor and zero-rate-returns-zero, `verify_api_key` 2xx/401/empty, submit happy-path + 401/503/network-error/missing-jobId, poll happy path + running-then-succeeded + failed/canceled/timeout, upload missing-file + missing-presigned-url, `diarize_via_cloud` empty-key guard.
- **`test_notification_settings.py`:** mask `pyannote_api_key`, reject invalid `diarization_provider`, reject negative `pyannote_cloud_cost_per_second_usd`, new `TestRuntimeDiarizationSettings` with DB-override + env-default cases.
- **`test_task_diarize.py`:** `precision2` happy path asserts cost written via `update_episode`; `precision2` failure preserves graceful-failure contract with the cloud error message.

Full suite: `614 passed, 1 skipped` (was 577).

## Test plan

- [x] Unit suite green (`make test-unit` / docker test runner)
- [x] No other test hardcodes old defaults
- [ ] Merge-time: rebuild and restart pipeline (PR still has no user-facing trigger — `diarization_provider` defaults to `local`, so behavior is unchanged until a user or PR C writes `precision2`)
- [ ] Manual smoke test (deferred — easier after PR C lands the Settings UI)

## Out of scope

- UI (PR C): provider toggle, masked key input, help text, queue-dashboard cost line.
- Docs (PR D): signup / token / pricing guide, RISKS-AND-GAPS entry, VERSION bump.
- Webhooks: polling is the chosen sync model; webhook receiver is a future enhancement.
- Fallback local ↔ cloud on failure: per issue, this is out of scope (user's explicit choice).

## Related

- Part of #516 (4-PR split): A migration (#541 ✓) / **B backend (this)** / C web UI / D docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)