### PR TITLE
test(web): cover lib helpers (db, filterOpts, mentions, grouped) (#565)

### DIFF
--- a/apps/web/tests/unit/db.test.ts
+++ b/apps/web/tests/unit/db.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for @/lib/db — PostgreSQL connection pool factory.
+ *
+ * @jest-environment node
+ */
+jest.mock("pg", () => {
+  return {
+    Pool: jest.fn().mockImplementation((config: Record<string, unknown>) => ({
+      __config: config,
+    })),
+  };
+});
+
+describe("lib/db", () => {
+  it("exports a pg Pool constructed with DATABASE_URL and sane defaults", async () => {
+    const original = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://user:pw@localhost:5432/podlog";
+
+    jest.resetModules();
+    const { Pool } = await import("pg");
+    const mod = await import("@/lib/db");
+
+    expect(Pool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionString: "postgresql://user:pw@localhost:5432/podlog",
+        max: 10,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+      })
+    );
+    expect(mod.default).toBeDefined();
+
+    if (original === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = original;
+    }
+  });
+});

--- a/apps/web/tests/unit/filterOpts.test.ts
+++ b/apps/web/tests/unit/filterOpts.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for @/lib/search/filterOpts — `buildMetadataSnippet` formatting.
+ */
+import { buildMetadataSnippet } from "@/lib/search/filterOpts";
+import { parseSearchQuery } from "@/lib/search/queryParser";
+
+describe("buildMetadataSnippet", () => {
+  it("prefers a title match when titleFilter matches and episode_title present", () => {
+    const parsed = parseSearchQuery("title:election");
+    const snippet = buildMetadataSnippet(
+      { episode_title: "Election 2026 Recap", episode_description: null },
+      parsed
+    );
+    expect(snippet).toBe("Title match: Election 2026 Recap");
+  });
+
+  it("returns trimmed description for descriptionFilter matches", () => {
+    const parsed = parseSearchQuery("description:climate");
+    const snippet = buildMetadataSnippet(
+      { episode_title: "T", episode_description: "  Long climate episode.  " },
+      parsed
+    );
+    expect(snippet).toBe("Long climate episode.");
+  });
+
+  it("truncates long descriptions to 240 chars with ellipsis", () => {
+    const parsed = parseSearchQuery("description:x");
+    const longText = "a".repeat(500);
+    const snippet = buildMetadataSnippet(
+      { episode_title: null, episode_description: longText },
+      parsed
+    );
+    expect(snippet).toHaveLength(240 + 3);
+    expect(snippet.endsWith("...")).toBe(true);
+  });
+
+  it("returns speaker-match snippet when only speakerFilter is set", () => {
+    const parsed = parseSearchQuery("speaker:Alice");
+    const snippet = buildMetadataSnippet(
+      { episode_title: null, episode_description: null },
+      parsed
+    );
+    expect(snippet).toBe("Speaker match: Alice");
+  });
+
+  it("falls back to episode_title when no scoped filters", () => {
+    const parsed = parseSearchQuery("free text");
+    const snippet = buildMetadataSnippet(
+      { episode_title: "My Episode", episode_description: null },
+      parsed
+    );
+    expect(snippet).toBe("My Episode");
+  });
+
+  it("final fallback is 'Episode match' when everything is null", () => {
+    const parsed = parseSearchQuery("free text");
+    const snippet = buildMetadataSnippet(
+      { episode_title: null, episode_description: null },
+      parsed
+    );
+    expect(snippet).toBe("Episode match");
+  });
+});

--- a/apps/web/tests/unit/search-grouped.test.ts
+++ b/apps/web/tests/unit/search-grouped.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for @/lib/search/grouped — searchGrouped() end-to-end shape,
+ * covering both the FTS path and the metadata-only path.
+ *
+ * @jest-environment node
+ */
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
+
+jest.mock("@/lib/search/coverage", () => ({
+  buildCoverage: jest.fn().mockResolvedValue(null),
+  toCoverage: jest.fn(() => ({
+    totalFeedsIndexed: 0,
+    totalEpisodesIndexed: 0,
+    indexedSpeakerCount: 0,
+    totalSegments: 0,
+  })),
+}));
+
+type GroupedModule = typeof import("@/lib/search/grouped");
+let searchGrouped: GroupedModule["searchGrouped"];
+
+beforeAll(async () => {
+  const mod: GroupedModule = await import("@/lib/search/grouped");
+  searchGrouped = mod.searchGrouped;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    feed_id: "f1",
+    feed_title: "F1",
+    feed_mode: "full",
+    episode_id: "ep-1",
+    episode_title: "Ep 1",
+    audio_url: null,
+    audio_local_path: null,
+    episode_url: null,
+    mention_count: 1,
+    best_rank: 0.5,
+    ...overrides,
+  };
+}
+
+describe("searchGrouped — metadata_only path", () => {
+  it("runs metadata SQL when query has only scoped filters and no free text", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [row({ episode_title: "T1" }), row({ episode_id: "ep-2" })] })
+      .mockResolvedValueOnce({
+        rows: [{ total_episodes: 2, total_feeds: 1, total_mentions: 2, has_manual: false }],
+      });
+
+    const result = await searchGrouped("title:foo", null, true, 1, 20);
+
+    expect(result.totalEpisodes).toBe(2);
+    expect(result.totalFeeds).toBe(1);
+    expect(result.totalMentions).toBe(2);
+    expect(result.feeds).toHaveLength(1);
+    expect(result.feeds[0].episodes).toHaveLength(2);
+
+    const [rowsSql] = mockQuery.mock.calls[0];
+    expect(rowsSql).toMatch(/FROM episodes e/);
+    expect(rowsSql).not.toMatch(/speaker_turns/);
+  });
+
+  it("bumps totalFeeds by 1 when manual uploads are present", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [row({ feed_id: null, feed_title: "Manual episode" })] })
+      .mockResolvedValueOnce({
+        rows: [{ total_episodes: 1, total_feeds: 0, total_mentions: 1, has_manual: true }],
+      });
+
+    const result = await searchGrouped("title:foo", null, true, 1, 20);
+
+    expect(result.totalFeeds).toBe(1);
+  });
+
+  it("skipCount=true means no count query is issued", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row()] });
+
+    const result = await searchGrouped("title:foo", null, true, 1, 20, true);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(result.totalEpisodes).toBe(-1);
+    expect(result.totalMentions).toBe(-1);
+  });
+});
+
+describe("searchGrouped — FTS path", () => {
+  it("uses the speaker_turns CTE when query has free text", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [row({ mention_count: 3, best_rank: 0.9 })] })
+      .mockResolvedValueOnce({
+        rows: [{ total_episodes: 1, total_feeds: 1, total_mentions: 3, has_manual: false }],
+      });
+
+    const result = await searchGrouped("climate", null, true, 1, 20);
+
+    const [rowsSql, rowsParams] = mockQuery.mock.calls[0];
+    expect(rowsSql).toMatch(/WITH.*speaker_turns/s);
+    expect(rowsParams[0]).toBe("climate");
+    expect(result.feeds[0].episodes[0].mentionCount).toBe(3);
+  });
+
+  it("passes feedIds and pageSize/offset into the rows query", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ total_episodes: 0, total_feeds: 0, total_mentions: 0, has_manual: false }],
+      });
+
+    await searchGrouped("climate", ["feed-A", "feed-B"], false, 2, 10);
+
+    const [, rowsParams] = mockQuery.mock.calls[0];
+    expect(rowsParams[rowsParams.length - 2]).toBe(10);
+    expect(rowsParams[rowsParams.length - 1]).toBe(10);
+    // feedIds are bound as a single array param (f.id = ANY($N::uuid[])).
+    expect(rowsParams).toEqual(
+      expect.arrayContaining([["feed-A", "feed-B"]])
+    );
+  });
+
+  it("returns -1 sentinels on counts when skipCount=true in FTS mode", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row()] });
+
+    const result = await searchGrouped("climate", null, true, 1, 20, true);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(result.totalEpisodes).toBe(-1);
+  });
+});

--- a/apps/web/tests/unit/search-mentions.test.ts
+++ b/apps/web/tests/unit/search-mentions.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for @/lib/search/mentions — searchMentions() context builder.
+ *
+ * @jest-environment node
+ */
+const mockQuery = jest.fn();
+jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
+
+type MentionsModule = typeof import("@/lib/search/mentions");
+let searchMentions: MentionsModule["searchMentions"];
+
+beforeAll(async () => {
+  const mod: MentionsModule = await import("@/lib/search/mentions");
+  searchMentions = mod.searchMentions;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function turn(
+  id: string,
+  text: string,
+  isMatch: boolean,
+  start = 0,
+  end = 5,
+  label = "SPEAKER_00",
+  display = "SPEAKER_00"
+) {
+  return {
+    id,
+    start_time: String(start),
+    end_time: String(end),
+    speaker_label: label,
+    speaker_display: display,
+    full_text: text,
+    is_match: isMatch,
+    snippet: isMatch ? `<b>${text}</b>` : "",
+    rank: isMatch ? "0.5" : "0",
+  };
+}
+
+describe("searchMentions", () => {
+  it("returns empty list when query is blank after parsing", async () => {
+    const result = await searchMentions("   ", "ep-1");
+    expect(result).toEqual({ episodeId: "ep-1", mentions: [] });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("builds mentions with up to 2 surrounding non-match context segments each side", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        turn("1", "before-2", false, 0, 1),
+        turn("2", "before-1", false, 2, 3),
+        turn("3", "the match here", true, 4, 5),
+        turn("4", "after-1", false, 6, 7),
+        turn("5", "after-2", false, 8, 9),
+        turn("6", "after-3", false, 10, 11),
+      ],
+    });
+
+    const result = await searchMentions("match", "ep-1");
+
+    expect(result.episodeId).toBe("ep-1");
+    expect(result.mentions).toHaveLength(1);
+    const m = result.mentions[0];
+    expect(m.id).toBe("3");
+    expect(m.startTime).toBe(4);
+    expect(m.contextBefore.map((c) => c.text)).toEqual(["before-2", "before-1"]);
+    expect(m.contextAfter.map((c) => c.text)).toEqual(["after-1", "after-2"]);
+  });
+
+  it("stops context collection when another match is encountered", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        turn("1", "before-match", false, 0, 1),
+        turn("2", "match A", true, 2, 3),
+        turn("3", "between", false, 4, 5),
+        turn("4", "match B", true, 6, 7),
+      ],
+    });
+
+    const result = await searchMentions("match", "ep-1");
+
+    expect(result.mentions).toHaveLength(2);
+    const [a, b] = result.mentions;
+    expect(a.contextAfter.map((c) => c.text)).toEqual(["between"]);
+    expect(b.contextBefore.map((c) => c.text)).toEqual(["between"]);
+  });
+
+  it("appends speaker filter to SQL when speaker scope present", async () => {
+    mockQuery.mockResolvedValue({ rows: [turn("1", "m", true)] });
+
+    // Free text first, then scoped — otherwise the parser eats everything
+    // after `speaker:` as the filter value (see queryParser.ts).
+    await searchMentions("match speaker:Alice", "ep-1");
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params).toEqual(["match", "ep-1", "%Alice%"]);
+  });
+
+  it("returns empty mentions when no rows are matches", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        turn("1", "no match", false),
+        turn("2", "also not", false),
+      ],
+    });
+
+    const result = await searchMentions("term", "ep-1");
+    expect(result.mentions).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #565 (child of #550).

## Summary
Adds 18 tests across four lib modules that were all below 60%:

| File | Before | After |
|------|--------|-------|
| \`lib/db.ts\` | 0% | **100%** |
| \`lib/search/filterOpts.ts\` | 0% | **100%** |
| \`lib/search/mentions.ts\` | 10% | **100%** |
| \`lib/search/grouped.ts\` | 18% | **100%** |

## Coverage details
- **db**: pool factory receives \`DATABASE_URL\` + configured timeouts.
- **filterOpts**: every branch of \`buildMetadataSnippet\` (title / description / speaker / fallback / truncation).
- **mentions**: empty-query short-circuit, the context-window walker (±2 non-match turns), stop-on-next-match logic, speaker-filter SQL param wiring.
- **grouped**: both the metadata-only path and the FTS path, plus the \`has_manual\` total bump and \`skipCount\` short-circuit.

## Test plan
- [x] \`npx jest\` — **420 passed** (+18 from 402).
- [x] All four target files at 100% statement coverage, well above the 60% bar.