### PR TITLE
test(web): seeded e2e specs for Ask AI + SSR pages (#567)

### DIFF
--- a/apps/web/tests/e2e/ask.spec.ts
+++ b/apps/web/tests/e2e/ask.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import type { Pool } from "pg";
+import { getFixturePool, seedEpisode, type SeededEpisode } from "./fixtures/db";
+
+/**
+ * Browser E2E for the Ask-AI chat overlay on an episode page (#567).
+ *
+ * EpisodeChat fetches /api/pipeline/ask and consumes an SSE stream. We
+ * stub the proxy with a full SSE body; Playwright's real `fetch` +
+ * `ReadableStream` implementation drives the component's reader loop
+ * end-to-end (which jsdom can't do — see #573 for the jest attempt).
+ *
+ * The /episodes/[id] page is a server component that reads the episode
+ * row via `pool.query`, so we seed a disposable episode in the DB
+ * before the tests and clean it up after.
+ */
+
+let pool: Pool | null = null;
+let seeded: SeededEpisode | null = null;
+
+test.beforeAll(async () => {
+  pool = getFixturePool();
+  if (!pool) {
+    test.skip(
+      true,
+      "Set DATABASE_URL to run the seeded e2e specs (see fixtures/db.ts)"
+    );
+    return;
+  }
+  seeded = await seedEpisode(pool, {
+    title: "E2E Ask target",
+    withSegments: true,
+  });
+});
+
+test.afterAll(async () => {
+  if (seeded) await seeded.cleanup();
+  if (pool) await pool.end();
+});
+
+function sseBody(events: Array<[string, unknown]>): string {
+  return (
+    events
+      .map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}`)
+      .join("\n\n") + "\n\n"
+  );
+}
+
+test.describe("Ask AI (EpisodeChat)", () => {
+  test("streams token + sources + done events into an assistant message", async ({
+    page,
+  }) => {
+    await page.route("**/api/pipeline/ask", async (route) => {
+      const body = sseBody([
+        ["token", { content: "The guest said " }],
+        ["token", { content: "hello." }],
+        [
+          "sources",
+          [
+            {
+              chunk_id: 1,
+              episode_id: seeded!.episodeId,
+              episode_title: "E2E Ask target",
+              speaker_label: "SPEAKER_00",
+              start_time: 5.0,
+              end_time: 9.0,
+              timestamp: "00:05",
+              text: "The relevant passage for the citation.",
+              similarity: 0.91,
+            },
+          ],
+        ],
+        ["done", {}],
+      ]);
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body,
+      });
+    });
+
+    await page.goto(`/episodes/${seeded!.episodeId}`);
+
+    await page
+      .getByRole("button", { name: /ask about this episode/i })
+      .click();
+
+    const input = page.getByPlaceholder(/ask about this episode\.\.\./i);
+    await input.fill("what did the guest say?");
+    await input.press("Enter");
+
+    await expect(
+      page.getByText(/The guest said\s+hello\./)
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /relevant passage/i })
+    ).toBeVisible();
+  });
+
+  test("surfaces a connection banner when the proxy is unreachable", async ({
+    page,
+  }) => {
+    await page.route("**/api/pipeline/ask", async (route) => {
+      await route.abort("failed");
+    });
+
+    await page.goto(`/episodes/${seeded!.episodeId}`);
+
+    await page
+      .getByRole("button", { name: /ask about this episode/i })
+      .click();
+
+    const input = page.getByPlaceholder(/ask about this episode\.\.\./i);
+    await input.fill("hello");
+    await input.press("Enter");
+
+    await expect(
+      page.getByText(/Connection failed/i)
+    ).toBeVisible();
+  });
+});

--- a/apps/web/tests/e2e/fixtures/db.ts
+++ b/apps/web/tests/e2e/fixtures/db.ts
@@ -1,0 +1,90 @@
+/**
+ * DB fixture helpers for Playwright e2e specs that target SSR pages.
+ *
+ * The /episodes/[id] route and other server components read directly
+ * from Postgres via `pool.query` — they can't be stubbed with
+ * `page.route`. These helpers insert a minimal feed + episode row (and
+ * optionally a couple of segments) so specs can navigate to a known
+ * URL, then delete what they inserted.
+ *
+ * DATABASE_URL resolution:
+ *   - CI (docker-compose.test.yml `web_test` service): DATABASE_URL is
+ *     set to the disposable `db_test` instance.
+ *   - Local: set DATABASE_URL when running e2e, e.g.
+ *       DATABASE_URL="postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/podlog" \
+ *         npm run test:e2e
+ *     If DATABASE_URL is unset, `getFixturePool()` returns null and
+ *     specs that need a DB should `test.skip()` with a clear message.
+ */
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+
+export interface SeededEpisode {
+  feedId: string;
+  episodeId: string;
+  cleanup: () => Promise<void>;
+}
+
+export function getFixturePool(): Pool | null {
+  const url = process.env.DATABASE_URL;
+  if (!url) return null;
+  return new Pool({ connectionString: url, max: 2 });
+}
+
+export interface SeedEpisodeOpts {
+  title?: string;
+  description?: string;
+  feedTitle?: string;
+  withSegments?: boolean;
+}
+
+export async function seedEpisode(
+  pool: Pool,
+  opts: SeedEpisodeOpts = {}
+): Promise<SeededEpisode> {
+  const feedId = randomUUID();
+  const episodeId = randomUUID();
+  const feedTitle = opts.feedTitle ?? `E2E Feed ${feedId.slice(0, 8)}`;
+  const title = opts.title ?? `E2E Episode ${episodeId.slice(0, 8)}`;
+  const description = opts.description ?? "Seeded by Playwright e2e.";
+
+  await pool.query(
+    `INSERT INTO feeds (id, url, title, mode) VALUES ($1, $2, $3, 'full')`,
+    [feedId, `https://e2e.podlog.test/${feedId}/feed.xml`, feedTitle]
+  );
+  await pool.query(
+    `INSERT INTO episodes (
+       id, feed_id, title, description, audio_url, guid,
+       status, has_diarization
+     ) VALUES ($1, $2, $3, $4, $5, $6, 'done', true)`,
+    [
+      episodeId,
+      feedId,
+      title,
+      description,
+      `https://e2e.podlog.test/${episodeId}.mp3`,
+      episodeId,
+    ]
+  );
+
+  if (opts.withSegments) {
+    await pool.query(
+      `INSERT INTO segments (episode_id, speaker_label, start_time, end_time, text)
+       VALUES ($1, 'SPEAKER_00', 0, 10, 'Hello and welcome to the show.'),
+              ($1, 'SPEAKER_01', 10, 20, 'Thanks for having me on.')`,
+      [episodeId]
+    );
+  }
+
+  async function cleanup() {
+    // Order matters: segments FK -> episodes FK -> feeds.
+    await pool.query("DELETE FROM segments WHERE episode_id = $1", [episodeId]);
+    await pool.query("DELETE FROM speaker_names WHERE episode_id = $1", [
+      episodeId,
+    ]);
+    await pool.query("DELETE FROM episodes WHERE id = $1", [episodeId]);
+    await pool.query("DELETE FROM feeds WHERE id = $1", [feedId]);
+  }
+
+  return { feedId, episodeId, cleanup };
+}

--- a/apps/web/tests/e2e/server-pages.spec.ts
+++ b/apps/web/tests/e2e/server-pages.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import type { Pool } from "pg";
+import { getFixturePool, seedEpisode, type SeededEpisode } from "./fixtures/db";
+
+/**
+ * Render smoke for SSR pages that read from the DB directly (#567).
+ *
+ * Pages under test: /docs, /feeds, /podcasts, /episodes/[id], /settings.
+ * All are Next.js server components, so page.route can't stub the data
+ * path. We seed one feed + episode for the duration of the suite and
+ * assert each page renders a stable landmark without console errors.
+ */
+
+let pool: Pool | null = null;
+let seeded: SeededEpisode | null = null;
+
+test.beforeAll(async () => {
+  pool = getFixturePool();
+  if (!pool) {
+    test.skip(
+      true,
+      "Set DATABASE_URL to run the seeded e2e specs (see fixtures/db.ts)"
+    );
+    return;
+  }
+  seeded = await seedEpisode(pool, {
+    title: "E2E Smoke episode",
+    feedTitle: "E2E Smoke feed",
+  });
+});
+
+test.afterAll(async () => {
+  if (seeded) await seeded.cleanup();
+  if (pool) await pool.end();
+});
+
+test.describe("Server-rendered page smoke", () => {
+  // Stub ancillary API fetches these pages make client-side so they
+  // stay deterministic (coverage strip, hardware sensors, etc.).
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/ask/coverage", (r) =>
+      r.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ processed: 1, total: 1, has_manual_uploads: false }),
+      })
+    );
+    await page.route("**/api/hardware", (r) =>
+      r.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+    );
+  });
+
+  test("/docs loads and shows a chapter heading", async ({ page }) => {
+    const resp = await page.goto("/docs");
+    expect(resp?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  });
+
+  test("/feeds loads and lists the seeded feed", async ({ page }) => {
+    const resp = await page.goto("/feeds");
+    expect(resp?.status()).toBe(200);
+    // /feeds uses a client-side useQuery → /api/feeds, so the seeded
+    // feed's title is the reliable landmark once the fetch resolves.
+    await expect(page.getByText("E2E Smoke feed").first()).toBeVisible();
+  });
+
+  test("/podcasts loads and lists the seeded feed", async ({ page }) => {
+    const resp = await page.goto("/podcasts");
+    expect(resp?.status()).toBe(200);
+    await expect(page.getByText("E2E Smoke feed")).toBeVisible();
+  });
+
+  test("/episodes/[id] loads and shows the seeded episode title", async ({
+    page,
+  }) => {
+    const resp = await page.goto(`/episodes/${seeded!.episodeId}`);
+    expect(resp?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", { name: "E2E Smoke episode" })
+    ).toBeVisible();
+  });
+
+  test("/settings loads", async ({ page }) => {
+    const resp = await page.goto("/settings");
+    expect(resp?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading").filter({ hasText: /setting/i }).first()
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #567 (Playwright portion).

## Summary
Adds the DB-seeded e2e specs that #582 couldn't ship (those targeted client-side pages where `page.route` stubs were enough). The SSR pages and the EpisodeChat SSE flow need a real episode row, so this PR introduces a fixture helper and uses it.

## Infrastructure
- **`tests/e2e/fixtures/db.ts`** — `getFixturePool()` returns a `pg.Pool` from `DATABASE_URL`; `seedEpisode()` inserts a fresh feed + episode (and optional segments) and returns a `cleanup()` that deletes in FK-safe order.
- Specs **skip** cleanly when `DATABASE_URL` is unset (local dev), with a message pointing at the fixtures README.
- **CI works automatically** — `docker-compose.test.yml`'s `web_test` service already sets `DATABASE_URL` to the disposable `db_test` instance, and depends on `pipeline_test` (which runs Alembic migrations on startup, so schema exists by the time Playwright runs).

## New specs

**`ask.spec.ts`** (2 tests)
- Streams `token`/`sources`/`done` events into an assistant message. Playwright's real `fetch` + `ReadableStream` drives EpisodeChat's reader loop end-to-end — the exact path jsdom couldn't reach in #573.
- Surfaces the "Connection failed" banner when the proxy is unreachable.

**`server-pages.spec.ts`** (5 tests)
- `/docs`, `/feeds`, `/podcasts`, `/episodes/[id]`, `/settings` — each asserts a 200 and a stable landmark. The seeded feed/episode titles are the landmarks for the data-driven pages.
- Stubs `/api/ask/coverage` and `/api/hardware` so side requests don't flap.

## Test plan
- [x] `DATABASE_URL=... npx playwright test` locally — **16 passed** (was 9; +7 new, 0 regressions across existing search / dark-mode / queue / meta-analysis specs).
- [x] Cleanup verified: post-run queries show no lingering `E2E Smoke feed` / `E2E Smoke episode` / `E2E Ask target` rows.