### PR TITLE
test(web): cover meta-analysis + pipeline/ask API routes (#564)

### DIFF
--- a/apps/web/tests/unit/meta-analysis-missing-speakers-route.test.ts
+++ b/apps/web/tests/unit/meta-analysis-missing-speakers-route.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for GET /api/meta-analysis/coverage/missing-speakers — proxy to
+ * pipeline FastAPI. Transient failures degrade to `{podcasts: []}`.
+ *
+ * @jest-environment node
+ */
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+type RouteModule = typeof import(
+  "@/app/api/meta-analysis/coverage/missing-speakers/route"
+);
+let GET: RouteModule["GET"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import(
+    "@/app/api/meta-analysis/coverage/missing-speakers/route"
+  );
+  GET = mod.GET;
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("GET /api/meta-analysis/coverage/missing-speakers", () => {
+  it("proxies upstream podcasts list", async () => {
+    const podcasts = [{ feed_id: "f1", title: "T", episodes: [] }];
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ podcasts })),
+    });
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ podcasts });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/meta-analysis/coverage/missing-speakers",
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("degrades to empty podcasts on non-JSON upstream response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve("<html>down</html>"),
+    });
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({ podcasts: [] });
+  });
+
+  it("degrades to empty podcasts when fetch throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("ETIMEDOUT"));
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({ podcasts: [] });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns null body when upstream text is empty", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+    });
+
+    const resp = await GET();
+    expect(await resp.json()).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/meta-analysis-refresh-route.test.ts
+++ b/apps/web/tests/unit/meta-analysis-refresh-route.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for POST /api/meta-analysis/refresh — proxy to pipeline FastAPI.
+ *
+ * @jest-environment node
+ */
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+type RouteModule = typeof import("@/app/api/meta-analysis/refresh/route");
+let POST: RouteModule["POST"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/meta-analysis/refresh/route");
+  POST = mod.POST;
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("POST /api/meta-analysis/refresh", () => {
+  it("forwards POST and returns upstream JSON with status", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ recomputed: true })),
+    });
+
+    const resp = await POST();
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ recomputed: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/meta-analysis/refresh",
+      expect.objectContaining({ method: "POST", cache: "no-store" })
+    );
+  });
+
+  it("handles empty upstream body as null", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+    });
+
+    const resp = await POST();
+    expect(await resp.json()).toBeNull();
+  });
+
+  it("returns 502 with hint when upstream returns non-JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: () => Promise.resolve("bad gateway html"),
+    });
+
+    const resp = await POST();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({
+      error: "Upstream returned non-JSON (status 502)",
+    });
+  });
+
+  it("returns 502 'Refresh failed' when fetch throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    const resp = await POST();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({ error: "Refresh failed" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/tests/unit/meta-analysis-snapshot-route.test.ts
+++ b/apps/web/tests/unit/meta-analysis-snapshot-route.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for GET /api/meta-analysis/snapshot — proxy to pipeline FastAPI.
+ *
+ * @jest-environment node
+ */
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+type RouteModule = typeof import("@/app/api/meta-analysis/snapshot/route");
+let GET: RouteModule["GET"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/meta-analysis/snapshot/route");
+  GET = mod.GET;
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+describe("GET /api/meta-analysis/snapshot", () => {
+  it("proxies JSON response and status from upstream", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ snapshot: { x: 1 }, is_stale: false }));
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ snapshot: { x: 1 }, is_stale: false });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/meta-analysis/snapshot",
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("returns null body when upstream returns empty text", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
+    });
+
+    const resp = await GET();
+    expect(await resp.json()).toBeNull();
+  });
+
+  it("returns 502 with error hint when upstream returns non-JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("<html>upstream exploded</html>"),
+    });
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({
+      error: "Upstream returned non-JSON (status 500)",
+    });
+  });
+
+  it("returns 502 'Pipeline unreachable' when fetch throws", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const resp = await GET();
+
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({ error: "Pipeline unreachable" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/tests/unit/pipeline-ask-route.test.ts
+++ b/apps/web/tests/unit/pipeline-ask-route.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for POST /api/pipeline/ask — SSE proxy to pipeline /api/ask.
+ *
+ * The route wraps the upstream ReadableStream so client disconnects
+ * cancel the upstream fetch cleanly.
+ *
+ * @jest-environment node
+ */
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
+
+type RouteModule = typeof import("@/app/api/pipeline/ask/route");
+let POST: RouteModule["POST"];
+
+beforeAll(async () => {
+  const mod: RouteModule = await import("@/app/api/pipeline/ask/route");
+  POST = mod.POST;
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function makeReq(body: unknown, signal: AbortSignal = new AbortController().signal) {
+  return {
+    json: () => Promise.resolve(body),
+    signal,
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value);
+  }
+  return out;
+}
+
+describe("POST /api/pipeline/ask", () => {
+  it("forwards body to upstream and streams response with SSE headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: streamFromChunks(["event: token\ndata: hi\n\n", "event: done\ndata: {}\n\n"]),
+    });
+
+    const resp = await POST(makeReq({ question: "why?", model: "qwen2.5:3b" }));
+
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toBe("text/event-stream");
+    expect(resp.headers.get("cache-control")).toBe("no-cache");
+    expect(resp.headers.get("x-accel-buffering")).toBe("no");
+
+    const streamed = await collectStream(resp.body!);
+    expect(streamed).toContain("event: token");
+    expect(streamed).toContain("event: done");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/ask",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: "why?", model: "qwen2.5:3b" }),
+      })
+    );
+  });
+
+  it("returns upstream status with error message when upstream is not ok", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      body: null,
+    });
+
+    const resp = await POST(makeReq({ question: "x" }));
+
+    expect(resp.status).toBe(500);
+    expect(await resp.text()).toBe("Pipeline API error");
+  });
+
+  it("returns error response when upstream is ok but body is null", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: null,
+    });
+
+    const resp = await POST(makeReq({ question: "x" }));
+
+    // Route hits the `!resp.ok || !resp.body` branch and returns
+    // upstream status with the error message.
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toBe("Pipeline API error");
+  });
+
+  it("aborts upstream when client abort signal fires", async () => {
+    const upstreamSignals: AbortSignal[] = [];
+    mockFetch.mockImplementation((_url, init) => {
+      upstreamSignals.push(init.signal);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: streamFromChunks(["data: x\n\n"]),
+      });
+    });
+
+    const clientAbort = new AbortController();
+    await POST(makeReq({ question: "x" }, clientAbort.signal));
+
+    expect(upstreamSignals).toHaveLength(1);
+    const upstream = upstreamSignals[0];
+    expect(upstream.aborted).toBe(false);
+
+    clientAbort.abort();
+    expect(upstream.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #564 (child of #550).

## Summary
Adds 16 tests across four API route files all previously at 0% coverage:

| Route | Before | After |
|-------|--------|-------|
| \`api/meta-analysis/coverage/missing-speakers\` | 0% | **100%** |
| \`api/meta-analysis/refresh\` | 0% | **100%** |
| \`api/meta-analysis/snapshot\` | 0% | **100%** |
| \`api/pipeline/ask\` | 0% | **95%** |

The three meta-analysis routes are JSON proxies to the pipeline FastAPI — tested for success, empty body, non-JSON upstream, and fetch throw. The \`missing-speakers\` degrade-to-empty fallback is explicitly asserted.

The \`pipeline/ask\` route is an SSE proxy that wraps the upstream \`ReadableStream\` so client disconnects cancel the upstream fetch — tests verify stream passthrough, error branches, and that triggering the client \`AbortController\` propagates to the upstream \`fetch\` signal.

## Test plan
- [x] \`npx jest\` — **402 passed** (+16 from 386).
- [x] Target files confirmed at ≥95% stmts coverage, well above the 60% bar.