### PR TITLE
docs: reflect shipped features in PRD roadmaps (#549)

### DIFF
--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -377,6 +377,8 @@ GET    /api/health                   Health check — includes worker warm-up st
 - Chunking and embedding pipeline tasks
 - Notification system (email, Telegram)
 - Zombie job detection
+- pyannote.ai Precision-2 cloud diarization as an alternative to local pyannote, selected via `DIARIZATION_PROVIDER=precision2` (Issue #516; see RISKS-AND-GAPS RISK-11)
+- Fireworks AI remote-inference profile (`make up-remote`) for users who prefer remote Whisper/LLM over a local Ollama container
 
 ### Future
 - GPU support via Docker NVIDIA runtime flag

--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -548,6 +548,7 @@ const { playEpisode } = useAudioPlayer();
 - Keyboard navigation of search results
 - Export transcript as `.txt` or `.srt` from episode page
 - "Copy timestamp link" button
+- Meta-Analysis dashboard (`/meta-analysis`) aggregating cross-feed metrics — coverage, episode length, WPM, turn density, host/guest share, tokens, processing time, and cost per feed (Issue #521; see §5.11)
 
 ### V2 (Phase 3)
 - **Authentication:** NextAuth.js + JWT, invite-only


### PR DESCRIPTION
Closes #549.

## Summary
- **PRD-01 V1 (Phase 2) — Done**: records pyannote.ai Precision-2 cloud diarization (#516) and the Fireworks AI remote-inference profile, both already shipped.
- **PRD-02 V1 (Phase 2)**: records the Meta-Analysis dashboard (#521, spec already at §5.11).

## Test plan
- [x] Each added line cross-checked against an existing shipped artifact (commit hash, route, or config flag).