### PR TITLE
fix(web): center text in Search and Ask search bars (#579)

### DIFF
--- a/apps/web/src/components/SearchInput.tsx
+++ b/apps/web/src/components/SearchInput.tsx
@@ -38,7 +38,7 @@ export default function SearchInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="w-full pl-10 pr-16 py-3 border border-input rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring text-base transition-shadow"
+          className="w-full pl-10 pr-16 py-3 text-center border border-input rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring text-base transition-shadow"
           disabled={disabled}
           autoFocus={autoFocus}
         />


### PR DESCRIPTION
Closes #579.

One-line change: adds \`text-center\` to the shared \`SearchInput\` component's input className. Both \`/search\` and \`/ask\` consume the same component, so the centered text applies to both bars.

## Test plan
- [x] Rebuilt the web container, loaded each route in a headless browser, confirmed \`getComputedStyle(input).textAlign === "center"\`.
- [x] \`npx jest\` — 501 passed (no regressions).
- [x] \`npx playwright test\` — 16 passed (no regressions).