### PR TITLE
fix: surface unavailable audio in player + recovery script (#569)

### DIFF
--- a/apps/pipeline/scripts/redownload_missing_audio.py
+++ b/apps/pipeline/scripts/redownload_missing_audio.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Re-download audio for episodes whose audio file is missing on disk.
+
+Covers two cases:
+  1. `audio_local_path` is set but the file is gone (external wipe of the volume).
+  2. `audio_local_path` is NULL — episode was archived without keeping a path
+     (e.g. archive_audio off at the time, or archive partial-failed). For these
+     we recover into the standard archive path and write the path back to the DB.
+
+Either way we re-fetch `audio_url`, re-encode to MP3 64 kbps to match
+archive.py's `_compress_audio` output, and write to the archive directory.
+
+Non-fetchable URLs (`local://`, etc.) are skipped — those are manual uploads
+without a remote source and need a fresh user re-upload.
+
+Usage (inside the worker container — needs app.* imports + /data mount):
+    python /app/scripts/redownload_missing_audio.py --list
+    python /app/scripts/redownload_missing_audio.py --episode-id <uuid>
+    python /app/scripts/redownload_missing_audio.py --all
+"""
+import argparse
+import logging
+import sys
+import tempfile
+from pathlib import Path
+
+import ffmpeg
+import httpx
+
+from app.config import settings
+from app.database import SessionLocal
+from app.models import Episode
+
+logger = logging.getLogger("redownload")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _is_fetchable_url(url: str | None) -> bool:
+    return bool(url) and url.startswith(("http://", "https://"))
+
+
+def _target_path(episode: Episode) -> Path:
+    """Where the recovered MP3 should land."""
+    if episode.audio_local_path:
+        return Path(episode.audio_local_path)
+    return Path(settings.audio_archive_dir) / f"{episode.id}.mp3"
+
+
+def find_missing(db) -> list[Episode]:
+    """Episodes that should have audio on disk but don't.
+
+    Two states qualify:
+      - audio_local_path set, file gone (volume wipe case)
+      - audio_local_path NULL, episode is `done`, audio_url is fetchable
+    """
+    rows = (
+        db.query(Episode)
+        .filter(Episode.status == "done")
+        .order_by(Episode.processed_at)
+        .all()
+    )
+    out = []
+    for e in rows:
+        if e.audio_local_path:
+            if not Path(e.audio_local_path).exists():
+                out.append(e)
+        elif _is_fetchable_url(e.audio_url):
+            out.append(e)
+    return out
+
+
+def redownload_one(db, episode: Episode) -> tuple[bool, str]:
+    target = _target_path(episode)
+    needs_writeback = episode.audio_local_path is None
+    if target.exists() and not needs_writeback:
+        return True, "already_present"
+    if not _is_fetchable_url(episode.audio_url):
+        return False, f"unrecoverable_url_scheme: {episode.audio_url}"
+
+    tmp = tempfile.NamedTemporaryFile(prefix="redl_", suffix=".raw", delete=False)
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    try:
+        try:
+            with httpx.stream(
+                "GET",
+                episode.audio_url,
+                follow_redirects=True,
+                timeout=120.0,
+                headers={"User-Agent": "podlog-redownload/1.0"},
+            ) as resp:
+                resp.raise_for_status()
+                with open(tmp_path, "wb") as f:
+                    for chunk in resp.iter_bytes(chunk_size=65536):
+                        f.write(chunk)
+        except httpx.HTTPStatusError as exc:
+            return False, f"http_{exc.response.status_code}"
+        except httpx.InvalidURL as exc:
+            # `local://...` (manual upload, no remote source) — unrecoverable
+            # without a fresh user upload. Caller will fall back to Plan A.
+            return False, f"unrecoverable_url: {exc}"
+        except httpx.RequestError as exc:
+            return False, f"download_error: {type(exc).__name__}: {exc}"
+
+        if tmp_path.stat().st_size == 0:
+            return False, "empty_download"
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            ffmpeg.input(str(tmp_path)).output(
+                str(target),
+                audio_bitrate=settings.audio_archive_bitrate,
+                acodec="libmp3lame",
+            ).overwrite_output().run(capture_stdout=True, capture_stderr=True)
+        except ffmpeg.Error as exc:
+            stderr = (exc.stderr or b"").decode("utf-8", "replace")[:300]
+            return False, f"ffmpeg: {stderr}"
+
+        if not target.exists() or target.stat().st_size == 0:
+            return False, "encode_produced_nothing"
+
+        size = target.stat().st_size
+        if needs_writeback:
+            db.query(Episode).filter(Episode.id == episode.id).update(
+                {"audio_local_path": str(target)}
+            )
+            db.commit()
+            return True, f"{size:,} bytes (path_writeback={target})"
+        return True, f"{size:,} bytes"
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--episode-id", help="Re-download a single episode by ID")
+    group.add_argument("--all", action="store_true", help="Re-download all missing")
+    group.add_argument("--list", action="store_true", help="Dry-run: list missing episodes")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        if args.episode_id:
+            ep = db.query(Episode).filter(Episode.id == args.episode_id).first()
+            if not ep:
+                logger.error("episode not found: %s", args.episode_id)
+                return 1
+            if ep.audio_local_path and Path(ep.audio_local_path).exists():
+                logger.warning(
+                    "file already present at %s — nothing to do", ep.audio_local_path
+                )
+                return 0
+            if not _is_fetchable_url(ep.audio_url):
+                logger.error(
+                    "audio_url not fetchable (%s) — episode needs manual re-upload",
+                    ep.audio_url,
+                )
+                return 1
+            episodes = [ep]
+        else:
+            episodes = find_missing(db)
+            logger.info("found %d episodes with missing audio", len(episodes))
+            if args.list:
+                for ep in episodes:
+                    print(f"{ep.id}\t{ep.title}")
+                return 0
+
+        ok = 0
+        fail = 0
+        failed_ids: list[str] = []
+        for i, ep in enumerate(episodes, 1):
+            logger.info(
+                "[%d/%d] %s — %s",
+                i,
+                len(episodes),
+                ep.id,
+                (ep.title or "")[:60],
+            )
+            success, msg = redownload_one(db, ep)
+            if success:
+                ok += 1
+                logger.info("  OK   %s", msg)
+            else:
+                fail += 1
+                failed_ids.append(str(ep.id))
+                logger.warning("  FAIL %s", msg)
+
+        logger.info("=" * 60)
+        logger.info("done: %d ok, %d fail", ok, fail)
+        if failed_ids:
+            logger.info("failed IDs (candidates for audio_local_path=NULL):")
+            for fid in failed_ids:
+                print(fid)
+        return 0 if fail == 0 else 2
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/web/src/components/AudioPlayer.tsx
+++ b/apps/web/src/components/AudioPlayer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Play, Pause, Volume2, VolumeX, ChevronUp, ChevronDown, SkipBack, SkipForward, X } from "lucide-react";
+import { Play, Pause, Volume2, VolumeX, ChevronUp, ChevronDown, SkipBack, SkipForward, X, AlertTriangle } from "lucide-react";
 import { useAudioPlayer } from "@/components/AudioPlayerContext";
 import { formatTimestamp } from "@/lib/timestamp";
 
@@ -15,13 +15,23 @@ export default function AudioPlayer() {
   const [duration, setDuration] = useState(0);
   const [collapsed, setCollapsed] = useState(false);
   const [muted, setMuted] = useState(false);
+  const [loadError, setLoadError] = useState(false);
   const progressRef = useRef<HTMLDivElement>(null);
 
-  // Seek to startTime whenever a new episode is loaded
+  // Seek to startTime whenever a new episode is loaded.
+  // When state.src is null (no audio available) we still need to halt any
+  // currently-playing audio so it doesn't keep going while the UI shows the
+  // unavailable state for a different episode.
   useEffect(() => {
     const audio = audioRef.current;
-    if (!audio || !state.src) return;
-
+    if (!audio) return;
+    setLoadError(false);
+    if (!state.src) {
+      audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
+      return;
+    }
     audio.src = state.src;
     audio.load();
   }, [state.src, state.startTime]);
@@ -52,12 +62,17 @@ export default function AudioPlayer() {
   }
 
   function handleSeek(e: React.MouseEvent<HTMLDivElement>) {
+    if (loadError || !state.src) return;
     const audio = audioRef.current;
     const bar = progressRef.current;
     if (!audio || !bar || !duration) return;
     const rect = bar.getBoundingClientRect();
     const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
     audio.currentTime = pct * duration;
+  }
+
+  function handleError() {
+    setLoadError(true);
   }
 
   function skip(seconds: number) {
@@ -83,8 +98,12 @@ export default function AudioPlayer() {
     }
   }, [state.src]);
 
-  if (!state.src) return null;
+  if (!state.episodeId) return null;
 
+  // Audio is unavailable when the player is open but we have no src
+  // (episode lacks audio_local_path) or the <audio> element fired error
+  // (file missing on disk → /api/audio returns 404).
+  const unavailable = loadError || !state.src;
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   return (
@@ -95,12 +114,13 @@ export default function AudioPlayer() {
         onLoadedMetadata={handleLoadedMetadata}
         onTimeUpdate={handleTimeUpdate}
         onDurationChange={handleDurationChange}
+        onError={handleError}
       />
 
-      {/* Progress bar — always visible, clickable */}
+      {/* Progress bar — always visible, clickable (disabled when audio failed to load) */}
       <div
         ref={progressRef}
-        className="h-1 bg-muted cursor-pointer group"
+        className={`h-1 bg-muted group ${unavailable ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
         onClick={handleSeek}
       >
         <div
@@ -111,11 +131,22 @@ export default function AudioPlayer() {
 
       {collapsed ? (
         <div className="flex items-center gap-3 px-4 py-2">
-          <button onClick={togglePlayPause} className="text-foreground hover:text-primary transition-colors">
+          <button
+            onClick={togglePlayPause}
+            disabled={unavailable}
+            className="text-foreground hover:text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-foreground"
+          >
             {state.isPlaying ? <Pause size={18} /> : <Play size={18} />}
           </button>
           <span className="text-sm truncate flex-1">{state.title}</span>
-          <span className="text-xs text-muted-foreground tabular-nums">{formatTimestamp(currentTime)}</span>
+          {unavailable ? (
+            <span className="flex items-center gap-1 text-xs text-destructive shrink-0">
+              <AlertTriangle size={12} />
+              Audio unavailable
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground tabular-nums">{formatTimestamp(currentTime)}</span>
+          )}
           <button onClick={() => setCollapsed(false)} className="text-muted-foreground hover:text-foreground transition-colors" title="Expand player">
             <ChevronUp size={16} />
           </button>
@@ -135,28 +166,50 @@ export default function AudioPlayer() {
 
           {/* Playback controls */}
           <div className="flex items-center gap-3 shrink-0">
-            <button onClick={() => skip(-15)} className="text-muted-foreground hover:text-foreground transition-colors" title="Back 15s">
+            <button
+              onClick={() => skip(-15)}
+              disabled={unavailable}
+              className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-muted-foreground"
+              title="Back 15s"
+            >
               <SkipBack size={16} />
             </button>
             <button
               onClick={togglePlayPause}
-              className="h-9 w-9 flex items-center justify-center rounded-full bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+              disabled={unavailable}
+              className="h-9 w-9 flex items-center justify-center rounded-full bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {state.isPlaying ? <Pause size={18} /> : <Play size={18} className="ml-0.5" />}
             </button>
-            <button onClick={() => skip(15)} className="text-muted-foreground hover:text-foreground transition-colors" title="Forward 15s">
+            <button
+              onClick={() => skip(15)}
+              disabled={unavailable}
+              className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-muted-foreground"
+              title="Forward 15s"
+            >
               <SkipForward size={16} />
             </button>
           </div>
 
-          {/* Time + volume */}
-          <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0 tabular-nums">
-            <span>{formatTimestamp(currentTime)}</span>
-            <span>/</span>
-            <span>{formatTimestamp(duration)}</span>
-          </div>
+          {/* Time / error message */}
+          {unavailable ? (
+            <div className="flex items-center gap-2 text-xs text-destructive shrink-0">
+              <AlertTriangle size={14} />
+              <span>Audio unavailable</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0 tabular-nums">
+              <span>{formatTimestamp(currentTime)}</span>
+              <span>/</span>
+              <span>{formatTimestamp(duration)}</span>
+            </div>
+          )}
 
-          <button onClick={toggleMute} className="text-muted-foreground hover:text-foreground transition-colors shrink-0">
+          <button
+            onClick={toggleMute}
+            disabled={unavailable}
+            className="text-muted-foreground hover:text-foreground transition-colors shrink-0 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-muted-foreground"
+          >
             {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
           </button>
 

--- a/apps/web/src/components/AudioPlayerContext.tsx
+++ b/apps/web/src/components/AudioPlayerContext.tsx
@@ -17,7 +17,7 @@ interface AudioPlayerContextValue {
   audioRef: React.RefObject<HTMLAudioElement | null>;
   playEpisode: (
     episodeId: string,
-    filename: string,
+    filename: string | null,
     startTimeSecs: number,
     title?: string,
     feedTitle?: string
@@ -42,20 +42,22 @@ export function AudioPlayerProvider({ children }: { children: React.ReactNode })
 
   function playEpisode(
     episodeId: string,
-    filename: string,
+    filename: string | null,
     startTimeSecs: number,
     title?: string,
     feedTitle?: string
   ) {
-    const src = `/api/audio/${episodeId}/${encodeURIComponent(filename)}`;
+    const src = filename
+      ? `/api/audio/${episodeId}/${encodeURIComponent(filename)}`
+      : null;
     setState({
       episodeId,
-      filename,
+      filename: filename || null,
       src,
       startTime: startTimeSecs,
       title: title ?? null,
       feedTitle: feedTitle ?? null,
-      isPlaying: true,
+      isPlaying: !!src,
     });
   }
 

--- a/apps/web/src/components/EpisodeDescription.tsx
+++ b/apps/web/src/components/EpisodeDescription.tsx
@@ -122,9 +122,10 @@ export default function EpisodeDescription({
         e.preventDefault();
         const secs = Number(target.getAttribute("data-timestamp-secs"));
         if (!isNaN(secs)) {
-          // Play audio from this timestamp
-          if (episodeId && audioLocalPath) {
-            const filename = path.basename(audioLocalPath);
+          // Play audio from this timestamp (or open player with "unavailable"
+          // state when the episode has no audio_local_path).
+          if (episodeId) {
+            const filename = audioLocalPath ? path.basename(audioLocalPath) : null;
             playEpisode(
               episodeId,
               filename,

--- a/apps/web/src/components/TranscriptView.tsx
+++ b/apps/web/src/components/TranscriptView.tsx
@@ -97,8 +97,7 @@ export default function TranscriptView({
   }, [scrollToTime]);
 
   function handleTimestampClick(startTime: number) {
-    if (!audioLocalPath) return;
-    const filename = audioLocalPath.split("/").pop() ?? "";
+    const filename = audioLocalPath ? (audioLocalPath.split("/").pop() ?? null) : null;
     playEpisode(episodeId, filename, startTime, episodeTitle ?? undefined, feedTitle ?? undefined);
   }
 


### PR DESCRIPTION
## Summary
- Fixes the silent-failure UX from #569 by adding an `onError` handler on the `<audio>` element and rendering a clear "Audio unavailable" state when `/api/audio` returns 404 or `audio_local_path` is null.
- Adds a one-off recovery script that re-acquires audio for episodes whose archive file was wiped from `/data/audio/archive/` or whose `audio_local_path` was never recorded.
- Recovered 83 of 84 affected episodes during this session; the 1 unrecoverable case (`local://` upload, no remote source) had its `audio_local_path` set to NULL so the new UI surfaces it cleanly.

## Changes

### Web — `apps/web/src/components/`
- `AudioPlayer.tsx`: new `loadError` state set on `<audio>`'s `error` event; computed `unavailable = loadError || !state.src`. Render gate switched from `state.src` to `state.episodeId` so the bar still opens for episodes with no path. Progress bar, play/skip/volume buttons disable when unavailable; an inline `AlertTriangle` + "Audio unavailable" replaces the time block. Close button still works. The src useEffect now also pauses + clears the `<audio>` when `state.src` goes null, so previous playback doesn't bleed through when switching to an unplayable episode.
- `AudioPlayerContext.tsx`: `playEpisode` accepts `filename: string | null`. Null filename → `src = null`, `isPlaying = false`, but episode metadata still set so the player bar opens in the unavailable state.
- `TranscriptView.tsx`, `EpisodeDescription.tsx`: drop the silent `if (!audioLocalPath) return` early-returns; pass null filename through to `playEpisode` so the player surfaces the unavailable state instead of doing nothing.

### Pipeline — `apps/pipeline/scripts/redownload_missing_audio.py` (new)
- Finds episodes that should have audio but don't:
  - `audio_local_path` set, file gone (volume-wipe case)
  - `audio_local_path` null, `audio_url` is fetchable (archive-incomplete case)
- For each: streams `audio_url` via httpx (follows redirects), encodes to MP3 64 kbps via ffmpeg-python, writes to `settings.audio_archive_dir`. For null-path cases, writes the recovered path back to the DB.
- Skips non-HTTP URL schemes (`local://`, etc.) with a clear message — those need manual re-upload.
- Modes: `--list` (dry-run), `--episode-id <uuid>` (single), `--all` (bulk). Run inside the worker container with `PYTHONPATH=/app`.

## Testing
- TypeScript: `npx tsc --noEmit` is clean for all changed files (pre-existing errors in `tests/unit/*-route.test.ts` are unrelated; tracked in #545).
- ESLint: clean (pre-existing warnings on unrelated lines only).
- End-to-end: web image rebuilt and verified to serve "America Strikes Iran" (404 → 206 after recovery) and "What's in a name? (North Korea edition)" (NULL-path → 206 after path-writeback).
- Recovery: 68 missing-file episodes restored (bulk), 1 marked unavailable, 15 NULL-path episodes restored with DB writeback. All status checks pass.

## Test plan (manual)
- [ ] On `main` after merge, click a timestamp on an episode with NULL `audio_local_path` → player bar shows "Audio unavailable" + AlertTriangle, controls disabled, X closes.
- [ ] Click a timestamp on a normal episode → audio plays as before.
- [ ] Confirm `apps/pipeline/scripts/redownload_missing_audio.py --list` works inside the worker container.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)