### PR TITLE
test(web): add e2e coverage for queue + meta-analysis dashboards (#567)

### DIFF
--- a/apps/web/tests/e2e/meta-analysis.spec.ts
+++ b/apps/web/tests/e2e/meta-analysis.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Browser E2E smoke for the Meta-Analysis dashboard (#567).
+ *
+ * /meta-analysis mounts <MetaAnalysisClient/>, which fetches the
+ * snapshot + missing-speakers coverage through the web-side proxy.
+ * We stub both so the dashboard renders against deterministic fixtures.
+ */
+
+const MINIMAL_SNAPSHOT = {
+  snapshot: {
+    per_feed: [],
+    per_episode: [],
+    per_speaker: [],
+    timeline_monthly: [],
+    coverage: {
+      host_share: { included_count: 0, excluded: [] },
+      wpm_speaker: { included_count: 0, excluded: [] },
+      tokens_chunks: { included_count: 0, excluded: [] },
+    },
+  },
+  computed_at: new Date().toISOString(),
+  episode_count: 0,
+  feed_count: 0,
+  is_stale: false,
+  last_error: null,
+};
+
+test.describe("Meta-Analysis dashboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/meta-analysis/coverage/missing-speakers", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ podcasts: [] }),
+      });
+    });
+  });
+
+  test("empty snapshot renders every chart's no-data fallback", async ({ page }) => {
+    await page.route("**/api/meta-analysis/snapshot", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MINIMAL_SNAPSHOT),
+      });
+    });
+
+    await page.goto("/meta-analysis");
+
+    // Each chart component emits its own fallback string when its
+    // transform returns no rows. Hit a representative cross-section.
+    for (const fallback of [
+      /No dated episodes/i,
+      /No feeds yet/i,
+      /No processing data yet/i,
+      /No remote inference spend/i,
+      /No confirmed hosts yet/i,
+      /No confirmed speakers yet/i,
+      /No episode data/i,
+    ]) {
+      await expect(page.getByText(fallback).first()).toBeVisible();
+    }
+  });
+
+  test("refresh button triggers the refresh endpoint and re-fetches", async ({ page }) => {
+    let snapshotCalls = 0;
+    const refreshCalls: string[] = [];
+
+    await page.route("**/api/meta-analysis/snapshot", async (route) => {
+      snapshotCalls += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MINIMAL_SNAPSHOT),
+      });
+    });
+
+    await page.route("**/api/meta-analysis/refresh", async (route) => {
+      refreshCalls.push(route.request().method());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...MINIMAL_SNAPSHOT, is_stale: false }),
+      });
+    });
+
+    await page.goto("/meta-analysis");
+    await expect.poll(() => snapshotCalls).toBeGreaterThan(0);
+    const before = snapshotCalls;
+
+    await page.getByRole("button", { name: /refresh/i }).first().click();
+
+    await expect.poll(() => refreshCalls.length).toBeGreaterThan(0);
+    expect(refreshCalls[0]).toBe("POST");
+    await expect.poll(() => snapshotCalls).toBeGreaterThan(before);
+  });
+});

--- a/apps/web/tests/e2e/queue.spec.ts
+++ b/apps/web/tests/e2e/queue.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Browser E2E smoke for the Queue dashboard (#567).
+ *
+ * The /queue page is a thin wrapper around <QueueStatus/>, which fetches
+ * /api/queue (proxied through to the pipeline per #555). We stub the
+ * proxy response so the test is runnable without a seeded backend.
+ */
+
+const BASE_PAYLOAD = {
+  active_count: 0,
+  pending_count: 0,
+  failed_count: 0,
+  done_count: 0,
+  stuck_count: 0,
+  active_jobs: [],
+  pending_jobs: [],
+  failed_jobs: [],
+  done_jobs: [],
+  stuck_jobs: [],
+};
+
+test.describe("Queue dashboard", () => {
+  test("stage bar renders the six pipeline stages", async ({ page }) => {
+    await page.route("**/api/queue", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(BASE_PAYLOAD),
+      });
+    });
+
+    await page.goto("/queue");
+
+    for (const label of [
+      "Pending",
+      "Downloading",
+      "Transcribing",
+      "Diarizing",
+      "Inferring",
+      "Archiving",
+    ]) {
+      await expect(page.getByText(label, { exact: true })).toBeVisible();
+    }
+  });
+
+  test("shows an active episode with its mapped display status", async ({ page }) => {
+    await page.route("**/api/queue", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...BASE_PAYLOAD,
+          active_count: 1,
+          active_jobs: [
+            {
+              episode_id: "ep-active",
+              title: "Active transcription",
+              active_task: "transcribe",
+              status: "transcribing",
+              error_message: null,
+              error_class: null,
+              retry_count: 0,
+              retry_max: 3,
+              updated_at: new Date().toISOString(),
+              picked_at: new Date().toISOString(),
+              feed_mode: "full",
+              feed_title: "Some Podcast",
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/queue");
+
+    await expect(page.getByText("Active transcription")).toBeVisible();
+    await expect(page.getByText("TRANSCRIBING", { exact: true })).toBeVisible();
+  });
+
+  test("retry button on a failed episode hits the pipeline retry endpoint", async ({ page }) => {
+    const retryCalls: string[] = [];
+
+    await page.route("**/api/queue", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...BASE_PAYLOAD,
+          failed_count: 1,
+          failed_jobs: [
+            {
+              episode_id: "ep-fail",
+              title: "Broken episode",
+              status: "failed",
+              error_message: "HTTP 404",
+              error_class: "HTTP_ACCESS",
+              retry_count: 3,
+              retry_max: 3,
+              updated_at: new Date().toISOString(),
+              feed_mode: "full",
+              feed_title: "Broken Feed",
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route("**/api/pipeline/queue/ep-fail/retry", async (route) => {
+      retryCalls.push(route.request().url());
+      await route.fulfill({
+        status: 202,
+        contentType: "application/json",
+        body: JSON.stringify({ queued: true, episode_id: "ep-fail" }),
+      });
+    });
+
+    await page.goto("/queue");
+
+    // Expand the row. Every cell with an interactive child (title Link,
+    // feed-title button, status button) calls stopPropagation, so we
+    // click the retry-count cell (plain text) to let the tr handler fire.
+    await page.getByText("3/3", { exact: true }).click();
+    await page.getByRole("button", { name: /^retry$/i }).click();
+
+    await expect.poll(() => retryCalls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Partial fix for #567.

## Summary
Adds two Playwright spec files targeting client-side dashboard pages (`/queue` and `/meta-analysis`). Both pages fetch their data through `/api/*` routes, so `page.route` stubs are enough to make the tests deterministic — no DB fixtures needed.

## Specs

**`tests/e2e/queue.spec.ts`** (3 tests)
- Stage bar renders the six pipeline stages on an empty payload.
- Active episode row shows its task mapped to display status (`transcribe` → `TRANSCRIBING`).
- Retry flow on a failed row clicks through and hits `/api/pipeline/queue/{id}/retry`. Row expansion targets the retry-count cell because every interactive child of the `<tr>` calls `stopPropagation` (title Link, feed-title button, status button).

**`tests/e2e/meta-analysis.spec.ts`** (2 tests)
- Empty snapshot renders every chart's no-data fallback text ("No dated episodes", "No feeds yet", "No processing data yet", "No remote inference spend", "No confirmed hosts yet", "No confirmed speakers yet", "No episode data").
- Refresh button issues `POST /api/meta-analysis/refresh` and re-fetches the snapshot.

## Test plan
- [x] `npx playwright test` — **9 passed** (2 new + 3 new, plus the existing 4 search/dark-mode specs).

## What's left under #567
- **`ask.spec.ts`** — the EpisodeChat SSE flow lives on `/episodes/[id]`, which is a server component reading from the DB. Needs a seeded episode ID (or a test-DB fixture) before stubs alone can carry it.
- **`server-pages.spec.ts`** — same story for `/docs`, `/feeds`, `/podcasts`, `/search/print`, `/settings`. All SSR server components with direct DB reads.

Both need a small test-DB seeding layer rather than just route stubs. Tracking as a follow-up on #567.