### PR TITLE
docs: sync dev guide + user guide with current codebase (#548)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -17,16 +17,16 @@ podlog/
 │   │   │   ├── models.py           # SQLAlchemy ORM (feeds, episodes, segments)
 │   │   │   ├── database.py         # Engine + session factory
 │   │   │   ├── job_queue.py        # DB-backed job queue (FOR UPDATE SKIP LOCKED)
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware)
-│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, diarize, chunk, embed, infer, archive, cleanup, prewarm, backfill_chunks)
-│   │   │   └── services/           # Business logic (rss, whisper, pyannote, alignment, chunking, embed, rag, inference, notifications, digest, events, fireworks_audio, …)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware, meta_analysis)
+│   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, transcribe_helpers, diarize, chunk, embed, infer, archive, cleanup, prewarm, backfill_chunks, helpers)
+│   │   │   └── services/           # Business logic (rss, whisper, pyannote, pyannote_cloud, alignment, chunking, embed, rag, inference, inference_helpers, meta_analysis, notifications, notification_events, notification_runtime, notification_settings, digest, digest_formatters, events, hardware, fireworks_audio, pipeline_commands, timing_labels)
 │   │   ├── alembic/                # Database migrations
 │   │   └── tests/                  # Unit, integration, e2e tests
-│   └── web/                        # Next.js 16.2.2 (App Router)
-│       ├── src/app/                # Pages: /, /search, /ask, /podcasts, /episodes/[id], /queue, /feeds, /settings, /docs, /about (/notifications redirects to /settings)
-│       │   └── api/                # Route handlers: search, search/grouped, search/mentions, feeds, queue, audio, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, hardware, pipeline proxy
+│   └── web/                        # Next.js 16.2.4 (App Router)
+│       ├── src/app/                # Pages: /, /search, /ask, /podcasts, /episodes/[id], /queue, /feeds, /settings, /docs, /meta-analysis, /about (/notifications redirects to /settings)
+│       │   └── api/                # Route handlers: search, search/grouped, search/mentions, feeds, queue, audio, ask/coverage, episodes (ingest, upload, retry, speakers, merge), docs, notifications, hardware, meta-analysis (coverage, refresh, snapshot), pipeline proxy
 │       ├── src/components/         # React components (Navbar, AudioPlayer, SearchResult, QueueStatus, …)
-│       └── src/lib/                # Utilities (db, search, searchHybrid, timestamp, pipeline, types, utils, speakerColors, validateMergeRequest, citations, …)
+│       └── src/lib/                # Utilities (db, search, searchHybrid, timestamp, pipeline, types, utils, speakerColors, validateMergeRequest, citations, normalizeName, filename, metaAnalysisTypes, rag-models, …)
 ├── docs/                           # User-facing documentation
 └── prds/                           # Internal design specs and risk register
 ```

--- a/docs/guide/13-pyannote-cloud.md
+++ b/docs/guide/13-pyannote-cloud.md
@@ -114,4 +114,4 @@ Pairing **local Fireworks-less transcription** with **pyannote cloud diarization
 
 ---
 
-**Next:** [Troubleshooting](14-troubleshooting.md) | **Back:** [Ask AI (RAG Search)](12-rag-search.md) | **Home:** [Guide](README.md)
+**Next:** [Meta-Analysis Dashboard](14-meta-analysis.md) | **Back:** [Ask AI (RAG Search)](12-rag-search.md) | **Home:** [Guide](README.md)

--- a/docs/guide/14-meta-analysis.md
+++ b/docs/guide/14-meta-analysis.md
@@ -1,0 +1,47 @@
+# Meta-Analysis Dashboard
+
+The Meta-Analysis page at `/meta-analysis` aggregates metrics across all your feeds into one view. Useful for spotting outlier episodes, comparing podcasts, and tracking how much of your library is fully processed.
+
+## Opening the dashboard
+
+From the navbar click **Meta-Analysis**, or go directly to [http://localhost:3000/meta-analysis](http://localhost:3000/meta-analysis).
+
+The page shows:
+
+- A **Coverage strip** at the top — how many episodes are fully processed, still queued, partially transcribed, or missing speakers.
+- A **Filters bar** — narrow the view to a subset of feeds, a date range, or episode length.
+- Nine **charts** (see below). Click a chart to open a full-size modal with the raw data table underneath.
+
+## Charts
+
+| Chart | What it shows |
+|---|---|
+| **Release Timeline** | Episode release cadence per feed over time |
+| **Length per Feed** | Episode duration distribution by feed |
+| **Episode Length Trend** | How episode length has evolved per feed over time |
+| **WPM per Speaker** | Words-per-minute by speaker (useful for spotting hosts vs. guests) |
+| **Turn Density** | How often speakers switch per minute — a proxy for conversational format vs. monologue |
+| **Host / Guest Share** | Time-share between inferred hosts and guests per episode |
+| **Tokens per Episode** | LLM token count per episode (approximate; used for cost estimation) |
+| **Processing Time Distribution** | How long each pipeline stage takes per episode |
+| **Cost per Feed** | Cumulative pyannote cloud + remote-inference cost per feed (only populated if you use paid providers) |
+
+## Refreshing the snapshot
+
+The dashboard reads from a cached snapshot so the page loads instantly. To recompute:
+
+- Click **Refresh snapshot** in the top-right.
+- Or call `POST /api/meta-analysis/refresh` directly — the pipeline recomputes and stores the snapshot.
+
+Staleness indicators show the snapshot age next to the refresh button.
+
+## When to use it
+
+- After a large batch ingest, to confirm all episodes reached the archive stage.
+- Before running a big Ask AI query, to see which feeds have full speaker inference.
+- To compare podcasts by pace, format, or topic density.
+- To track spend if you use the pyannote cloud provider or Fireworks remote inference.
+
+---
+
+**Next:** [Troubleshooting](15-troubleshooting.md) | **Back:** [pyannote Cloud Diarization](13-pyannote-cloud.md) | **Home:** [Guide](README.md)

--- a/docs/guide/15-troubleshooting.md
+++ b/docs/guide/15-troubleshooting.md
@@ -108,4 +108,4 @@ The host-level health check (`make health-install`) runs the same probes every 1
 
 ---
 
-**Back:** [pyannote Cloud Diarization](13-pyannote-cloud.md) | **Home:** [Guide](README.md)
+**Back:** [Meta-Analysis Dashboard](14-meta-analysis.md) | **Home:** [Guide](README.md)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -17,7 +17,8 @@ Podlog is a self-hosted podcast transcription and search app. It downloads episo
 11. [Hardware & Performance](11-hardware.md) — Processing times, storage estimates
 12. [Ask AI (RAG Search)](12-rag-search.md) — AI-powered Q&A over transcripts
 13. [pyannote Cloud Diarization](13-pyannote-cloud.md) — Optional Precision-2 paid cloud provider
-14. [Troubleshooting](14-troubleshooting.md) — Common issues and fixes
+14. [Meta-Analysis Dashboard](14-meta-analysis.md) — Cross-feed metrics and charts
+15. [Troubleshooting](15-troubleshooting.md) — Common issues and fixes
 
 ## Quick Start
 


### PR DESCRIPTION
Closes #548.

## Summary
- \`docs/development.md\` project structure refreshed to match current pipeline modules (added `meta_analysis`, `pyannote_cloud`, and all omitted services/tasks), bumps Next.js reference 16.2.2 → 16.2.4, and adds `/meta-analysis` page plus `api/meta-analysis/*` routes.
- New user-guide chapter **14 Meta-Analysis Dashboard** covering the page shipped in #521 / PR #538 (navigation, charts, snapshot refresh).
- Troubleshooting chapter renumbered **14 → 15** with Next/Back links updated across `13-pyannote-cloud.md` and `15-troubleshooting.md`.

## Test plan
- [x] File listings spot-checked against \`ls apps/pipeline/app/{api,tasks,services}\` and \`ls apps/web/src/{app,lib}\`.
- [x] Guide TOC renumbering consistent: README.md, 13-pyannote-cloud.md Next, 15-troubleshooting.md Back.
- [x] New chapter 14 rendered preview OK (markdown only, no code).