### PR TITLE
chore(web): remove unused params, imports, and props (#552)

### DIFF
--- a/apps/web/src/app/api/docs/[slug]/route.ts
+++ b/apps/web/src/app/api/docs/[slug]/route.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 export async function GET(
-  req: NextRequest,
+  _req: NextRequest,
   context: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await context.params;

--- a/apps/web/src/app/api/episodes/[id]/retry/route.ts
+++ b/apps/web/src/app/api/episodes/[id]/retry/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PIPELINE_API } from "@/lib/pipeline";
 
-export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const resp = await fetch(`${PIPELINE_API}/api/queue/${id}/retry`, {
     method: "POST",

--- a/apps/web/src/app/api/feeds/[id]/poll/route.ts
+++ b/apps/web/src/app/api/feeds/[id]/poll/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PIPELINE_API } from "@/lib/pipeline";
 
-export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const resp = await fetch(`${PIPELINE_API}/api/feeds/${id}/poll`, { method: "POST" });
   const data = await resp.json();

--- a/apps/web/src/app/api/pipeline/queue/[episodeId]/retry/route.ts
+++ b/apps/web/src/app/api/pipeline/queue/[episodeId]/retry/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PIPELINE_API } from "@/lib/pipeline";
 
-export async function POST(req: NextRequest, { params }: { params: Promise<{ episodeId: string }> }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ episodeId: string }> }) {
   const { episodeId } = await params;
   const resp = await fetch(`${PIPELINE_API}/api/queue/${episodeId}/retry`, {
     method: "POST",

--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { AlertTriangle, ChevronLeft, ChevronRight, Info, XCircle } from "lucide-react";
 import pool from "@/lib/db";
 import type { Segment } from "@/lib/types";
-import { formatTimestamp } from "@/lib/timestamp";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import EpisodeDescription from "@/components/EpisodeDescription";

--- a/apps/web/src/app/search/print/page.tsx
+++ b/apps/web/src/app/search/print/page.tsx
@@ -5,10 +5,6 @@ import PrintButton from "./PrintButton";
 
 export const dynamic = "force-dynamic";
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
-}
-
 export default async function PrintPage({
   searchParams,
 }: {

--- a/apps/web/src/components/DownloadReportButton.tsx
+++ b/apps/web/src/components/DownloadReportButton.tsx
@@ -15,7 +15,6 @@ import { sanitizeFilename } from "@/lib/filename";
 
 interface DownloadReportButtonProps {
   query: string;
-  viewMode: "flat" | "grouped";
   flatResults?: SearchResult[];
   groupedResults?: GroupedSearchResult;
 }
@@ -131,7 +130,6 @@ function openPrintView(query: string) {
 
 export default function DownloadReportButton({
   query,
-  viewMode,
   flatResults,
   groupedResults,
 }: DownloadReportButtonProps) {

--- a/apps/web/src/components/EpisodeCard.tsx
+++ b/apps/web/src/components/EpisodeCard.tsx
@@ -294,7 +294,7 @@ export default function EpisodeCard({
 
         {/* Reprocess button - last item in tag row */}
         <span className="relative z-10 pointer-events-auto">
-          <ReprocessButton episodeId={ep.id} status={ep.status} />
+          <ReprocessButton episodeId={ep.id} />
         </span>
       </div>
 

--- a/apps/web/src/components/EpisodeChat.tsx
+++ b/apps/web/src/components/EpisodeChat.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
-import { renderAnswerWithCitations, type Source, type OnCitationClick } from "@/lib/citations";
+import { renderAnswerWithCitations, type Source } from "@/lib/citations";
 import { formatTimestamp } from "@/lib/timestamp";
 import { sanitizeFilename } from "@/lib/filename";
 import {
@@ -389,7 +389,7 @@ export default function EpisodeChat({ episodeId, episodeTitle, feedTitle, episod
         )}
 
         {messages.map((msg, i) => (
-          <MessageBubble key={i} message={msg} episodeId={episodeId} isStreaming={isStreaming && i === messages.length - 1} />
+          <MessageBubble key={i} message={msg} isStreaming={isStreaming && i === messages.length - 1} />
         ))}
 
         {status === "error" && errorMsg && (
@@ -430,7 +430,7 @@ function handleCitationClick(_episodeId: string, seconds: number) {
   scrollToTime(seconds);
 }
 
-function MessageBubble({ message, episodeId, isStreaming }: { message: Message; episodeId: string; isStreaming: boolean }) {
+function MessageBubble({ message, isStreaming }: { message: Message; isStreaming: boolean }) {
   const rendered = useMemo(
     () =>
       message.role === "assistant" && message.content

--- a/apps/web/src/components/EpisodeMetaTags.tsx
+++ b/apps/web/src/components/EpisodeMetaTags.tsx
@@ -197,7 +197,7 @@ export default function EpisodeMetaTags({
 
       {/* Row 3: actions */}
       <div>
-        <ReprocessButton episodeId={episodeId} status={status} />
+        <ReprocessButton episodeId={episodeId} />
       </div>
     </div>
   );

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -259,7 +259,7 @@ export default function QueueStatus() {
     return <div className="text-muted-foreground text-sm">Loading queue...</div>;
   }
 
-  const { counts, allJobs, filtered, filteredDone, effectiveShowDone, isEmpty } = computeQueueViewModel({
+  const { counts, filtered, filteredDone, effectiveShowDone, isEmpty } = computeQueueViewModel({
     queue,
     search: debouncedSearch,
     stageFilter,

--- a/apps/web/src/components/ReprocessButton.tsx
+++ b/apps/web/src/components/ReprocessButton.tsx
@@ -6,14 +6,11 @@ import { RefreshCw } from "lucide-react";
 
 interface ReprocessButtonProps {
   episodeId: string;
-  status: string;
 }
 
-export default function ReprocessButton({ episodeId, status }: ReprocessButtonProps) {
+export default function ReprocessButton({ episodeId }: ReprocessButtonProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-
-  // Always render - parent controls visibility via CSS if needed
 
   async function handleReprocess() {
     if (!window.confirm("Re-queue this episode for full reprocessing?")) return;

--- a/apps/web/src/components/SearchResultsToolbar.tsx
+++ b/apps/web/src/components/SearchResultsToolbar.tsx
@@ -55,7 +55,6 @@ export default function SearchResultsToolbar({
         </label>
         <DownloadReportButton
           query={submittedQuery}
-          viewMode={viewMode}
           flatResults={viewMode === "flat" ? flatData?.results : undefined}
           groupedResults={viewMode === "grouped" ? groupedData : undefined}
         />

--- a/apps/web/tests/unit/reprocess-button.test.tsx
+++ b/apps/web/tests/unit/reprocess-button.test.tsx
@@ -21,7 +21,7 @@ describe("ReprocessButton", () => {
   });
 
   it("uses compact tag-like sizing classes", () => {
-    render(<ReprocessButton episodeId="ep-1" status="done" />);
+    render(<ReprocessButton episodeId="ep-1" />);
 
     const button = screen.getByRole("button", { name: /reprocess/i });
     expect(button).toHaveClass(


### PR DESCRIPTION
Closes #552.

## Summary
Resolves every unused-symbol finding from the 2026-04-24 audit:

- **Route handlers** — rename unused \`req\` arg to \`_req\` in 4 routes (\`docs/[slug]\`, \`episodes/[id]/retry\`, \`feeds/[id]/poll\`, \`pipeline/queue/[episodeId]/retry\`). Next.js signature keeps the positional slot; \`_\` prefix signals intentionally unused.
- **DownloadReportButton** — drop dead \`viewMode\` prop and update the one caller (\`SearchResultsToolbar\`).
- **EpisodeChat** — remove unused \`OnCitationClick\` import and drop \`episodeId\` from \`MessageBubble\` (the click handler ignores it).
- **QueueStatus** — remove unused \`allJobs\` from the destructured view model.
- **ReprocessButton** — drop dead \`status\` prop; update 2 callers (\`EpisodeCard\`, \`EpisodeMetaTags\`) and the one existing test.
- **episodes/[id]/page.tsx** — remove unused \`formatTimestamp\` import.
- **search/print/page.tsx** — remove unused \`stripHtml\` helper.

## Test plan
- [x] \`npx tsc --noEmit\` — no new errors (two pre-existing test-file redeclaration errors unchanged, not touched by this PR).
- [x] \`npx jest\` — **385/386 unchanged + 1 test updated (reprocess-button) — 386 pass, 0 fail.**
- [x] Manually verified each renamed route still compiles with correct param extraction.

## Note
The related audit suggestion to enable \`noUnusedLocals\` / \`noUnusedParameters\` in \`tsconfig.json\` is intentionally left for a follow-up — turning those on today would also trip pre-existing issues in the test suites that are out of scope here.