### PR TITLE
refactor(queue): move queue read ownership to pipeline API (#555)

### DIFF
--- a/apps/pipeline/app/api/queue.py
+++ b/apps/pipeline/app/api/queue.py
@@ -1,14 +1,17 @@
 """
-Queue management API — control-plane endpoints only.
+Queue management API.
 
+GET   /api/queue                         Queue dashboard snapshot
 POST  /api/queue/{episode_id}/retry      Retry a failed/stuck/done job
 
-Queue read (GET /api/queue) is served directly by the Next.js web app
-via PostgreSQL queries (no proxy needed).
+The queue dashboard read (GET /api/queue) lives in the pipeline so that
+job_queue schema and the web app stay on opposite sides of a stable
+HTTP contract. Web's /api/queue route is a thin proxy (#555).
 """
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -23,6 +26,167 @@ NON_RETRYABLE = {"DISK_FULL", "OOM"}
 
 # Terminal or known-idle statuses that are always safe to retry
 _RETRYABLE_STATUSES = {"done", "failed", "pending"}
+
+# Map job_queue.task → UI display status for active jobs.
+TASK_TO_STATUS: dict[str, str] = {
+    "download": "downloading",
+    "transcribe": "transcribing",
+    "diarize": "diarizing",
+    "embed": "embedding",
+    "infer": "inferring",
+    "archive": "archiving",
+}
+
+
+def _rows(db: Session, sql: str) -> list[dict]:
+    """Run a read-only SQL statement and return rows as dicts."""
+    return [dict(row._mapping) for row in db.execute(text(sql)).all()]
+
+
+@router.get("/queue")
+def get_queue(db: Session = Depends(get_db)) -> dict:
+    """Return the queue dashboard snapshot consumed by the web UI.
+
+    Shape is the contract that `apps/web/src/components/QueueStatus.tsx`
+    and its view-model helper depend on — do not change keys without
+    coordinating a web-side update.
+    """
+    active_rows = _rows(
+        db,
+        """
+        SELECT DISTINCT ON (e.id)
+          e.id        AS episode_id,
+          e.title,
+          jq.task     AS active_task,
+          e.error_message,
+          e.error_class,
+          e.retry_count,
+          e.retry_max,
+          e.updated_at,
+          jq.picked_at,
+          f.mode      AS feed_mode,
+          f.title     AS feed_title
+        FROM job_queue jq
+        JOIN episodes e ON e.id = jq.episode_id
+        LEFT JOIN feeds f ON f.id = e.feed_id
+        WHERE jq.status = 'picked'
+        ORDER BY e.id, jq.picked_at DESC
+        """,
+    )
+    pending_rows = _rows(
+        db,
+        """
+        SELECT DISTINCT ON (e.id)
+          e.id        AS episode_id,
+          e.title,
+          jq.task     AS pending_task,
+          e.error_message,
+          e.error_class,
+          e.retry_count,
+          e.retry_max,
+          e.updated_at,
+          f.mode      AS feed_mode,
+          f.title     AS feed_title
+        FROM job_queue jq
+        JOIN episodes e ON e.id = jq.episode_id
+        LEFT JOIN feeds f ON f.id = e.feed_id
+        WHERE jq.status = 'pending'
+          AND e.status NOT IN ('done', 'failed')
+          AND NOT EXISTS (
+            SELECT 1 FROM job_queue jq2
+            WHERE jq2.episode_id = e.id AND jq2.status = 'picked'
+          )
+        ORDER BY e.id, jq.created_at ASC
+        """,
+    )
+    failed_rows = _rows(
+        db,
+        """
+        SELECT
+          e.id        AS episode_id,
+          e.title,
+          e.status,
+          e.error_message,
+          e.error_class,
+          e.retry_count,
+          e.retry_max,
+          e.updated_at,
+          f.mode      AS feed_mode,
+          f.title     AS feed_title
+        FROM episodes e
+        LEFT JOIN feeds f ON f.id = e.feed_id
+        WHERE e.status = 'failed'
+        ORDER BY e.updated_at DESC
+        """,
+    )
+    done_rows = _rows(
+        db,
+        """
+        SELECT
+          e.id        AS episode_id,
+          e.title,
+          e.status,
+          e.error_message,
+          e.error_class,
+          e.retry_count,
+          e.retry_max,
+          e.updated_at,
+          f.mode      AS feed_mode,
+          f.title     AS feed_title
+        FROM episodes e
+        LEFT JOIN feeds f ON f.id = e.feed_id
+        WHERE e.status = 'done'
+        ORDER BY e.updated_at DESC
+        LIMIT 50
+        """,
+    )
+    stuck_rows = _rows(
+        db,
+        """
+        SELECT
+          e.id        AS episode_id,
+          e.title,
+          e.status,
+          e.error_message,
+          e.error_class,
+          e.retry_count,
+          e.retry_max,
+          e.updated_at,
+          f.mode      AS feed_mode,
+          f.title     AS feed_title
+        FROM episodes e
+        LEFT JOIN feeds f ON f.id = e.feed_id
+        WHERE e.status NOT IN ('done', 'failed')
+          AND NOT EXISTS (
+            SELECT 1 FROM job_queue jq
+            WHERE jq.episode_id = e.id AND jq.status IN ('pending', 'picked')
+          )
+        ORDER BY e.updated_at DESC
+        """,
+    )
+    done_count = db.execute(
+        text("SELECT COUNT(*) AS count FROM episodes WHERE status = 'done'")
+    ).scalar_one()
+
+    for row in active_rows:
+        row["status"] = TASK_TO_STATUS.get(row.get("active_task"), row.get("active_task"))
+    for row in pending_rows:
+        row["status"] = "pending"
+    for row in stuck_rows:
+        row["status"] = "stuck"
+
+    return {
+        "active_count": len(active_rows),
+        "pending_count": len(pending_rows),
+        "failed_count": len(failed_rows),
+        "done_count": int(done_count or 0),
+        "stuck_count": len(stuck_rows),
+        "active_jobs": active_rows,
+        "pending_jobs": pending_rows,
+        "failed_jobs": failed_rows,
+        "done_jobs": done_rows,
+        "stuck_jobs": stuck_rows,
+    }
 
 
 @router.post("/queue/{episode_id}/retry", status_code=202)

--- a/apps/pipeline/tests/unit/test_queue_api.py
+++ b/apps/pipeline/tests/unit/test_queue_api.py
@@ -1,7 +1,8 @@
-"""Tests for the queue API retry logic."""
+"""Tests for the queue API: retry logic + dashboard read (#555)."""
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from app.api.queue import NON_RETRYABLE, retry_job
+from app.api.queue import NON_RETRYABLE, TASK_TO_STATUS, get_queue, retry_job
 from app.models import Episode, Job
 
 
@@ -116,3 +117,146 @@ class TestRetryJob:
         ep = _make_episode("transcribing")
         result = self._call_retry(ep, has_active_job=True)
         assert result.status_code == 409
+
+
+def _classify(sql_text: str) -> str:
+    """Route a queue SQL string to its dashboard bucket.
+
+    Order matters: check for the most specific markers first because the
+    stuck / count queries both mention 'done' and 'failed' as literals.
+    """
+    if "COUNT(*) AS count" in sql_text:
+        return "done_count"
+    if "jq.status = 'picked'" in sql_text:
+        return "active"
+    if "jq.status = 'pending'" in sql_text:
+        return "pending"
+    if "jq.status IN ('pending', 'picked')" in sql_text:
+        return "stuck"
+    if "LIMIT 50" in sql_text:
+        return "done"
+    if "WHERE e.status = 'failed'" in sql_text:
+        return "failed"
+    return "unknown"
+
+
+def _mock_execute(rows_by_bucket: dict[str, list[dict]], done_count: int = 0):
+    """Build a side_effect that routes db.execute(text(sql)) by bucket name."""
+    def side_effect(stmt):
+        bucket = _classify(str(stmt))
+        result = MagicMock()
+        if bucket == "done_count":
+            result.scalar_one.return_value = done_count
+            return result
+        rows = rows_by_bucket.get(bucket, [])
+        result.all.return_value = [
+            SimpleNamespace(_mapping=dict(row)) for row in rows  # type: ignore[arg-type]
+        ]
+        return result
+    return side_effect
+
+
+class TestGetQueue:
+    def test_empty_queue_returns_zero_counts(self):
+        db = MagicMock()
+        db.execute.side_effect = _mock_execute({}, done_count=0)
+
+        payload = get_queue(db=db)
+
+        assert payload["active_count"] == 0
+        assert payload["pending_count"] == 0
+        assert payload["failed_count"] == 0
+        assert payload["done_count"] == 0
+        assert payload["stuck_count"] == 0
+        assert payload["active_jobs"] == []
+        assert payload["pending_jobs"] == []
+        assert payload["failed_jobs"] == []
+        assert payload["done_jobs"] == []
+        assert payload["stuck_jobs"] == []
+
+    def test_active_rows_get_task_mapped_to_display_status(self):
+        db = MagicMock()
+        db.execute.side_effect = _mock_execute(
+            {
+                "active": [
+                    {"episode_id": "ep-1", "active_task": "transcribe", "title": "T1"},
+                    {"episode_id": "ep-2", "active_task": "diarize", "title": "T2"},
+                ]
+            }
+        )
+
+        payload = get_queue(db=db)
+
+        assert payload["active_count"] == 2
+        assert [j["status"] for j in payload["active_jobs"]] == ["transcribing", "diarizing"]
+
+    def test_active_task_falls_back_to_raw_name_when_unmapped(self):
+        db = MagicMock()
+        db.execute.side_effect = _mock_execute(
+            {
+                "active": [
+                    {"episode_id": "ep-x", "active_task": "custom_task", "title": "X"},
+                ]
+            }
+        )
+
+        payload = get_queue(db=db)
+
+        assert payload["active_jobs"][0]["status"] == "custom_task"
+
+    def test_pending_and_stuck_rows_are_tagged_with_literal_statuses(self):
+        db = MagicMock()
+        db.execute.side_effect = _mock_execute(
+            {
+                "pending": [
+                    {"episode_id": "ep-p", "pending_task": "transcribe", "title": "P"}
+                ],
+                "stuck": [
+                    {"episode_id": "ep-s", "status": "downloading:100", "title": "S"}
+                ],
+            }
+        )
+
+        payload = get_queue(db=db)
+
+        assert payload["pending_count"] == 1
+        assert payload["pending_jobs"][0]["status"] == "pending"
+        assert payload["stuck_count"] == 1
+        assert payload["stuck_jobs"][0]["status"] == "stuck"
+
+    def test_failed_and_done_rows_pass_through_with_done_count(self):
+        db = MagicMock()
+        db.execute.side_effect = _mock_execute(
+            {
+                "failed": [
+                    {"episode_id": "ep-f", "title": "F", "status": "failed",
+                     "error_message": "HTTP 404"},
+                ],
+                "done": [
+                    {"episode_id": "ep-d", "title": "D", "status": "done"},
+                ],
+            },
+            done_count=1234,
+        )
+
+        payload = get_queue(db=db)
+
+        assert payload["failed_count"] == 1
+        assert payload["failed_jobs"][0]["error_message"] == "HTTP 404"
+        assert payload["done_count"] == 1234
+        assert isinstance(payload["done_count"], int)
+        assert payload["done_jobs"][0]["episode_id"] == "ep-d"
+
+
+class TestTaskToStatusMap:
+    def test_covers_every_pipeline_task(self):
+        # If a new task stage is added to job_queue, this guard reminds us to
+        # teach the dashboard how to display it.
+        assert TASK_TO_STATUS == {
+            "download": "downloading",
+            "transcribe": "transcribing",
+            "diarize": "diarizing",
+            "embed": "embedding",
+            "infer": "inferring",
+            "archive": "archiving",
+        }

--- a/apps/web/src/app/api/queue/route.ts
+++ b/apps/web/src/app/api/queue/route.ts
@@ -1,169 +1,34 @@
 import { NextResponse } from "next/server";
-import pool from "@/lib/db";
+import { PIPELINE_API } from "@/lib/pipeline";
 
 export const dynamic = "force-dynamic";
 
-/** Map job_queue.task to the display status shown in the UI. */
-const TASK_TO_STATUS: Record<string, string> = {
-  download: "downloading",
-  transcribe: "transcribing",
-  diarize: "diarizing",
-  embed: "embedding",
-  infer: "inferring",
-  archive: "archiving",
-};
-
+/**
+ * GET /api/queue — thin proxy to the pipeline FastAPI.
+ *
+ * Queue reads used to run raw SQL against job_queue from the web app.
+ * Ownership lives in the pipeline now (#555) so the web and the
+ * pipeline don't silently drift on schema changes. Web just forwards.
+ */
 export async function GET() {
   try {
-    // Active: episodes with a picked job in job_queue (source of truth)
-    const activeQuery = pool.query(`
-      SELECT DISTINCT ON (e.id)
-        e.id        AS episode_id,
-        e.title,
-        jq.task     AS active_task,
-        e.error_message,
-        e.error_class,
-        e.retry_count,
-        e.retry_max,
-        e.updated_at,
-        jq.picked_at,
-        f.mode      AS feed_mode,
-        f.title     AS feed_title
-      FROM job_queue jq
-      JOIN episodes e ON e.id = jq.episode_id
-      LEFT JOIN feeds f ON f.id = e.feed_id
-      WHERE jq.status = 'picked'
-      ORDER BY e.id, jq.picked_at DESC
-    `);
-
-    // Pending: episodes with pending jobs but no picked job
-    const pendingQuery = pool.query(`
-      SELECT DISTINCT ON (e.id)
-        e.id        AS episode_id,
-        e.title,
-        jq.task     AS pending_task,
-        e.error_message,
-        e.error_class,
-        e.retry_count,
-        e.retry_max,
-        e.updated_at,
-        f.mode      AS feed_mode,
-        f.title     AS feed_title
-      FROM job_queue jq
-      JOIN episodes e ON e.id = jq.episode_id
-      LEFT JOIN feeds f ON f.id = e.feed_id
-      WHERE jq.status = 'pending'
-        AND e.status NOT IN ('done', 'failed')
-        AND NOT EXISTS (
-          SELECT 1 FROM job_queue jq2
-          WHERE jq2.episode_id = e.id AND jq2.status = 'picked'
-        )
-      ORDER BY e.id, jq.created_at ASC
-    `);
-
-    // Failed episodes (error details live on episodes table)
-    const failedQuery = pool.query(`
-      SELECT
-        e.id        AS episode_id,
-        e.title,
-        e.status,
-        e.error_message,
-        e.error_class,
-        e.retry_count,
-        e.retry_max,
-        e.updated_at,
-        f.mode      AS feed_mode,
-        f.title     AS feed_title
-      FROM episodes e
-      LEFT JOIN feeds f ON f.id = e.feed_id
-      WHERE e.status = 'failed'
-      ORDER BY e.updated_at DESC
-    `);
-
-    // Done episodes (limited to 50 + total count)
-    const doneQuery = pool.query(`
-      SELECT
-        e.id        AS episode_id,
-        e.title,
-        e.status,
-        e.error_message,
-        e.error_class,
-        e.retry_count,
-        e.retry_max,
-        e.updated_at,
-        f.mode      AS feed_mode,
-        f.title     AS feed_title
-      FROM episodes e
-      LEFT JOIN feeds f ON f.id = e.feed_id
-      WHERE e.status = 'done'
-      ORDER BY e.updated_at DESC
-      LIMIT 50
-    `);
-
-    const doneCountQuery = pool.query(
-      `SELECT COUNT(*) AS count FROM episodes WHERE status = 'done'`
-    );
-
-    // Stuck: episodes not done/failed, with no pending or picked jobs in job_queue
-    // (catches downloading:100 and other invalid status states)
-    const stuckQuery = pool.query(`
-      SELECT
-        e.id        AS episode_id,
-        e.title,
-        e.status,
-        e.error_message,
-        e.error_class,
-        e.retry_count,
-        e.retry_max,
-        e.updated_at,
-        f.mode      AS feed_mode,
-        f.title     AS feed_title
-      FROM episodes e
-      LEFT JOIN feeds f ON f.id = e.feed_id
-      WHERE e.status NOT IN ('done', 'failed')
-        AND NOT EXISTS (
-          SELECT 1 FROM job_queue jq
-          WHERE jq.episode_id = e.id AND jq.status IN ('pending', 'picked')
-        )
-      ORDER BY e.updated_at DESC
-    `);
-
-    const [activeResult, pendingResult, failedResult, doneResult, doneCountResult, stuckResult] =
-      await Promise.all([activeQuery, pendingQuery, failedQuery, doneQuery, doneCountQuery, stuckQuery]);
-
-    // Map task names to display statuses for active/pending jobs
-    const activeJobs = activeResult.rows.map((r: Record<string, unknown>) => ({
-      ...r,
-      status: TASK_TO_STATUS[r.active_task as string] ?? r.active_task,
-    }));
-
-    const pendingJobs = pendingResult.rows.map((r: Record<string, unknown>) => ({
-      ...r,
-      status: "pending",
-    }));
-
-    const stuckJobs = stuckResult.rows.map((r: Record<string, unknown>) => ({
-      ...r,
-      status: "stuck",
-    }));
-
-    return NextResponse.json({
-      active_count: activeJobs.length,
-      pending_count: pendingJobs.length,
-      failed_count: failedResult.rows.length,
-      done_count: parseInt(doneCountResult.rows[0].count, 10),
-      stuck_count: stuckJobs.length,
-      active_jobs: activeJobs,
-      pending_jobs: pendingJobs,
-      failed_jobs: failedResult.rows,
-      done_jobs: doneResult.rows,
-      stuck_jobs: stuckJobs,
-    });
+    const resp = await fetch(`${PIPELINE_API}/api/queue`, { cache: "no-store" });
+    const text = await resp.text();
+    let data: unknown;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      return NextResponse.json(
+        { error: `Upstream returned non-JSON (status ${resp.status})` },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json(data, { status: resp.status });
   } catch (err) {
     console.error("Queue fetch error:", err);
     return NextResponse.json(
       { error: "Failed to fetch queue" },
-      { status: 500 }
+      { status: 502 }
     );
   }
 }

--- a/apps/web/tests/unit/queue-route.test.ts
+++ b/apps/web/tests/unit/queue-route.test.ts
@@ -1,14 +1,16 @@
 /**
- * Tests for GET /api/queue — the queue dashboard's data source.
+ * Tests for GET /api/queue — thin proxy to the pipeline FastAPI.
  *
- * The route runs 6 parallel SQL queries. We mock pool.query with a
- * dispatcher that matches on query text so each call returns the
- * right shape.
+ * Ownership of the queue-dashboard read moved to the pipeline side
+ * (#555); the web route now just forwards, normalizes empty bodies,
+ * and degrades transient failures to a 502.
  *
  * @jest-environment node
  */
-const mockQuery = jest.fn();
-jest.mock("@/lib/db", () => ({ __esModule: true, default: { query: mockQuery } }));
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock("@/lib/pipeline", () => ({ PIPELINE_API: "http://pipeline:8000" }));
 
 type RouteModule = typeof import("@/app/api/queue/route");
 let GET: RouteModule["GET"];
@@ -19,156 +21,86 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  mockQuery.mockReset();
+  mockFetch.mockReset();
 });
 
-type QueueRow = Record<string, unknown>;
-
-function dispatch(rows: {
-  active?: QueueRow[];
-  pending?: QueueRow[];
-  failed?: QueueRow[];
-  done?: QueueRow[];
-  doneCount?: string;
-  stuck?: QueueRow[];
-}) {
-  mockQuery.mockImplementation((sql: string) => {
-    if (/jq\.status\s*=\s*'picked'/.test(sql)) {
-      return Promise.resolve({ rows: rows.active ?? [] });
-    }
-    if (/jq\.status\s*=\s*'pending'/.test(sql)) {
-      return Promise.resolve({ rows: rows.pending ?? [] });
-    }
-    if (/e\.status\s*=\s*'failed'/.test(sql)) {
-      return Promise.resolve({ rows: rows.failed ?? [] });
-    }
-    if (/COUNT\(\*\) AS count/.test(sql)) {
-      return Promise.resolve({ rows: [{ count: rows.doneCount ?? "0" }] });
-    }
-    if (/e\.status\s*=\s*'done'/.test(sql)) {
-      return Promise.resolve({ rows: rows.done ?? [] });
-    }
-    if (/NOT EXISTS/.test(sql)) {
-      return Promise.resolve({ rows: rows.stuck ?? [] });
-    }
-    return Promise.resolve({ rows: [] });
-  });
-}
-
 describe("GET /api/queue", () => {
-  it("returns empty buckets and zero counts when DB is empty", async () => {
-    dispatch({});
+  it("forwards the pipeline response verbatim on success", async () => {
+    const payload = {
+      active_count: 1,
+      pending_count: 2,
+      failed_count: 0,
+      done_count: 99,
+      stuck_count: 0,
+      active_jobs: [{ episode_id: "ep-1", status: "transcribing" }],
+      pending_jobs: [
+        { episode_id: "ep-2", status: "pending" },
+        { episode_id: "ep-3", status: "pending" },
+      ],
+      failed_jobs: [],
+      done_jobs: [],
+      stuck_jobs: [],
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(payload)),
+    });
 
     const resp = await GET();
 
     expect(resp.status).toBe(200);
-    const data = await resp.json();
-    expect(data).toEqual({
-      active_count: 0,
-      pending_count: 0,
-      failed_count: 0,
-      done_count: 0,
-      stuck_count: 0,
-      active_jobs: [],
-      pending_jobs: [],
-      failed_jobs: [],
-      done_jobs: [],
-      stuck_jobs: [],
-    });
-    expect(mockQuery).toHaveBeenCalledTimes(6);
+    expect(await resp.json()).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://pipeline:8000/api/queue",
+      expect.objectContaining({ cache: "no-store" })
+    );
   });
 
-  it("maps active job task to display status via TASK_TO_STATUS", async () => {
-    dispatch({
-      active: [
-        { episode_id: "ep-1", title: "T1", active_task: "transcribe" },
-        { episode_id: "ep-2", title: "T2", active_task: "diarize" },
-        { episode_id: "ep-3", title: "T3", active_task: "download" },
-        { episode_id: "ep-4", title: "T4", active_task: "embed" },
-        { episode_id: "ep-5", title: "T5", active_task: "infer" },
-        { episode_id: "ep-6", title: "T6", active_task: "archive" },
-      ],
+  it("returns null body when upstream returns empty text", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(""),
     });
 
     const resp = await GET();
-    const data = await resp.json();
-
-    expect(data.active_count).toBe(6);
-    const statuses = data.active_jobs.map((j: { status: string }) => j.status);
-    expect(statuses).toEqual([
-      "transcribing",
-      "diarizing",
-      "downloading",
-      "embedding",
-      "inferring",
-      "archiving",
-    ]);
+    expect(await resp.json()).toBeNull();
   });
 
-  it("falls back to raw task name when task has no display mapping", async () => {
-    dispatch({
-      active: [{ episode_id: "ep-x", title: "X", active_task: "custom_task" }],
+  it("surfaces upstream non-2xx status through to the client", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(JSON.stringify({ detail: "db down" })),
     });
 
     const resp = await GET();
-    const data = await resp.json();
-
-    expect(data.active_jobs[0].status).toBe("custom_task");
+    expect(resp.status).toBe(503);
+    expect(await resp.json()).toEqual({ detail: "db down" });
   });
 
-  it("tags pending jobs with status='pending' and stuck jobs with status='stuck'", async () => {
-    dispatch({
-      pending: [{ episode_id: "ep-p", title: "P", pending_task: "transcribe" }],
-      stuck: [{ episode_id: "ep-s", title: "S", status: "downloading:100" }],
+  it("returns 502 with hint when upstream body is non-JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("<html>upstream exploded</html>"),
     });
 
     const resp = await GET();
-    const data = await resp.json();
-
-    expect(data.pending_count).toBe(1);
-    expect(data.pending_jobs[0]).toMatchObject({
-      episode_id: "ep-p",
-      status: "pending",
-      pending_task: "transcribe",
-    });
-    expect(data.stuck_count).toBe(1);
-    expect(data.stuck_jobs[0]).toMatchObject({
-      episode_id: "ep-s",
-      status: "stuck",
+    expect(resp.status).toBe(502);
+    expect(await resp.json()).toEqual({
+      error: "Upstream returned non-JSON (status 500)",
     });
   });
 
-  it("returns failed jobs rows unchanged and done count as number", async () => {
-    dispatch({
-      failed: [
-        {
-          episode_id: "ep-f",
-          title: "F",
-          status: "failed",
-          error_message: "HTTP 404",
-        },
-      ],
-      done: [{ episode_id: "ep-d", title: "D", status: "done" }],
-      doneCount: "1234",
-    });
-
-    const resp = await GET();
-    const data = await resp.json();
-
-    expect(data.failed_count).toBe(1);
-    expect(data.failed_jobs[0].error_message).toBe("HTTP 404");
-    expect(data.done_count).toBe(1234);
-    expect(typeof data.done_count).toBe("number");
-    expect(data.done_jobs[0].episode_id).toBe("ep-d");
-  });
-
-  it("returns 500 when any query throws", async () => {
-    mockQuery.mockRejectedValue(new Error("connection refused"));
+  it("returns 502 with fetch-error fallback when the pipeline is unreachable", async () => {
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
 
     const resp = await GET();
 
-    expect(resp.status).toBe(500);
+    expect(resp.status).toBe(502);
     expect(await resp.json()).toEqual({ error: "Failed to fetch queue" });
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();


### PR DESCRIPTION
Closes #555.

## Summary
The web's \`/api/queue\` route ran 6 parallel raw-SQL queries against \`job_queue\` / \`episodes\`. Schema lived on both sides of the HTTP boundary — a pipeline-side change could silently break the dashboard without CI catching it.

This PR moves the read ownership to the pipeline FastAPI and turns the web side into a thin proxy, mirroring how \`/api/pipeline/queue/[episodeId]/retry\` already works.

## Pipeline side (\`apps/pipeline/app/api/queue.py\`)
- New \`GET /api/queue\` returns the **exact shape the UI already consumes** (\`active_count\`, \`pending_count\`, \`failed_count\`, \`done_count\`, \`stuck_count\`, and the 5 corresponding row lists).
- \`TASK_TO_STATUS\` mapping moved here with a unit-test guard so a new pipeline stage can't ship without teaching the dashboard about it.

## Web side (\`apps/web/src/app/api/queue/route.ts\`)
- **170 LOC of SQL + response shaping → 33-line proxy.**
- Degrades upstream errors to 502 with the same console-logged path used by the meta-analysis proxies.

## Tests
- **Pipeline** — `test_queue_api.py` gains 6 tests for `get_queue` (empty queue, task→status mapping, pending/stuck tagging, failed/done + count, `TASK_TO_STATUS` exhaustiveness).
- **Web** — `queue-route.test.ts` rewritten from SQL-mock dispatcher to proxy tests (success, empty body, upstream non-2xx passthrough, non-JSON 502, fetch-error 502).

## Test plan
- [x] \`pytest tests/unit/\` — **704 passed**, overall coverage **86.68%** (gate 82%).
- [x] \`npx jest\` — **501 passed**.
- [x] **Smoke-tested against local stack**: rebuilt \`pipeline\` + \`web\` containers, hit \`/api/queue\` via web proxy — same 10-key shape, \`done_count: 366\` returned from real data. Loaded \`/queue\` in a headless browser — six expected stage labels (Pending/Downloading/Transcribing/Diarizing/Inferring/Archiving), no console or pageerror events.