### PR TITLE
fix(web): exclude tests/** from base tsconfig so tsc --noEmit passes (#545)

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests/**"
   ]
 }


### PR DESCRIPTION
## Summary
Addresses Item 2 from #545. `npx tsc --noEmit` now exits 0 on a clean checkout — the explicit acceptance criterion from the issue.

## Root cause
The default `apps/web/tsconfig.json` included `**/*.ts` and `**/*.tsx`, which swept in `tests/` files. TypeScript treated all included files as one program, so module-scope declarations in sibling test files collided:

- `mockQuery` redeclared in `ask-coverage-route.test.ts` and `queue-route.test.ts` (and similar files)
- `RouteModule` and `GET` similarly redeclared
- Plus stale type errors in `download-report-button.test.tsx` and `meta-analysis-*.test.ts` (test fixtures not kept in sync with prod types)

Jest itself didn't care — at runtime each test file is its own ES module. Only the project-wide `tsc --noEmit` saw the collisions.

## Change
One line in `apps/web/tsconfig.json`: add `"tests/**"` to `exclude`. Matches issue author's stated preference (option b: "rely on tsconfig.test.json alone for test-file type checking").

## Why this is safe
- Jest runs through Next.js's SWC transformer (`nextJest` in `jest.config.js`), not tsc. Each test file is compiled independently. Test execution unaffected.
- Production code (`src/**`) is still type-checked by `tsc --noEmit`.
- Verified: 502 unit tests across 101 suites all pass after the change.

## Out of scope (intentional)
`tsconfig.test.json` still fails when invoked with `-p` due to pre-existing test-fixture drift (see e.g. `download-report-button.test.tsx` — `SearchResult` shape changes that weren't propagated to fixtures). This isn't the collision the issue called out, and fixing it would mean updating ~5 test files. Happy to do it as a follow-up if there's interest; for now `npm run typecheck` will still report those errors on its second invocation.

Item 1 from #545 (Zod runtime validation for the Settings type-drift) will follow as a separate PR.

## Test plan
- [x] `npx tsc --noEmit` from `apps/web/` exits 0
- [x] `npm test` — 502 / 502 tests pass

Refs #545 (Item 2; issue stays open until Item 1 also ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)