### PR TITLE
fix(web): remove Large tiles option from podcasts list (#581)

### DIFF
--- a/apps/web/src/components/PodcastsList.tsx
+++ b/apps/web/src/components/PodcastsList.tsx
@@ -9,7 +9,6 @@ import {
   List,
   ListChecks,
   Podcast,
-  Rows3,
   Rss,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
@@ -27,13 +26,13 @@ export interface PodcastsListFeed {
   last_polled_at: string | null;
 }
 
-type ViewMode = "list" | "grid" | "large";
+type ViewMode = "list" | "grid";
 
 const STORAGE_KEY = "podlog-podcasts-view";
 const DEFAULT_VIEW: ViewMode = "grid";
 
 function isViewMode(v: unknown): v is ViewMode {
-  return v === "list" || v === "grid" || v === "large";
+  return v === "list" || v === "grid";
 }
 
 interface Props {
@@ -85,8 +84,7 @@ export default function PodcastsList({ feeds, initialView }: Props) {
       </div>
 
       {view === "list" && <FeedListRows feeds={feeds} />}
-      {view === "grid" && <FeedGrid feeds={feeds} density="default" />}
-      {view === "large" && <FeedGrid feeds={feeds} density="large" />}
+      {view === "grid" && <FeedGrid feeds={feeds} />}
     </div>
   );
 }
@@ -101,7 +99,6 @@ function ViewToggle({
   const options: { mode: ViewMode; label: string; icon: React.ReactNode }[] = [
     { mode: "list", label: "List view", icon: <List size={14} /> },
     { mode: "grid", label: "Grid view", icon: <LayoutGrid size={14} /> },
-    { mode: "large", label: "Large tiles", icon: <Rows3 size={14} /> },
   ];
   return (
     <div
@@ -195,43 +192,21 @@ function ImageOrPlaceholder({
   );
 }
 
-function FeedGrid({
-  feeds,
-  density,
-}: {
-  feeds: PodcastsListFeed[];
-  density: "default" | "large";
-}) {
-  const gridClass =
-    density === "large"
-      ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5"
-      : "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4";
-  const imgSize = density === "large" ? 480 : 300;
+function FeedGrid({ feeds }: { feeds: PodcastsListFeed[] }) {
   return (
-    <div className={gridClass}>
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
       {feeds.map((feed) => (
         <Link key={feed.id} href={`/podcasts/${feed.id}`}>
           <Card className="overflow-hidden hover:bg-accent/30 transition-colors h-full">
-            <ImageOrPlaceholder feed={feed} size={imgSize} />
-            <CardContent
-              className={density === "large" ? "p-4 space-y-1.5" : "p-3 space-y-1"}
-            >
+            <ImageOrPlaceholder feed={feed} size={300} />
+            <CardContent className="p-3 space-y-1">
               <div className="flex items-center gap-1.5">
-                <p
-                  className={`font-medium line-clamp-2 ${
-                    density === "large" ? "text-base" : "text-sm"
-                  }`}
-                >
+                <p className="font-medium line-clamp-2 text-sm">
                   {feed.title ?? "Untitled"}
                 </p>
                 <ModeBadges mode={feed.mode} />
               </div>
               <EpisodeCounter feed={feed} />
-              {density === "large" && feed.description && (
-                <p className="text-xs text-muted-foreground line-clamp-2">
-                  {feed.description}
-                </p>
-              )}
             </CardContent>
           </Card>
         </Link>

--- a/apps/web/tests/unit/podcasts-list.test.tsx
+++ b/apps/web/tests/unit/podcasts-list.test.tsx
@@ -60,8 +60,8 @@ describe("<PodcastsList>", () => {
     render(<PodcastsList feeds={[makeFeed()]} />);
     fireEvent.click(screen.getByRole("button", { name: "List view" }));
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("list");
-    fireEvent.click(screen.getByRole("button", { name: "Large tiles" }));
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("large");
+    fireEvent.click(screen.getByRole("button", { name: "Grid view" }));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("grid");
   });
 
   it("marks the active toggle with aria-pressed", () => {
@@ -83,7 +83,7 @@ describe("<PodcastsList>", () => {
 
   it("renders the feed title in every view", () => {
     const feed = makeFeed({ title: "Unique Title" });
-    for (const view of ["list", "grid", "large"] as const) {
+    for (const view of ["list", "grid"] as const) {
       const { unmount } = render(
         <PodcastsList feeds={[feed]} initialView={view} />,
       );
@@ -92,22 +92,28 @@ describe("<PodcastsList>", () => {
     }
   });
 
-  it("renders the description only in large view", () => {
+  it("does not render feed descriptions in any view", () => {
+    // Description belongs on /podcasts/[id] detail page; the list page
+    // shows only title + episode counter to keep tiles compact (#581).
     const feed = makeFeed({ description: "Look, a description!" });
-    const { unmount: u1 } = render(
-      <PodcastsList feeds={[feed]} initialView="grid" />,
-    );
-    expect(screen.queryByText("Look, a description!")).not.toBeInTheDocument();
-    u1();
+    for (const view of ["list", "grid"] as const) {
+      const { unmount } = render(
+        <PodcastsList feeds={[feed]} initialView={view} />,
+      );
+      expect(
+        screen.queryByText("Look, a description!"),
+      ).not.toBeInTheDocument();
+      unmount();
+    }
+  });
 
-    const { unmount: u2 } = render(
-      <PodcastsList feeds={[feed]} initialView="list" />,
-    );
-    expect(screen.queryByText("Look, a description!")).not.toBeInTheDocument();
-    u2();
-
-    render(<PodcastsList feeds={[feed]} initialView="large" />);
-    expect(screen.getByText("Look, a description!")).toBeInTheDocument();
+  it("treats stored 'large' as garbage and falls back to grid", () => {
+    // Migration safety: users who had the removed view cached should
+    // land on the default rather than render nothing (#581).
+    window.localStorage.setItem(STORAGE_KEY, "large");
+    render(<PodcastsList feeds={[makeFeed()]} />);
+    const root = screen.getByText("Example Podcast").closest("[data-view]");
+    expect(root?.getAttribute("data-view")).toBe("grid");
   });
 
   it("shows the processed/total counter when not all episodes are done", () => {


### PR DESCRIPTION
Closes #581.

## Summary
\`PodcastsList\` offered three view modes: **list / grid (small tiles) / large tiles**. The "Large tiles" mode duplicated grid with bigger images and a description preview already shown on the podcast detail page. Removing it keeps the UI focused per the issue.

## Changes
- \`ViewMode\` narrowed to \`"list" | "grid"\`; \`isViewMode\` + \`ViewToggle\` drop the \`"large"\` branch; \`Rows3\` icon import removed.
- \`FeedGrid\` loses its \`density\` prop and the description block — single inlined layout.
- Description (the unique large-mode content) was already mirrored on \`/podcasts/[id]\`, so no information is lost.

## Test plan
- [x] \`npx jest tests/unit/podcasts-list.test.tsx\` — **12 passed** (was 11; replaced the description-only-in-large case with an explicit no-descriptions check + a migration-safety test that asserts a stored \`"large"\` localStorage value falls back to the default \`grid\`).
- [x] Full \`npx jest\` — **502 passed**, no regressions.
- [x] \`npx tsc --noEmit\` — clean (no new src errors).
- [x] **Browser smoke** against rebuilt web container: toggle now shows only \`List view\` / \`Grid view\` labels, and seeding \`localStorage["podlog-podcasts-view"] = "large"\` lands on \`grid\` without console errors.

## Migration safety
Users with \`"large"\` cached in localStorage hit the updated \`isViewMode\` check, fail, and fall back to \`DEFAULT_VIEW = "grid"\`. No migration script needed.