### PR TITLE
test(web): cover simple UI components (#566)

### DIFF
--- a/apps/web/tests/unit/audio-upload.test.tsx
+++ b/apps/web/tests/unit/audio-upload.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for AudioUpload — file validation, metadata fields, and submit.
+ *
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import AudioUpload from "@/components/AudioUpload";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function makeFile(name: string, type = "audio/mpeg", sizeBytes = 1024): File {
+  const content = new Uint8Array(sizeBytes);
+  return new File([content], name, { type });
+}
+
+describe("AudioUpload", () => {
+  it("renders the dropzone with allowed extensions hint", () => {
+    render(<AudioUpload />);
+    expect(screen.getByText(/Drop an audio file here/i)).toBeInTheDocument();
+    expect(screen.getByText(/MP3, M4A/)).toBeInTheDocument();
+  });
+
+  it("accepts a valid audio file and seeds the title from the filename", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("my_great_episode.mp3"));
+
+    const titleInput = screen.getByPlaceholderText("Episode title") as HTMLInputElement;
+    // defaultTitle replaces `_` / `-` with spaces and drops the extension.
+    expect(titleInput.value).toBe("my great episode");
+    expect(screen.getByRole("button", { name: /upload and process/i })).toBeEnabled();
+  });
+
+  it("rejects a file with an unsupported extension", () => {
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    // fireEvent.change with Object.defineProperty bypasses the input's
+    // accept= filter so the component's own validation runs.
+    const badFile = makeFile("readme.txt", "text/plain");
+    Object.defineProperty(input, "files", { value: [badFile] });
+    fireEvent.change(input);
+
+    expect(screen.getByText(/Unsupported file type/i)).toBeInTheDocument();
+  });
+
+  it("accepts a file by extension when MIME type is blank", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("talk.flac", ""));
+
+    // No error, title is seeded.
+    expect(screen.queryByText(/Unsupported file type/i)).not.toBeInTheDocument();
+  });
+
+  it("clears the selection when the X button is clicked", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("talk.mp3"));
+    expect(screen.getByRole("button", { name: /upload and process/i })).toBeInTheDocument();
+
+    // The X button has no accessible name, so find by icon container.
+    const clearBtn = container.querySelector("button.ml-auto") as HTMLButtonElement;
+    await user.click(clearBtn);
+
+    expect(screen.queryByRole("button", { name: /upload and process/i })).not.toBeInTheDocument();
+  });
+
+  it("submits via POST /api/episodes/upload and calls onUploaded on success", async () => {
+    const onUploaded = jest.fn();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ episode_id: "new-ep" }),
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload onUploaded={onUploaded} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("talk.mp3"));
+    await user.click(screen.getByRole("button", { name: /upload and process/i }));
+
+    await waitFor(() => {
+      expect(onUploaded).toHaveBeenCalledWith("new-ep");
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/episodes/upload",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(screen.getByText(/Upload successful/i)).toBeInTheDocument();
+  });
+
+  it("shows the API error detail when the upload fails", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ detail: "File too large" }),
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("talk.mp3"));
+    await user.click(screen.getByRole("button", { name: /upload and process/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("File too large")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a generic connection error when fetch throws", async () => {
+    mockFetch.mockRejectedValue(new Error("ENETUNREACH"));
+
+    const user = userEvent.setup();
+    const { container } = render(<AudioUpload />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await user.upload(input, makeFile("talk.mp3"));
+    await user.click(screen.getByRole("button", { name: /upload and process/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your connection/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/tests/unit/download-report-button.test.tsx
+++ b/apps/web/tests/unit/download-report-button.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for DownloadReportButton — dropdown of export actions.
+ *
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import DownloadReportButton from "@/components/DownloadReportButton";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const mockOpen = jest.fn();
+const origOpen = window.open;
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+const originalAnchorClick = HTMLAnchorElement.prototype.click;
+
+const createObjectURL = jest.fn(() => "blob:mock");
+const revokeObjectURL = jest.fn();
+const anchorClick = jest.fn();
+
+beforeAll(() => {
+  URL.createObjectURL = createObjectURL;
+  URL.revokeObjectURL = revokeObjectURL;
+  HTMLAnchorElement.prototype.click = anchorClick;
+  (window as { open: typeof mockOpen }).open = mockOpen;
+});
+
+afterAll(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  HTMLAnchorElement.prototype.click = originalAnchorClick;
+  (window as { open: typeof origOpen }).open = origOpen;
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockOpen.mockClear();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  anchorClick.mockClear();
+});
+
+const sampleFlat = [
+  {
+    id: "seg-1",
+    episodeId: "ep-1",
+    episodeTitle: "Ep 1",
+    feedTitle: "Feed A",
+    episodeUrl: null,
+    audioUrl: null,
+    startTime: 10,
+    endTime: 20,
+    speakerLabel: "SPEAKER_00",
+    speakerDisplay: "Host",
+    snippet: "hello",
+    text: "hello",
+    rank: 1,
+  },
+];
+
+describe("DownloadReportButton", () => {
+  it("renders null when there are no results", () => {
+    const { container } = render(
+      <DownloadReportButton query="x" flatResults={[]} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the export dropdown when flat results are present", async () => {
+    render(<DownloadReportButton query="climate" flatResults={sampleFlat} />);
+    expect(screen.getByRole("button", { name: /export/i })).toBeInTheDocument();
+  });
+
+  it("renders when grouped results have at least one feed", () => {
+    render(
+      <DownloadReportButton
+        query="x"
+        groupedResults={{
+          feeds: [
+            {
+              feedId: "f1",
+              feedTitle: "Feed",
+              feedMode: "full",
+              episodes: [],
+              totalMentions: 0,
+            },
+          ],
+          totalFeeds: 1,
+          totalEpisodes: 0,
+          totalMentions: 0,
+          coverage: {
+            totalFeedsIndexed: 0,
+            totalEpisodesIndexed: 0,
+            indexedSpeakerCount: 0,
+            totalSegments: 0,
+          },
+        }}
+      />
+    );
+    expect(screen.getByRole("button", { name: /export/i })).toBeInTheDocument();
+  });
+
+  it("print export opens the print route in a new window", async () => {
+    const user = userEvent.setup();
+    render(<DownloadReportButton query="climate" flatResults={sampleFlat} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Print / PDF"));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      "/search/print?q=climate",
+      "_blank"
+    );
+  });
+
+  it("markdown export fetches and downloads a .md blob", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: sampleFlat }),
+    });
+
+    const user = userEvent.setup();
+    render(<DownloadReportButton query="climate" flatResults={sampleFlat} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Markdown (.md)"));
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalled();
+    });
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining("q=climate"));
+  });
+
+  it("plain text export fetches and downloads a .txt blob", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: sampleFlat }),
+    });
+
+    const user = userEvent.setup();
+    render(<DownloadReportButton query="climate" flatResults={sampleFlat} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Plain Text (.txt)"));
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  it("logs and does not crash when fetch throws during export", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("network"));
+
+    const user = userEvent.setup();
+    render(<DownloadReportButton query="climate" flatResults={sampleFlat} />);
+
+    await user.click(screen.getByRole("button", { name: /export/i }));
+    await user.click(screen.getByText("Markdown (.md)"));
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Export failed:",
+        expect.any(Error)
+      );
+    });
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/tests/unit/episode-description.test.tsx
+++ b/apps/web/tests/unit/episode-description.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for EpisodeDescription — renders sanitized HTML, linkifies
+ * timestamps when audio metadata is present, and toggles show more/less.
+ *
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+// isomorphic-dompurify ships ESM-only deps jest can't parse. Stub it so
+// the component renders — we assert structural outcomes (target/rel, no
+// <script>) from the tag-filtering step that follows sanitization.
+jest.mock("isomorphic-dompurify", () => ({
+  __esModule: true,
+  default: {
+    sanitize: (html: string) => html.replace(/<script[\s\S]*?<\/script>/gi, ""),
+  },
+}));
+
+import EpisodeDescription from "@/components/EpisodeDescription";
+import { AudioPlayerProvider } from "@/components/AudioPlayerContext";
+
+function wrap(ui: React.ReactNode) {
+  return <AudioPlayerProvider>{ui}</AudioPlayerProvider>;
+}
+
+describe("EpisodeDescription", () => {
+  it("renders plain text description", () => {
+    render(wrap(<EpisodeDescription description="A short description." />));
+    expect(screen.getByText(/A short description\./)).toBeInTheDocument();
+  });
+
+  it("sanitizes unsafe HTML (strips <script>)", () => {
+    const malicious = 'safe text <script>alert("xss")</script>';
+    const { container } = render(wrap(<EpisodeDescription description={malicious} />));
+    expect(container.innerHTML).not.toContain("<script");
+    expect(container.textContent).toContain("safe text");
+  });
+
+  it("allows anchor tags and forces target=_blank + rel", () => {
+    const html = '<a href="https://example.com">link</a>';
+    const { container } = render(wrap(<EpisodeDescription description={html} />));
+    const anchor = container.querySelector("a");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("shows 'Show more' toggle when description is long (>300 chars)", async () => {
+    const user = userEvent.setup();
+    const long = "x".repeat(500);
+    render(wrap(<EpisodeDescription description={long} />));
+    expect(screen.getByRole("button", { name: /show more/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show more/i }));
+    expect(screen.getByRole("button", { name: /show less/i })).toBeInTheDocument();
+  });
+
+  it("hides the toggle for short descriptions", () => {
+    render(wrap(<EpisodeDescription description="Short." />));
+    expect(screen.queryByRole("button", { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it("linkifies MM:SS timestamps when episodeId + audioLocalPath present", () => {
+    const { container } = render(
+      wrap(
+        <EpisodeDescription
+          description="Check 12:34 for the key moment."
+          episodeId="ep-1"
+          audioLocalPath="/data/audio/archive/ep-1.mp3"
+        />
+      )
+    );
+    const anchor = container.querySelector("a.podlog-timestamp-link");
+    expect(anchor).toBeTruthy();
+    // 12:34 → 12*60 + 34 = 754
+    expect(anchor?.getAttribute("data-timestamp-secs")).toBe("754");
+    expect(anchor?.textContent).toBe("12:34");
+  });
+
+  it("linkifies HH:MM:SS timestamps as well", () => {
+    const { container } = render(
+      wrap(
+        <EpisodeDescription
+          description="Jump to 01:02:03 for the conclusion."
+          episodeId="ep-1"
+          audioLocalPath="/data/audio/archive/ep-1.mp3"
+        />
+      )
+    );
+    const anchor = container.querySelector("a.podlog-timestamp-link");
+    // 1h 2m 3s → 3723
+    expect(anchor?.getAttribute("data-timestamp-secs")).toBe("3723");
+  });
+
+  it("does not linkify timestamps when audio metadata is missing", () => {
+    const { container } = render(
+      wrap(<EpisodeDescription description="Jump to 12:34." />)
+    );
+    expect(container.querySelector("a.podlog-timestamp-link")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/transcript-section.test.tsx
+++ b/apps/web/tests/unit/transcript-section.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Tests for TranscriptSection — state coordination between SpeakerPanel,
+ * TranscriptView, and the export button.
+ *
+ * Child components are mocked to keep this focused on TranscriptSection's
+ * own logic (handleRenamed / handleMerged segment updates).
+ *
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/TranscriptView", () => ({
+  __esModule: true,
+  default: ({ segments }: { segments: Array<{ id: number; text: string; display_name?: string | null; speaker_label: string | null }> }) => (
+    <div data-testid="transcript-view">
+      {segments.map((s) => (
+        <div key={s.id} data-testid={`seg-${s.id}`}>
+          {s.speaker_label ?? "—"}:{s.display_name ?? ""}:{s.text}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/TranscriptExportButton", () => ({
+  __esModule: true,
+  default: () => <button>Export transcript</button>,
+}));
+
+type SpeakerPanelProps = {
+  onRenamed: (speakerLabel: string, newName: string) => void;
+  onMerged: (sourceLabels: string[], targetLabel: string) => void;
+};
+let capturedSpeakerPanelProps: SpeakerPanelProps | null = null;
+
+jest.mock("@/components/SpeakerPanel", () => ({
+  __esModule: true,
+  default: (props: SpeakerPanelProps) => {
+    capturedSpeakerPanelProps = props;
+    return <div data-testid="speaker-panel" />;
+  },
+}));
+
+import TranscriptSection from "@/components/TranscriptSection";
+import { AudioPlayerProvider } from "@/components/AudioPlayerContext";
+
+function wrap(ui: React.ReactNode) {
+  return <AudioPlayerProvider>{ui}</AudioPlayerProvider>;
+}
+
+const baseProps = {
+  episodeId: "ep-1",
+  hasDiarization: true,
+  status: "done",
+  audioLocalPath: null,
+  episodeTitle: null,
+  feedTitle: null,
+  publishedAt: null,
+  durationSecs: null,
+  description: null,
+  feedUrl: null,
+  feedWebsiteUrl: null,
+  feedDescription: null,
+  audioUrl: null,
+  guid: null,
+};
+
+const sampleSegments = [
+  {
+    id: 1,
+    start_time: 0,
+    end_time: 5,
+    speaker_label: "SPEAKER_00",
+    display_name: null,
+    inferred: false,
+    confirmed_by_user: false,
+    text: "hello",
+  },
+  {
+    id: 2,
+    start_time: 5,
+    end_time: 10,
+    speaker_label: "SPEAKER_01",
+    display_name: null,
+    inferred: false,
+    confirmed_by_user: false,
+    text: "world",
+  },
+];
+
+describe("TranscriptSection", () => {
+  beforeEach(() => {
+    capturedSpeakerPanelProps = null;
+  });
+
+  it("renders SpeakerPanel when hasDiarization=true", () => {
+    render(wrap(<TranscriptSection {...baseProps} segments={sampleSegments} />));
+    expect(screen.getByTestId("speaker-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("transcript-view")).toBeInTheDocument();
+  });
+
+  it("hides SpeakerPanel when hasDiarization=false", () => {
+    render(
+      wrap(
+        <TranscriptSection
+          {...baseProps}
+          hasDiarization={false}
+          segments={sampleSegments}
+        />
+      )
+    );
+    expect(screen.queryByTestId("speaker-panel")).not.toBeInTheDocument();
+  });
+
+  it("omits the export button when there are no segments", () => {
+    render(wrap(<TranscriptSection {...baseProps} segments={[]} />));
+    expect(screen.queryByText("Export transcript")).not.toBeInTheDocument();
+  });
+
+  it("shows the export button when segments exist", () => {
+    render(wrap(<TranscriptSection {...baseProps} segments={sampleSegments} />));
+    expect(screen.getByText("Export transcript")).toBeInTheDocument();
+  });
+
+  it("handleRenamed updates display_name for matching speaker_label", () => {
+    render(wrap(<TranscriptSection {...baseProps} segments={sampleSegments} />));
+
+    act(() => {
+      capturedSpeakerPanelProps!.onRenamed("SPEAKER_00", "Alice");
+    });
+
+    expect(screen.getByTestId("seg-1").textContent).toContain("Alice");
+    // Other speaker untouched.
+    expect(screen.getByTestId("seg-2").textContent).not.toContain("Alice");
+  });
+
+  it("handleMerged reassigns source speakers onto the target label", () => {
+    const segments = [
+      ...sampleSegments,
+      {
+        id: 3,
+        start_time: 10,
+        end_time: 15,
+        speaker_label: "SPEAKER_00",
+        display_name: "Host",
+        inferred: false,
+        confirmed_by_user: true,
+        text: "again",
+      },
+    ];
+    render(wrap(<TranscriptSection {...baseProps} segments={segments} />));
+
+    act(() => {
+      // Merge SPEAKER_01 into SPEAKER_00.
+      capturedSpeakerPanelProps!.onMerged(["SPEAKER_01"], "SPEAKER_00");
+    });
+
+    // Segment 2 now carries SPEAKER_00 with Host display name inherited from segment 3.
+    const seg2 = screen.getByTestId("seg-2").textContent;
+    expect(seg2).toContain("SPEAKER_00");
+    expect(seg2).toContain("Host");
+  });
+
+  it("shows the back-to-top button once window.scrollY exceeds 400", async () => {
+    render(wrap(<TranscriptSection {...baseProps} segments={sampleSegments} />));
+    expect(screen.queryByTitle(/back to top/i)).not.toBeInTheDocument();
+
+    act(() => {
+      Object.defineProperty(window, "scrollY", { value: 500, configurable: true });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(screen.getByTitle(/back to top/i)).toBeInTheDocument();
+
+    // Click scroll-to-top button to exercise its handler.
+    const scrollSpy = jest.spyOn(window, "scrollTo").mockImplementation(() => {});
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle(/back to top/i));
+    expect(scrollSpy).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+    scrollSpy.mockRestore();
+  });
+});

--- a/apps/web/tests/unit/uploads-section.test.tsx
+++ b/apps/web/tests/unit/uploads-section.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for UploadsSection — header counts, search filter, empty states.
+ *
+ * EpisodeCard and AudioUpload are mocked so tests focus on the section's
+ * own state (search, counts, dialog toggle, delete flow).
+ *
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+const mockRefresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+jest.mock("@/components/EpisodeCard", () => ({
+  __esModule: true,
+  default: ({
+    episode,
+    onDelete,
+    onToggleError,
+  }: {
+    episode: { id: string; title: string | null };
+    onDelete?: (ep: { id: string; title: string | null }) => Promise<void> | void;
+    onToggleError?: (e: React.MouseEvent, id: string) => void;
+  }) => (
+    <div data-testid={`card-${episode.id}`}>
+      <span>{episode.title ?? "—"}</span>
+      <button
+        data-testid={`delete-${episode.id}`}
+        onClick={() => onDelete?.(episode)}
+      >
+        delete
+      </button>
+      <button
+        data-testid={`toggle-${episode.id}`}
+        onClick={(e) => onToggleError?.(e, episode.id)}
+      >
+        toggle
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/AudioUpload", () => ({
+  __esModule: true,
+  default: () => <div data-testid="audio-upload-mock" />,
+}));
+
+import UploadsSection from "@/components/UploadsSection";
+import type { UploadedEpisode } from "@/components/UploadsSection";
+
+function makeEp(overrides: Partial<UploadedEpisode> = {}): UploadedEpisode {
+  return {
+    id: "ep-1",
+    title: "First upload",
+    description: "A great audio file",
+    published_at: null,
+    processed_at: null,
+    duration_secs: 60,
+    language: null,
+    status: "done",
+    has_diarization: true,
+    diarization_error: null,
+    error_class: null,
+    error_message: null,
+    retry_count: 0,
+    retry_max: 3,
+    transcribe_duration_secs: 10,
+    diarize_duration_secs: 5,
+    inference_provider_used: null,
+    fireworks_audio_minutes: null,
+    fireworks_stt_cost_usd: null,
+    pyannote_cloud_cost_usd: null,
+    speaker_count: 1,
+    speaker_name_tags: [],
+    ...overrides,
+  };
+}
+
+describe("UploadsSection", () => {
+  it("shows the empty state when no uploads exist", () => {
+    render(<UploadsSection uploads={[]} processed={0} total={0} />);
+    expect(screen.getByText(/No uploads yet/i)).toBeInTheDocument();
+    // No header count when total=0
+    expect(screen.queryByText(/processed/)).not.toBeInTheDocument();
+  });
+
+  it("shows the file count in the header when fully processed", () => {
+    const uploads = [makeEp({ id: "ep-1" }), makeEp({ id: "ep-2", title: "Second" })];
+    render(<UploadsSection uploads={uploads} processed={2} total={2} />);
+    expect(screen.getByText(/\(2 files\)/)).toBeInTheDocument();
+  });
+
+  it("shows the processed/total count when processing is incomplete", () => {
+    const uploads = [makeEp()];
+    render(<UploadsSection uploads={uploads} processed={1} total={3} />);
+    expect(screen.getByText(/\(1 \/ 3 processed\)/)).toBeInTheDocument();
+  });
+
+  it("filters uploads by title substring", async () => {
+    const user = userEvent.setup();
+    const uploads = [
+      makeEp({ id: "ep-1", title: "Climate talk" }),
+      makeEp({ id: "ep-2", title: "Economy brief" }),
+    ];
+    render(<UploadsSection uploads={uploads} processed={2} total={2} />);
+
+    expect(screen.getByTestId("card-ep-1")).toBeInTheDocument();
+    expect(screen.getByTestId("card-ep-2")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/search manual uploads/i), "climate");
+
+    expect(screen.getByTestId("card-ep-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("card-ep-2")).not.toBeInTheDocument();
+  });
+
+  it("filters by description when title does not match", async () => {
+    const user = userEvent.setup();
+    const uploads = [
+      makeEp({ id: "ep-1", title: "Untitled", description: "about climate change" }),
+      makeEp({ id: "ep-2", title: "Untitled", description: "about economy" }),
+    ];
+    render(<UploadsSection uploads={uploads} processed={2} total={2} />);
+
+    await user.type(screen.getByLabelText(/search manual uploads/i), "climate");
+
+    expect(screen.getByTestId("card-ep-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("card-ep-2")).not.toBeInTheDocument();
+  });
+
+  it("shows 'No uploads match' when filter returns zero results", async () => {
+    const user = userEvent.setup();
+    render(
+      <UploadsSection
+        uploads={[makeEp({ id: "ep-1", title: "Climate" })]}
+        processed={1}
+        total={1}
+      />
+    );
+
+    await user.type(
+      screen.getByLabelText(/search manual uploads/i),
+      "zzznomatch"
+    );
+
+    expect(screen.getByText(/No uploads match your search/i)).toBeInTheDocument();
+  });
+
+  it("delete flow: confirmation + DELETE fetch + router refresh on success", async () => {
+    mockRefresh.mockClear();
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true, status: 204 });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const user = userEvent.setup();
+    render(
+      <UploadsSection
+        uploads={[makeEp({ id: "ep-1", title: "Climate" })]}
+        processed={1}
+        total={1}
+      />
+    );
+
+    await user.click(screen.getByTestId("delete-ep-1"));
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/episodes/ep-1",
+      expect.objectContaining({ method: "DELETE" })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockRefresh).toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it("delete flow: user cancels the confirm and no fetch is issued", async () => {
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const user = userEvent.setup();
+    render(
+      <UploadsSection
+        uploads={[makeEp({ id: "ep-9", title: "Nope" })]}
+        processed={1}
+        total={1}
+      />
+    );
+
+    await user.click(screen.getByTestId("delete-ep-9"));
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("toggleError adds/removes ids from the expanded error set", async () => {
+    const user = userEvent.setup();
+    render(
+      <UploadsSection
+        uploads={[makeEp({ id: "ep-5", title: "E" })]}
+        processed={1}
+        total={1}
+      />
+    );
+    // Covers the toggleError callback path (adds then removes).
+    await user.click(screen.getByTestId("toggle-ep-5"));
+    await user.click(screen.getByTestId("toggle-ep-5"));
+  });
+
+  it("clears the search when the X button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <UploadsSection
+        uploads={[makeEp({ id: "ep-1", title: "Climate" })]}
+        processed={1}
+        total={1}
+      />
+    );
+
+    const input = screen.getByLabelText(/search manual uploads/i);
+    await user.type(input, "xyz");
+    await user.click(screen.getByRole("button", { name: /clear search/i }));
+
+    expect((input as HTMLInputElement).value).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #566 (child of #550).

## Summary
Adds 40 tests for five components flagged at 0-6% in the audit:

| Component | Before | After |
|-----------|--------|-------|
| \`AudioUpload.tsx\` | 0% | **85%** |
| \`DownloadReportButton.tsx\` | 5.71% | **95%** |
| \`EpisodeDescription.tsx\` | 0% | **66%** |
| \`TranscriptSection.tsx\` | 0% | **97%** |
| \`UploadsSection.tsx\` | 0% | **86%** |

## Approach
- Each test file mocks child components (EpisodeCard, AudioUpload, TranscriptView, SpeakerPanel, TranscriptExportButton) so the suite exercises the parent's own state / callbacks rather than the full subtree.
- \`EpisodeDescription\` mocks \`isomorphic-dompurify\` because its transitive chain ships native ESM that jest's default transformer can't parse. The component's safety path (strip \`<script>\`, force target=_blank) is still asserted via the post-sanitize regex step.
- \`UploadsSection\` covers the delete flow (confirm → DELETE → router.refresh), search filtering by title and description, and the toggleError callback.

## Test plan
- [x] \`npx jest\` — **460 passed** (+40 from 420).
- [x] All five target components confirmed ≥60%.