### PR TITLE
feat(web): zod runtime validation for settings response (#545)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -33,7 +33,8 @@
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -14811,7 +14812,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,7 +41,8 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/apps/web/src/components/NotificationSettings.tsx
+++ b/apps/web/src/components/NotificationSettings.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Settings, Toast } from "./NotificationSettingsSections";
+import { SettingsSchema } from "@/lib/settings-schema";
 import NotificationSection from "./NotificationSection";
 import RemoteInferenceSection from "./RemoteInferenceSection";
 
@@ -32,11 +33,26 @@ export default function NotificationSettings() {
   } | null>(null);
   const [dirtyNotifications, setDirtyNotifications] = useState<Partial<Settings>>({});
   const [dirtyInference, setDirtyInference] = useState<Partial<Settings>>({});
+  const [shapeError, setShapeError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/notifications/settings")
       .then((r) => r.json())
-      .then((data) => setSettings(data))
+      .then((data) => {
+        const parsed = SettingsSchema.safeParse(data);
+        if (parsed.success) {
+          setSettings(parsed.data);
+          return;
+        }
+        // Drift between backend allowlist and frontend schema. Surface it
+        // visibly instead of writing back a corrupted shape on the next PUT.
+        const summary = parsed.error.issues
+          .slice(0, 5)
+          .map((iss) => `${iss.path.join(".") || "(root)"}: ${iss.message}`)
+          .join("; ");
+        console.error("settings_shape_mismatch", parsed.error.issues);
+        setShapeError(summary);
+      })
       .catch(() => {});
   }, []);
 
@@ -45,6 +61,24 @@ export default function NotificationSettings() {
     const id = setTimeout(() => setToast(null), 4000);
     return () => clearTimeout(id);
   }, [toast]);
+
+  if (shapeError) {
+    return (
+      <div className="border border-destructive/40 bg-destructive/10 rounded-md p-4 text-sm space-y-2">
+        <div className="font-medium text-destructive">
+          Settings response shape didn&apos;t match the expected schema.
+        </div>
+        <div className="text-muted-foreground">
+          The backend may have added or changed a field. Refusing to render
+          editable fields to avoid corrupting the database on save. Please
+          report this with the details below.
+        </div>
+        <pre className="text-xs bg-muted/40 rounded p-2 overflow-x-auto whitespace-pre-wrap">
+          {shapeError}
+        </pre>
+      </div>
+    );
+  }
 
   if (!settings) {
     return (

--- a/apps/web/src/components/NotificationSettingsSections.tsx
+++ b/apps/web/src/components/NotificationSettingsSections.tsx
@@ -1,39 +1,9 @@
 "use client";
 
-export interface Settings {
-  telegram_bot_token: string | null;
-  telegram_chat_id: string | null;
-  notification_email_to: string | null;
-  notification_email_from: string;
-  smtp_host: string;
-  smtp_port: number;
-  smtp_user: string | null;
-  smtp_password: string | null;
-  smtp_use_tls: boolean;
-  notification_frequency: string;
-  health_check_notifications_enabled: boolean;
-  inference_provider: "local" | "fireworks";
-  fireworks_api_key: string | null;
-  fireworks_audio_base_url: string;
-  fireworks_stt_model: string;
-  fireworks_stt_diarize: boolean;
-  fireworks_chat_base_url: string;
-  fireworks_chat_model: string;
-  fireworks_stt_cost_per_minute_usd: number;
-  embedding_provider: "local" | "fireworks";
-  embedding_model: string;
-  fireworks_embedding_base_url: string;
-  fireworks_embedding_model: string;
-  diarization_provider: "local" | "precision2";
-  pyannote_api_key: string | null;
-  pyannote_cloud_base_url: string;
-  pyannote_cloud_model: string;
-  pyannote_cloud_cost_per_second_usd: number;
-  telegram_configured: boolean;
-  email_configured: boolean;
-  fireworks_configured: boolean;
-  pyannote_cloud_configured: boolean;
-}
+// `Settings` is defined by the Zod schema in @/lib/settings-schema so the
+// runtime parse and the compile-time type cannot drift from each other.
+// Re-exported here to keep existing imports stable across the codebase.
+export type { Settings } from "@/lib/settings-schema";
 
 export function Toast({
   message,

--- a/apps/web/src/lib/settings-schema.ts
+++ b/apps/web/src/lib/settings-schema.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Runtime schema for the settings payload returned by
+ * `GET /api/notifications/settings`. The shape must stay in lockstep with
+ * the backend allowlist:
+ *
+ *   apps/pipeline/app/services/notification_settings.py::_FIELDS
+ *   (+ _NULLABLE_FIELDS, _VALID_FREQUENCIES, _VALID_INFERENCE_PROVIDERS,
+ *      _VALID_EMBEDDING_PROVIDERS, _VALID_DIARIZATION_PROVIDERS)
+ *
+ * The pipeline is the source of truth. If a new field is added there, mirror
+ * it here. Drift is caught at runtime when the Settings page parses the
+ * response — the page surfaces a clear error rather than silently using a
+ * mistyped shape (which previously could corrupt the DB on a follow-up PUT
+ * because /api/notifications/settings is a thin proxy that forwards arbitrary
+ * JSON to the backend).
+ */
+export const SettingsSchema = z.object({
+  // Nullable string fields (mirror _NULLABLE_FIELDS).
+  telegram_bot_token: z.string().nullable(),
+  telegram_chat_id: z.string().nullable(),
+  notification_email_to: z.string().nullable(),
+  smtp_user: z.string().nullable(),
+  smtp_password: z.string().nullable(),
+  fireworks_api_key: z.string().nullable(),
+  pyannote_api_key: z.string().nullable(),
+
+  // Required string fields.
+  notification_email_from: z.string(),
+  smtp_host: z.string(),
+  fireworks_audio_base_url: z.string(),
+  fireworks_stt_model: z.string(),
+  fireworks_chat_base_url: z.string(),
+  fireworks_chat_model: z.string(),
+  embedding_model: z.string(),
+  fireworks_embedding_base_url: z.string(),
+  fireworks_embedding_model: z.string(),
+  pyannote_cloud_base_url: z.string(),
+  pyannote_cloud_model: z.string(),
+
+  // Numbers.
+  smtp_port: z.number(),
+  fireworks_stt_cost_per_minute_usd: z.number(),
+  pyannote_cloud_cost_per_second_usd: z.number(),
+
+  // Booleans.
+  smtp_use_tls: z.boolean(),
+  health_check_notifications_enabled: z.boolean(),
+  fireworks_stt_diarize: z.boolean(),
+
+  // Enums (mirror backend _VALID_* sets).
+  notification_frequency: z.enum(["immediate", "daily", "weekly"]),
+  inference_provider: z.enum(["local", "fireworks"]),
+  embedding_provider: z.enum(["local", "fireworks"]),
+  diarization_provider: z.enum(["local", "precision2"]),
+
+  // Server-computed read-only flags. Not in _FIELDS but always present in
+  // the response payload — derived booleans the API includes alongside
+  // writable settings.
+  telegram_configured: z.boolean(),
+  email_configured: z.boolean(),
+  fireworks_configured: z.boolean(),
+  pyannote_cloud_configured: z.boolean(),
+});
+
+export type Settings = z.infer<typeof SettingsSchema>;

--- a/apps/web/tests/unit/settings-schema.test.ts
+++ b/apps/web/tests/unit/settings-schema.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment node
+ */
+import { SettingsSchema } from "@/lib/settings-schema";
+
+const validPayload = {
+  telegram_bot_token: null,
+  telegram_chat_id: null,
+  notification_email_to: null,
+  notification_email_from: "podlog@example.com",
+  smtp_host: "smtp.example.com",
+  smtp_port: 587,
+  smtp_user: null,
+  smtp_password: null,
+  smtp_use_tls: true,
+  notification_frequency: "daily",
+  health_check_notifications_enabled: true,
+  inference_provider: "local",
+  fireworks_api_key: null,
+  fireworks_audio_base_url: "https://api.fireworks.ai/inference/v1/audio",
+  fireworks_stt_model: "whisper-v3-turbo",
+  fireworks_stt_diarize: false,
+  fireworks_chat_base_url: "https://api.fireworks.ai/inference/v1",
+  fireworks_chat_model: "accounts/fireworks/models/llama-v3p3-70b-instruct",
+  fireworks_stt_cost_per_minute_usd: 0.0009,
+  embedding_provider: "local",
+  embedding_model: "all-MiniLM-L6-v2",
+  fireworks_embedding_base_url: "https://api.fireworks.ai/inference/v1",
+  fireworks_embedding_model: "nomic-ai/nomic-embed-text-v1.5",
+  diarization_provider: "local",
+  pyannote_api_key: null,
+  pyannote_cloud_base_url: "https://api.pyannote.ai/v1",
+  pyannote_cloud_model: "precision-2",
+  pyannote_cloud_cost_per_second_usd: 0.0006,
+  telegram_configured: false,
+  email_configured: false,
+  fireworks_configured: false,
+  pyannote_cloud_configured: false,
+};
+
+describe("SettingsSchema", () => {
+  it("accepts a known-good payload", () => {
+    const result = SettingsSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when a required field is missing", () => {
+    const { smtp_host: _omitted, ...rest } = validPayload;
+    const result = SettingsSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes("smtp_host"))).toBe(true);
+    }
+  });
+
+  it("rejects when a field has the wrong type (string instead of number)", () => {
+    const result = SettingsSchema.safeParse({ ...validPayload, smtp_port: "587" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes("smtp_port"))).toBe(true);
+    }
+  });
+
+  it("rejects an enum value outside the allowed set", () => {
+    const result = SettingsSchema.safeParse({ ...validPayload, notification_frequency: "hourly" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.includes("notification_frequency")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects when a non-nullable string is null", () => {
+    const result = SettingsSchema.safeParse({ ...validPayload, smtp_host: null });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null for nullable secret fields", () => {
+    const result = SettingsSchema.safeParse({ ...validPayload, fireworks_api_key: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a string for nullable secret fields", () => {
+    const result = SettingsSchema.safeParse({
+      ...validPayload,
+      fireworks_api_key: "fw_test_key",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("strips unknown keys (additive backend changes don't break the page)", () => {
+    const result = SettingsSchema.safeParse({ ...validPayload, _unknown_future_field: 42 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(
+        (result.data as unknown as Record<string, unknown>)._unknown_future_field,
+      ).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Closes Item 1 from #545. Adds runtime validation of the Settings fetch response so backend/frontend type drift surfaces as a visible error on the Settings page instead of corrupting the DB on the next PUT.

## Why
The pipeline-side allowlist (`apps/pipeline/app/services/notification_settings.py::_FIELDS`) and the frontend `Settings` interface were kept in lockstep by code review only. The proxy at `apps/web/src/app/api/notifications/settings/route.ts` forwards arbitrary JSON to the backend, so a typo on the frontend (e.g. `fireworks_api_key` mistyped as `fireworks_apikey`) could quietly write a corrupt shape on save. The issue author voted for option 1 (Zod) — cheapest, catches the failure mode they care about.

## Changes
- **`apps/web/src/lib/settings-schema.ts`** (new): Zod schema mirroring the backend allowlist. Includes narrow enums (`notification_frequency`: immediate|daily|weekly; `inference_provider` / `embedding_provider`: local|fireworks; `diarization_provider`: local|precision2) and nullability for the secret-bearing fields. Doc comment cross-references the backend file as source-of-truth.
- **`apps/web/src/components/NotificationSettingsSections.tsx`**: replaces hand-written `interface Settings` (35 lines) with `export type { Settings } from "@/lib/settings-schema"` so the runtime parse and the compile-time type cannot drift.
- **`apps/web/src/components/NotificationSettings.tsx`**: parses the GET response via `SettingsSchema.safeParse`. On failure, renders an explicit error block (with a summary of the first 5 Zod issues) instead of accepting a mistyped shape. The full issue list is also logged to the console for ops.
- **`apps/web/tests/unit/settings-schema.test.ts`** (new): 8 unit tests — valid payload accepted; missing required field rejected; wrong type rejected; invalid enum rejected; null on non-nullable rejected; null/string on nullable accepted; unknown keys stripped (so additive backend changes don't break the page).
- **`apps/web/package.json` / `package-lock.json`**: pin `zod@^4.3.6` as a direct dep (was already a transitive).

## Drift caught by the schema
- One pre-existing latent issue: the old hand-written `Settings` typed `notification_frequency: string`, while the backend has only ever accepted `{immediate, daily, weekly}`. The schema narrows it to the enum so a future UI change can't ship a value the backend rejects.

## Why `.strip()` (default) and not `.strict()`
A `.strict()` schema would error on any unknown key — meaning every additive backend change would brick the Settings page until the frontend schema is updated. That's too brittle. The schema as written:
- catches unknown FIELDS being added on the frontend (since the frontend can only send what the schema lets through after parse),
- catches type-of-value drift on existing fields (the failure mode the issue calls out),
- but tolerates the backend introducing new fields the frontend doesn't know about yet.

If a stricter posture is wanted later, swap `z.object({...})` for `z.object({...}).strict()` — one line.

## Test plan
- [x] `npx tsc --noEmit` from `apps/web/` exits 0
- [x] `npm test` — 510 / 510 tests pass (was 502; +8 new)
- [x] New schema tests cover all the rejection paths
- [ ] Manual on `main` after merge: load `/settings`, confirm no console error and all sections render normally
- [ ] Manual: temporarily mutate the schema (e.g. `z.literal("must-be-this")` for some required field), reload `/settings`, confirm the error block renders and editing is blocked

## Out of scope
- POST/PUT body validation (currently we only validate the response). Belt-and-suspenders for a follow-up if desired — the more pressing failure mode (silent DB corruption on drift) is closed by parsing the response.
- Codegen from the Python allowlist (option 2 in the issue) — heavier for similar protection.
- OpenAPI from FastAPI (option 3) — heavier still.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
