### PR TITLE
test(pipeline): cover low-coverage modules (#556)

### DIFF
--- a/apps/pipeline/tests/unit/test_meta_analysis_api.py
+++ b/apps/pipeline/tests/unit/test_meta_analysis_api.py
@@ -1,0 +1,169 @@
+"""Unit tests for app.api.meta_analysis (#556)."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.meta_analysis import (
+    _serialize,
+    get_snapshot,
+    missing_speakers,
+    post_refresh,
+)
+
+
+def _fake_row(snapshot: dict | None = None):
+    return SimpleNamespace(
+        snapshot=snapshot if snapshot is not None else {"per_feed": []},
+        computed_at=datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc),
+        episode_count=3,
+        feed_count=2,
+    )
+
+
+class TestSerialize:
+    def test_none_row_returns_empty_shape_with_stale_flag(self):
+        result = _serialize(None, stale=True)
+        assert result == {
+            "snapshot": None,
+            "computed_at": None,
+            "episode_count": 0,
+            "feed_count": 0,
+            "is_stale": True,
+            "last_error": None,
+        }
+
+    def test_serializes_row_fields(self):
+        row = _fake_row({"per_feed": [{"feed_id": "f1"}]})
+        result = _serialize(row, stale=False)
+        assert result["snapshot"] == {"per_feed": [{"feed_id": "f1"}]}
+        assert result["computed_at"] == "2026-04-24T12:00:00+00:00"
+        assert result["episode_count"] == 3
+        assert result["feed_count"] == 2
+        assert result["is_stale"] is False
+        assert result["last_error"] is None
+
+    def test_handles_missing_computed_at(self):
+        row = SimpleNamespace(
+            snapshot={}, computed_at=None, episode_count=0, feed_count=0
+        )
+        assert _serialize(row, stale=True)["computed_at"] is None
+
+
+class TestGetSnapshot:
+    def test_returns_empty_stale_when_no_row(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = None
+        result = get_snapshot(db)
+        assert result["snapshot"] is None
+        assert result["is_stale"] is True
+        assert result["episode_count"] == 0
+
+    def test_returns_serialized_row_with_stale_flag_from_service(self):
+        db = MagicMock()
+        row = _fake_row({"per_feed": []})
+        db.query.return_value.filter.return_value.one_or_none.return_value = row
+
+        with patch("app.api.meta_analysis.is_stale", return_value=False):
+            result = get_snapshot(db)
+
+        assert result["snapshot"] == {"per_feed": []}
+        assert result["is_stale"] is False
+        assert result["episode_count"] == 3
+
+
+class TestPostRefresh:
+    def test_acquires_advisory_lock_and_returns_serialized_row(self):
+        db = MagicMock()
+        row = _fake_row({"per_episode": []})
+
+        with patch("app.api.meta_analysis.recompute_and_store", return_value=row) as mock_recompute:
+            result = post_refresh(db)
+
+        # Advisory lock acquired via db.execute(...)
+        db.execute.assert_called_once()
+        mock_recompute.assert_called_once_with(db)
+        assert result["is_stale"] is False
+        assert result["episode_count"] == 3
+
+    def test_wraps_recompute_exceptions_in_http_500(self):
+        db = MagicMock()
+
+        with patch(
+            "app.api.meta_analysis.recompute_and_store",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                post_refresh(db)
+
+        assert exc_info.value.status_code == 500
+        assert "Recompute failed" in exc_info.value.detail
+
+
+class TestMissingSpeakers:
+    def test_returns_empty_podcasts_when_snapshot_row_missing(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = None
+        assert missing_speakers(db) == {"podcasts": []}
+
+    def test_returns_empty_podcasts_when_no_excluded_entries(self):
+        db = MagicMock()
+        row = SimpleNamespace(
+            snapshot={"coverage": {"host_share": {"excluded": []}}}
+        )
+        db.query.return_value.filter.return_value.one_or_none.return_value = row
+        assert missing_speakers(db) == {"podcasts": []}
+
+    def test_groups_excluded_episodes_by_feed(self):
+        db = MagicMock()
+        snapshot = {
+            "coverage": {
+                "host_share": {
+                    "excluded": [
+                        {
+                            "episode_id": "ep-1",
+                            "feed_id": "feed-A",
+                            "feed_title": "Feed A",
+                            "title": "Ep One",
+                            "reason": "no confirmed host",
+                        },
+                        {
+                            "episode_id": "ep-2",
+                            "feed_id": "feed-A",
+                            "feed_title": "Feed A",
+                            "title": "Ep Two",
+                            "reason": "no chunks yet",
+                        },
+                        {
+                            "episode_id": "ep-3",
+                            "feed_id": "feed-B",
+                            "feed_title": "Feed B",
+                            "title": "Ep Three",
+                            "reason": "no confirmed host",
+                        },
+                    ]
+                }
+            }
+        }
+        row = SimpleNamespace(snapshot=snapshot)
+        db.query.return_value.filter.return_value.one_or_none.return_value = row
+
+        result = missing_speakers(db)
+        podcasts = {p["feed_id"]: p for p in result["podcasts"]}
+        assert set(podcasts) == {"feed-A", "feed-B"}
+        assert podcasts["feed-A"]["title"] == "Feed A"
+        assert len(podcasts["feed-A"]["episodes"]) == 2
+        assert podcasts["feed-A"]["episodes"][0] == {
+            "id": "ep-1", "title": "Ep One", "reason": "no confirmed host"
+        }
+        assert podcasts["feed-B"]["episodes"][0]["id"] == "ep-3"
+
+    def test_handles_missing_coverage_path_gracefully(self):
+        db = MagicMock()
+        row = SimpleNamespace(snapshot={})  # no "coverage" key
+        db.query.return_value.filter.return_value.one_or_none.return_value = row
+        assert missing_speakers(db) == {"podcasts": []}

--- a/apps/pipeline/tests/unit/test_meta_analysis_service.py
+++ b/apps/pipeline/tests/unit/test_meta_analysis_service.py
@@ -1,0 +1,304 @@
+"""Unit tests for app.services.meta_analysis (#556).
+
+Focus on pure helpers and stale-flag orchestration. DB-heavy aggregates
+(_per_episode, _per_speaker, _coverage_and_host_share) are exercised by
+integration tests and covered indirectly through compute_snapshot wiring.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.services import meta_analysis as svc
+
+
+class TestCountTurns:
+    def test_empty_returns_zero(self):
+        assert svc._count_turns([]) == 0
+
+    def test_single_segment_is_one_turn(self):
+        segs = [SimpleNamespace(start_time=0.0, speaker_label="A")]
+        assert svc._count_turns(segs) == 1
+
+    def test_counts_speaker_changes(self):
+        segs = [
+            SimpleNamespace(start_time=0.0, speaker_label="A"),
+            SimpleNamespace(start_time=1.0, speaker_label="A"),
+            SimpleNamespace(start_time=2.0, speaker_label="B"),
+            SimpleNamespace(start_time=3.0, speaker_label="A"),
+        ]
+        # A (start) -> A (no change) -> B (change) -> A (change) = 3 turns
+        assert svc._count_turns(segs) == 3
+
+    def test_sorts_by_start_time_before_counting(self):
+        # Input order shouldn't matter — sort happens first.
+        segs = [
+            SimpleNamespace(start_time=3.0, speaker_label="A"),
+            SimpleNamespace(start_time=1.0, speaker_label="B"),
+            SimpleNamespace(start_time=2.0, speaker_label="A"),
+        ]
+        # Sorted by time: B, A, A → 2 turns (B→A, then A→A no change)
+        assert svc._count_turns(segs) == 2
+
+
+class TestRollUpFeedTextTotals:
+    def test_sums_word_and_token_totals_per_feed(self):
+        per_feed = [
+            {"feed_id": "f1"},
+            {"feed_id": "f2"},
+        ]
+        per_ep = [
+            {"feed_id": "f1", "word_count": 100, "token_count_segments": 50, "token_count_chunks": 10},
+            {"feed_id": "f1", "word_count": 200, "token_count_segments": 80, "token_count_chunks": 20},
+            {"feed_id": "f2", "word_count": 50, "token_count_segments": 25, "token_count_chunks": 5},
+        ]
+
+        svc._roll_up_feed_text_totals(per_feed, per_ep)
+
+        assert per_feed[0]["total_words"] == 300
+        assert per_feed[0]["total_tokens_segments"] == 130
+        assert per_feed[0]["total_tokens_chunks"] == 30
+        assert per_feed[1]["total_words"] == 50
+
+    def test_feed_with_no_episodes_gets_zeroes(self):
+        per_feed = [{"feed_id": "empty"}]
+        svc._roll_up_feed_text_totals(per_feed, per_ep=[])
+        assert per_feed[0]["total_words"] == 0
+        assert per_feed[0]["total_tokens_segments"] == 0
+        assert per_feed[0]["total_tokens_chunks"] == 0
+
+
+class TestTimelineMonthly:
+    def test_buckets_by_month_and_sums(self):
+        per_ep = [
+            {"feed_id": "f1", "published_at": "2026-01-15T10:00:00Z",
+             "word_count": 100, "duration_secs": 600},
+            {"feed_id": "f1", "published_at": "2026-01-20T10:00:00Z",
+             "word_count": 200, "duration_secs": 1200},
+            {"feed_id": "f1", "published_at": "2026-02-01T10:00:00Z",
+             "word_count": 50, "duration_secs": 300},
+        ]
+        result = svc._timeline_monthly(db=MagicMock(), per_ep=per_ep)
+        assert len(result) == 2
+        jan, feb = result[0], result[1]
+        assert jan["month"] == "2026-01"
+        assert jan["episode_count"] == 2
+        assert jan["total_words"] == 300
+        assert jan["total_duration_min"] == 30.0
+        assert feb["month"] == "2026-02"
+        assert feb["episode_count"] == 1
+
+    def test_skips_episodes_without_published_at(self):
+        per_ep = [
+            {"feed_id": "f1", "published_at": None,
+             "word_count": 999, "duration_secs": 9999},
+        ]
+        assert svc._timeline_monthly(db=MagicMock(), per_ep=per_ep) == []
+
+    def test_sorts_by_feed_id_then_month(self):
+        per_ep = [
+            {"feed_id": "b", "published_at": "2026-02-01T00:00:00Z",
+             "word_count": 1, "duration_secs": 60},
+            {"feed_id": "a", "published_at": "2026-03-01T00:00:00Z",
+             "word_count": 1, "duration_secs": 60},
+            {"feed_id": "a", "published_at": "2026-01-01T00:00:00Z",
+             "word_count": 1, "duration_secs": 60},
+        ]
+        result = svc._timeline_monthly(db=MagicMock(), per_ep=per_ep)
+        assert [(r["feed_id"], r["month"]) for r in result] == [
+            ("a", "2026-01"),
+            ("a", "2026-03"),
+            ("b", "2026-02"),
+        ]
+
+
+class TestIdentifyFeedHost:
+    def test_prefers_feed_speaker_cache_top(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=[{"role": "host", "name": "Other"}],
+            itunes_owner_name="Owner",
+            itunes_author="Author",
+        )
+        top_map = {"f1": "Cached Host"}
+        assert svc._identify_feed_host(feed, top_map) == "Cached Host"
+
+    def test_falls_back_to_podcast_persons_host_role(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=[
+                {"role": "guest", "name": "G"},
+                {"role": "HOST", "name": "Real Host"},
+            ],
+            itunes_owner_name="Owner",
+            itunes_author="Author",
+        )
+        assert svc._identify_feed_host(feed, feed_speaker_cache_top={}) == "Real Host"
+
+    def test_falls_back_to_itunes_owner(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=[],
+            itunes_owner_name="Owner",
+            itunes_author="Author",
+        )
+        assert svc._identify_feed_host(feed, feed_speaker_cache_top={}) == "Owner"
+
+    def test_falls_back_to_itunes_author_when_owner_missing(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=None,
+            itunes_owner_name=None,
+            itunes_author="Author",
+        )
+        assert svc._identify_feed_host(feed, feed_speaker_cache_top={}) == "Author"
+
+    def test_returns_none_when_nothing_resolves(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=[{"role": "guest", "name": "G"}],
+            itunes_owner_name=None,
+            itunes_author=None,
+        )
+        assert svc._identify_feed_host(feed, feed_speaker_cache_top={}) is None
+
+    def test_skips_malformed_persons_entries(self):
+        feed = SimpleNamespace(
+            id="f1",
+            podcast_persons=[{"role": "host"}, "not-a-dict", {"role": "host", "name": "OK"}],
+            itunes_owner_name=None,
+            itunes_author=None,
+        )
+        assert svc._identify_feed_host(feed, feed_speaker_cache_top={}) == "OK"
+
+
+class TestHostSpeakerLabelForEpisode:
+    def _sn(self, episode_id: str, speaker_label: str, display_name: str, *,
+            confirmed: bool = False, confidence: str | None = None):
+        return SimpleNamespace(
+            episode_id=episode_id,
+            speaker_label=speaker_label,
+            display_name=display_name,
+            confirmed_by_user=confirmed,
+            confidence=confidence,
+        )
+
+    def test_returns_label_for_confirmed_match(self):
+        sn_by_ep = {
+            "ep1": [self._sn("ep1", "SPEAKER_00", "Alice", confirmed=True)],
+        }
+        assert svc._host_speaker_label_for_episode("ep1", "Alice", sn_by_ep) == "SPEAKER_00"
+
+    def test_returns_label_for_high_confidence_match(self):
+        sn_by_ep = {
+            "ep1": [self._sn("ep1", "SPEAKER_01", "Bob", confidence="HIGH")],
+        }
+        assert svc._host_speaker_label_for_episode("ep1", "Bob", sn_by_ep) == "SPEAKER_01"
+
+    def test_name_normalization_collapses_case(self):
+        sn_by_ep = {
+            "ep1": [self._sn("ep1", "SPEAKER_00", "alice", confirmed=True)],
+        }
+        assert svc._host_speaker_label_for_episode("ep1", "Alice", sn_by_ep) == "SPEAKER_00"
+
+    def test_skips_low_confidence_unconfirmed(self):
+        sn_by_ep = {
+            "ep1": [self._sn("ep1", "SPEAKER_00", "Alice", confidence="LOW")],
+        }
+        assert svc._host_speaker_label_for_episode("ep1", "Alice", sn_by_ep) is None
+
+    def test_returns_none_when_host_name_empty(self):
+        assert svc._host_speaker_label_for_episode("ep1", "", {}) is None
+
+    def test_returns_none_when_episode_has_no_speakers(self):
+        assert svc._host_speaker_label_for_episode("ep1", "Alice", {}) is None
+
+
+class TestStaleFlagHelpers:
+    def test_is_stale_true_when_row_has_non_false_value(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = SimpleNamespace(
+            key=svc.STALE_KEY, value="token-123"
+        )
+        assert svc.is_stale(db) is True
+
+    def test_is_stale_false_when_row_missing(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = None
+        assert svc.is_stale(db) is False
+
+    def test_is_stale_false_when_value_is_false_string(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = SimpleNamespace(
+            key=svc.STALE_KEY, value="false"
+        )
+        assert svc.is_stale(db) is False
+
+    def test_set_stale_writes_random_token_and_commits(self):
+        db = MagicMock()
+        svc.set_stale(db)
+        db.execute.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_clear_stale_writes_false_and_commits(self):
+        db = MagicMock()
+        svc.clear_stale(db)
+        db.execute.assert_called_once()
+        db.commit.assert_called_once()
+
+    def test_capture_stale_token_returns_value_when_set(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = SimpleNamespace(
+            value="tok-xyz"
+        )
+        assert svc._capture_stale_token(db) == "tok-xyz"
+
+    def test_capture_stale_token_returns_none_when_cleared(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = SimpleNamespace(
+            value="false"
+        )
+        assert svc._capture_stale_token(db) is None
+
+    def test_capture_stale_token_returns_none_when_missing(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.one_or_none.return_value = None
+        assert svc._capture_stale_token(db) is None
+
+    def test_clear_stale_if_token_noop_for_none_token(self):
+        db = MagicMock()
+        assert svc._clear_stale_if_token(db, None) is False
+        db.commit.assert_not_called()
+
+    def test_clear_stale_if_token_returns_true_when_row_updated(self):
+        db = MagicMock()
+        # The chained filter().update() returns affected-row count.
+        db.query.return_value.filter.return_value.update.return_value = 1
+        assert svc._clear_stale_if_token(db, "tok-1") is True
+        db.commit.assert_called_once()
+
+    def test_clear_stale_if_token_returns_false_when_rotated(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.update.return_value = 0
+        assert svc._clear_stale_if_token(db, "tok-1") is False
+
+
+class TestRecomputeAndStore:
+    def test_orchestrates_compute_upsert_and_clear(self):
+        db = MagicMock()
+        fake_snap = {
+            "per_episode": [{"id": "a"}, {"id": "b"}],
+            "per_feed": [{"id": "f1"}],
+        }
+
+        with patch.object(svc, "_capture_stale_token", return_value="tok-A") as cap, \
+             patch.object(svc, "compute_snapshot", return_value=fake_snap) as comp, \
+             patch.object(svc, "upsert_snapshot", return_value="ROW") as ups, \
+             patch.object(svc, "_clear_stale_if_token") as clr:
+            result = svc.recompute_and_store(db)
+
+        cap.assert_called_once_with(db)
+        comp.assert_called_once_with(db)
+        ups.assert_called_once_with(db, fake_snap, 2, 1)
+        clr.assert_called_once_with(db, "tok-A")
+        assert result == "ROW"

--- a/apps/pipeline/tests/unit/test_pipeline_commands.py
+++ b/apps/pipeline/tests/unit/test_pipeline_commands.py
@@ -1,0 +1,29 @@
+"""Unit tests for app.services.pipeline_commands (#556)."""
+from unittest.mock import MagicMock, patch
+
+from app.services.pipeline_commands import (
+    enqueue_episode_ingest,
+    run_chunk_backfill,
+)
+
+
+def test_enqueue_episode_ingest_delegates_to_job_queue():
+    db = MagicMock()
+    with patch("app.services.pipeline_commands.job_queue.enqueue") as mock_enqueue:
+        enqueue_episode_ingest(db, "ep-123")
+        mock_enqueue.assert_called_once_with(db, "ep-123", "download")
+
+
+def test_run_chunk_backfill_default_embed_true():
+    with patch("app.tasks.backfill_chunks.backfill_chunks") as mock_backfill:
+        mock_backfill.return_value = {"processed": 5}
+        result = run_chunk_backfill()
+        mock_backfill.assert_called_once_with(embed=True)
+        assert result == {"processed": 5}
+
+
+def test_run_chunk_backfill_explicit_embed_false():
+    with patch("app.tasks.backfill_chunks.backfill_chunks") as mock_backfill:
+        mock_backfill.return_value = {"processed": 0}
+        run_chunk_backfill(embed=False)
+        mock_backfill.assert_called_once_with(embed=False)

--- a/apps/pipeline/tests/unit/test_transcribe_helpers.py
+++ b/apps/pipeline/tests/unit/test_transcribe_helpers.py
@@ -1,0 +1,121 @@
+"""Unit tests for app.tasks.transcribe_helpers (#556)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.tasks.transcribe_helpers import (
+    compute_fireworks_cost,
+    estimate_fireworks_usage,
+    persist_transcription_artifacts,
+    remove_artifacts,
+)
+
+
+class TestEstimateFireworksUsage:
+    def test_uses_max_segment_end_when_available(self):
+        segments = [
+            {"end": 10.0},
+            {"end": 42.5},
+            {"end": 5.0},
+        ]
+        assert estimate_fireworks_usage(segments, fallback_duration_secs=999) == 42.5
+
+    def test_falls_back_to_episode_duration_when_segments_empty(self):
+        assert estimate_fireworks_usage([], fallback_duration_secs=120) == 120.0
+
+    def test_falls_back_when_no_valid_end_values(self):
+        # All end values missing / zero -> fall back
+        segments = [{"end": 0.0}, {"end": None}]
+        assert estimate_fireworks_usage(segments, fallback_duration_secs=60) == 60.0
+
+    def test_returns_zero_when_nothing_available(self):
+        assert estimate_fireworks_usage([], fallback_duration_secs=None) == 0.0
+
+    def test_skips_invalid_end_values(self):
+        # Non-numeric end should be skipped, still pick max of valid ones.
+        segments = [{"end": "bad"}, {"end": 12.0}, {"end": object()}]
+        assert estimate_fireworks_usage(segments, fallback_duration_secs=100) == 12.0
+
+
+class TestComputeFireworksCost:
+    def test_rounds_minutes_to_three_decimals_and_cost_to_four(self):
+        minutes, cost = compute_fireworks_cost(audio_secs=90.0, configured_rate_usd_per_minute=0.01)
+        assert minutes == 1.5
+        assert cost == 0.015
+
+    def test_zero_audio_returns_zero(self):
+        assert compute_fireworks_cost(0.0, 0.05) == (0.0, 0.0)
+
+    def test_negative_audio_returns_zero(self):
+        # audio_secs > 0 gate means negatives short-circuit to 0.
+        assert compute_fireworks_cost(-5.0, 0.05) == (0.0, 0.0)
+
+
+class TestRemoveArtifacts:
+    def test_unlinks_existing_files(self, tmp_path: Path):
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.write_text("{}")
+        b.write_text("{}")
+        missing = tmp_path / "missing.json"  # never created
+
+        remove_artifacts(a, b, missing)
+
+        assert not a.exists()
+        assert not b.exists()
+        # No crash for missing file.
+
+    def test_swallows_unlink_errors(self, tmp_path: Path):
+        a = tmp_path / "a.json"
+        a.write_text("{}")
+
+        with patch.object(Path, "unlink", side_effect=OSError("locked")):
+            # Should not raise.
+            remove_artifacts(a)
+
+
+class TestPersistTranscriptionArtifacts:
+    def test_writes_both_artifacts_and_returns_paths(self, tmp_path: Path):
+        aligned_path, fireworks_path = persist_transcription_artifacts(
+            transcript_dir=str(tmp_path),
+            episode_id="ep-1",
+            aligned_result={"segments": [1, 2]},
+            fireworks_result={"words": []},
+        )
+
+        assert aligned_path == tmp_path / "ep-1.whisperx.json"
+        assert fireworks_path == tmp_path / "ep-1.fireworks.json"
+        assert json.loads(aligned_path.read_text()) == {"segments": [1, 2]}
+        assert json.loads(fireworks_path.read_text()) == {"words": []}
+
+    def test_only_aligned_side(self, tmp_path: Path):
+        aligned_path, fireworks_path = persist_transcription_artifacts(
+            transcript_dir=str(tmp_path),
+            episode_id="ep-2",
+            aligned_result={"a": 1},
+            fireworks_result=None,
+        )
+        assert aligned_path.exists()
+        assert not fireworks_path.exists()
+
+    def test_only_fireworks_side(self, tmp_path: Path):
+        aligned_path, fireworks_path = persist_transcription_artifacts(
+            transcript_dir=str(tmp_path),
+            episode_id="ep-3",
+            aligned_result=None,
+            fireworks_result={"b": 2},
+        )
+        assert not aligned_path.exists()
+        assert fireworks_path.exists()
+
+    def test_creates_transcript_dir_if_missing(self, tmp_path: Path):
+        target = tmp_path / "nested" / "dir"
+        persist_transcription_artifacts(
+            transcript_dir=str(target),
+            episode_id="ep-4",
+            aligned_result={"x": True},
+            fireworks_result=None,
+        )
+        assert (target / "ep-4.whisperx.json").exists()


### PR DESCRIPTION
Closes #556.

## Summary
Adds 61 targeted unit tests for the four pipeline modules flagged in the 2026-04-24 audit:

| Module | Before | After |
|--------|--------|-------|
| \`services/pipeline_commands.py\` | 57% | **100%** |
| \`tasks/transcribe_helpers.py\` | 50% | **100%** |
| \`api/meta_analysis.py\` | 41% | **100%** |
| \`services/meta_analysis.py\` | 51% | **72%** |

For \`services/meta_analysis.py\`, tests focus on pure helpers (\`_count_turns\`, \`_timeline_monthly\`, \`_identify_feed_host\`, \`_host_speaker_label_for_episode\`, \`_roll_up_feed_text_totals\`) and the stale-flag / recompute orchestration. DB-heavy aggregates (\`_per_episode\`, \`_per_speaker\`, \`_coverage_and_host_share\`) remain covered by integration tests — mocking their multi-stage SQLAlchemy query chains for unit tests adds little value.

## Test plan
- [x] \`python -m pytest tests/unit/ -q\` — **698 passed** (was 637; +61).
- [x] \`python -m pytest tests/unit/ --cov=app\` — overall 87%, CI gate \`--cov-fail-under=82\` comfortably met.
- [x] Target modules confirmed ≥60%; three are now at 100%.