### PR TITLE
feat(web): keyword search across docs (#580)

### DIFF
--- a/apps/web/src/app/docs/DocsClient.tsx
+++ b/apps/web/src/app/docs/DocsClient.tsx
@@ -5,6 +5,14 @@ import { useSearchParams, useRouter } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import { Search, X } from "lucide-react";
+import { slugifyHeading, makeUniqueSlugger } from "@/lib/docs-slug";
+import {
+  searchIndex as searchDocs,
+  makeSnippet,
+  type DocSection,
+  type SearchHit,
+} from "@/lib/docs-search";
 
 interface DocEntry {
   name: string;        // filename without extension, e.g. "01-installation"
@@ -13,6 +21,7 @@ interface DocEntry {
 
 interface DocsClientProps {
   docs: DocEntry[];
+  searchIndex: DocSection[];
 }
 
 export interface TocItem {
@@ -69,24 +78,7 @@ export function resolveMarkdownHref(href: string | undefined, docs: DocEntry[]):
   return `${REPO_BLOB_BASE_URL}/${repoPath}${hashSuffix}`;
 }
 
-export function slugifyHeading(text: string): string {
-  return text
-    .toLowerCase()
-    .trim()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
-function makeUniqueSlugger() {
-  const slugCounts = new Map<string, number>();
-  return (text: string) => {
-    const base = slugifyHeading(text) || "section";
-    const count = slugCounts.get(base) ?? 0;
-    slugCounts.set(base, count + 1);
-    return count === 0 ? base : `${base}-${count}`;
-  };
-}
+export { slugifyHeading } from "@/lib/docs-slug";
 
 export function extractTocItems(markdown: string): TocItem[] {
   const getUniqueSlug = makeUniqueSlugger();
@@ -115,12 +107,38 @@ function textFromNode(node: ReactNode): string {
   return "";
 }
 
-export default function DocsClient({ docs }: DocsClientProps) {
+const MAX_SEARCH_RESULTS = 30;
+
+export default function DocsClient({ docs, searchIndex }: DocsClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const searchHits = useMemo<SearchHit[]>(() => {
+    if (!query.trim()) return [];
+    return searchDocs(query, searchIndex).slice(0, MAX_SEARCH_RESULTS);
+  }, [query, searchIndex]);
+  const isSearching = query.trim().length > 0;
+
+  function gotoSearchHit(hit: SearchHit) {
+    setQuery("");
+    const isSameDoc = hit.section.docSlug === currentPage;
+    const anchor = hit.section.sectionId ? `#${hit.section.sectionId}` : "";
+    router.push(`/docs?page=${encodeURIComponent(hit.section.docSlug)}${anchor}`);
+    // Same-doc navigation doesn't reload content, so the post-render scroll
+    // effect won't fire. Scroll directly here. Different-doc clicks fall
+    // through to the content-load scroll effect below.
+    if (isSameDoc && hit.section.sectionId) {
+      setTimeout(() => {
+        document
+          .getElementById(hit.section.sectionId)
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 50);
+    }
+  }
 
   const requestedPage = searchParams.get("page");
   const defaultPage = docs.find((doc) => doc.name === "README")?.name ?? docs[0]?.name ?? null;
@@ -167,6 +185,21 @@ export default function DocsClient({ docs }: DocsClientProps) {
     [content]
   );
 
+  // Scroll to URL hash after content finishes loading (covers different-doc
+  // search clicks, deep links, and back-button navigation). Tiny timeout
+  // gives react-markdown a chance to commit heading IDs to the DOM.
+  useEffect(() => {
+    if (loading || !content || typeof window === "undefined") return;
+    const hash = window.location.hash.replace(/^#/, "");
+    if (!hash) return;
+    const timer = setTimeout(() => {
+      document
+        .getElementById(hash)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [content, loading]);
+
   useEffect(() => {
     if (!tocItems.length) {
       setActiveHeadingId(null);
@@ -205,6 +238,36 @@ export default function DocsClient({ docs }: DocsClientProps) {
       {/* Sidebar / mobile navigator */}
       <aside className="w-full md:w-auto md:shrink-0">
         <h2 className="mb-2 px-1 text-sm font-semibold text-muted-foreground">Knowledge base</h2>
+
+        {/* Keyword search across all docs (issue #580). Filters by section. */}
+        {searchIndex.length > 0 && (
+          <div className="relative mb-3">
+            <Search
+              size={14}
+              className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape") setQuery(""); }}
+              placeholder="Search docs..."
+              aria-label="Search documentation"
+              className="w-full rounded-md border border-input bg-background pl-7 pr-7 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent"
+              >
+                <X size={12} />
+              </button>
+            )}
+          </div>
+        )}
+
         <div className="md:hidden">
           <label htmlFor="docs-page-select" className="sr-only">Choose document</label>
           <select
@@ -225,21 +288,67 @@ export default function DocsClient({ docs }: DocsClientProps) {
             )}
           </select>
         </div>
-        <nav className="hidden space-y-1 md:block md:sticky md:top-20">
-          {docs.map((doc) => (
-            <button
-              key={doc.name}
-              onClick={() => router.push(`/docs?page=${encodeURIComponent(doc.name)}`)}
-              className={`w-full text-left px-2 py-1.5 rounded-md text-sm transition-colors ${
-                currentPage === doc.name
-                  ? "bg-accent text-accent-foreground font-medium"
-                  : "text-muted-foreground hover:text-foreground hover:bg-accent"
-              }`}
-            >
-              {doc.title}
-            </button>
-          ))}
-        </nav>
+        {isSearching ? (
+          <div className="hidden md:block md:sticky md:top-20 max-h-[calc(100vh-7rem)] overflow-y-auto">
+            {searchHits.length === 0 ? (
+              <p className="px-2 py-1.5 text-sm text-muted-foreground">
+                No matches for &ldquo;{query.trim()}&rdquo;
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {searchHits.map((hit) => {
+                  const key = `${hit.section.docSlug}#${hit.section.sectionId || "_"}`;
+                  const snippetSource =
+                    hit.matchedIn === "title" ? hit.section.content : hit.section.content;
+                  const snippet = makeSnippet(snippetSource, query);
+                  return (
+                    <li key={key}>
+                      <button
+                        type="button"
+                        onClick={() => gotoSearchHit(hit)}
+                        className="w-full text-left rounded-md border border-border/60 bg-background hover:bg-accent transition-colors p-2 space-y-0.5"
+                      >
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          {hit.section.docTitle}
+                        </div>
+                        <div className="text-sm font-medium">
+                          {hit.section.sectionTitle || "(introduction)"}
+                        </div>
+                        {(snippet.before || snippet.match || snippet.after) && (
+                          <div className="text-xs text-muted-foreground">
+                            {snippet.before}
+                            {snippet.match && (
+                              <mark className="bg-yellow-200/70 dark:bg-yellow-700/50 text-foreground rounded px-0.5">
+                                {snippet.match}
+                              </mark>
+                            )}
+                            {snippet.after}
+                          </div>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        ) : (
+          <nav className="hidden space-y-1 md:block md:sticky md:top-20">
+            {docs.map((doc) => (
+              <button
+                key={doc.name}
+                onClick={() => router.push(`/docs?page=${encodeURIComponent(doc.name)}`)}
+                className={`w-full text-left px-2 py-1.5 rounded-md text-sm transition-colors ${
+                  currentPage === doc.name
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                }`}
+              >
+                {doc.title}
+              </button>
+            ))}
+          </nav>
+        )}
       </aside>
 
       {/* Content */}

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -2,6 +2,7 @@ import { readdir } from "fs/promises";
 import { join } from "path";
 import { Suspense } from "react";
 import DocsClient from "./DocsClient";
+import { buildDocsIndex } from "@/lib/docs-index";
 
 export const dynamic = "force-dynamic";
 
@@ -30,9 +31,11 @@ export default async function DocsPage() {
     // Directory doesn't exist or is empty
   }
 
+  const searchIndex = await buildDocsIndex();
+
   return (
     <Suspense fallback={<div className="p-6 text-muted-foreground">Loading...</div>}>
-      <DocsClient docs={docs} />
+      <DocsClient docs={docs} searchIndex={searchIndex} />
     </Suspense>
   );
 }

--- a/apps/web/src/lib/docs-index.ts
+++ b/apps/web/src/lib/docs-index.ts
@@ -1,0 +1,114 @@
+/**
+ * Build the docs search index server-side.
+ *
+ * Reads every `.md` file under `docs/guide/`, splits each into sections at
+ * `## ` and `### ` headings, and emits a flat array consumed by the client
+ * search UI in DocsClient. Section anchor IDs are produced by the same
+ * slug algorithm DocsClient uses when rendering headings, so a result's
+ * link resolves to the heading the user expects.
+ *
+ * The result is memoized at module level so we don't re-read the corpus on
+ * every render — `force-dynamic` on the page would otherwise mean fresh
+ * filesystem reads on every request.
+ */
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+
+import type { DocSection } from "./docs-search";
+import { makeUniqueSlugger } from "./docs-slug";
+
+function filenameToTitle(filename: string): string {
+  return filename
+    .replace(/^\d+-/, "")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Split a single document into ## / ### sections. */
+function splitDocIntoSections(
+  docSlug: string,
+  docTitle: string,
+  markdown: string,
+): DocSection[] {
+  const lines = markdown.split("\n");
+  const sluggify = makeUniqueSlugger();
+  const sections: DocSection[] = [];
+
+  // Anything before the first ## heading goes into a synthetic preamble
+  // section so it remains searchable. Its anchor matches the doc itself.
+  let current: DocSection = {
+    docSlug,
+    docTitle,
+    sectionId: "",
+    sectionTitle: "",
+    level: 0,
+    content: "",
+  };
+
+  const flush = () => {
+    if (current.content.trim() || current.sectionTitle) {
+      sections.push({ ...current, content: current.content.trim() });
+    }
+  };
+
+  for (const line of lines) {
+    const match = line.match(/^(##|###)\s+(.+)$/);
+    if (match) {
+      flush();
+      const level = match[1] === "##" ? 2 : 3;
+      const text = match[2].trim();
+      current = {
+        docSlug,
+        docTitle,
+        sectionId: sluggify(text),
+        sectionTitle: text,
+        level,
+        content: "",
+      };
+      continue;
+    }
+    current.content += (current.content ? "\n" : "") + line;
+  }
+  flush();
+
+  return sections;
+}
+
+let cachedIndex: DocSection[] | null = null;
+
+/** Reads the docs corpus and returns the flat search index. Memoized. */
+export async function buildDocsIndex(): Promise<DocSection[]> {
+  if (cachedIndex) return cachedIndex;
+
+  const docsDir = join(process.cwd(), "..", "..", "docs", "guide");
+  let files: string[] = [];
+  try {
+    files = (await readdir(docsDir)).filter((f) => f.endsWith(".md")).sort();
+  } catch {
+    cachedIndex = [];
+    return cachedIndex;
+  }
+
+  const out: DocSection[] = [];
+  for (const file of files) {
+    const slug = file.replace(/\.md$/, "");
+    const title = filenameToTitle(slug);
+    let raw = "";
+    try {
+      raw = await readFile(join(docsDir, file), "utf-8");
+    } catch {
+      continue;
+    }
+    out.push(...splitDocIntoSections(slug, title, raw));
+  }
+
+  cachedIndex = out;
+  return cachedIndex;
+}
+
+/** Test hook to force a re-read on the next call. Not used in app code. */
+export function _resetDocsIndexCache(): void {
+  cachedIndex = null;
+}
+
+export { splitDocIntoSections };

--- a/apps/web/src/lib/docs-search.ts
+++ b/apps/web/src/lib/docs-search.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure helpers for client-side docs keyword search.
+ *
+ * The index is built server-side in @/lib/docs-index and shipped to the
+ * client via DocsPage props. These helpers run in the browser to filter
+ * the corpus and produce the snippet UI.
+ */
+
+export interface DocSection {
+  /** Filename without extension, e.g. "06-speakers". Matches DocEntry.name. */
+  docSlug: string;
+  /** Human-readable doc title, e.g. "Speakers". */
+  docTitle: string;
+  /** Heading anchor id (matches DocsClient's slugifyHeading + makeUniqueSlugger). */
+  sectionId: string;
+  /** Heading text, e.g. "Renaming a speaker". Empty string for content before the first heading. */
+  sectionTitle: string;
+  /** Heading level, 2 for ##, 3 for ###. 0 means "before any heading" (preamble). */
+  level: 0 | 2 | 3;
+  /** Section body, raw markdown text. */
+  content: string;
+}
+
+export interface SearchHit {
+  section: DocSection;
+  /** Where the match was found — drives ranking. */
+  matchedIn: "title" | "content";
+  /** Index of the first match within the searched string (lowercased). */
+  matchIndex: number;
+}
+
+export interface Snippet {
+  before: string;
+  match: string;
+  after: string;
+}
+
+/**
+ * Filter the index by query and return ranked hits.
+ *
+ * Ranking:
+ *   1) section-title matches first (most discoverable)
+ *   2) then content matches
+ *   3) within each tier, hits with an earlier match position rank higher
+ *   4) ties broken by docSlug then sectionId for determinism
+ *
+ * Empty / whitespace-only queries return [].
+ */
+export function searchIndex(query: string, index: DocSection[]): SearchHit[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const hits: SearchHit[] = [];
+  for (const section of index) {
+    const titleIdx = section.sectionTitle.toLowerCase().indexOf(q);
+    if (titleIdx !== -1) {
+      hits.push({ section, matchedIn: "title", matchIndex: titleIdx });
+      continue;
+    }
+    const contentIdx = section.content.toLowerCase().indexOf(q);
+    if (contentIdx !== -1) {
+      hits.push({ section, matchedIn: "content", matchIndex: contentIdx });
+    }
+  }
+
+  hits.sort((a, b) => {
+    if (a.matchedIn !== b.matchedIn) return a.matchedIn === "title" ? -1 : 1;
+    if (a.matchIndex !== b.matchIndex) return a.matchIndex - b.matchIndex;
+    if (a.section.docSlug !== b.section.docSlug) {
+      return a.section.docSlug.localeCompare(b.section.docSlug);
+    }
+    return a.section.sectionId.localeCompare(b.section.sectionId);
+  });
+
+  return hits;
+}
+
+/**
+ * Build a snippet around the first match in `content`. Trims to roughly
+ * `halfWidth` characters on either side, snapping at word boundaries when
+ * possible to avoid mid-word cuts.
+ */
+export function makeSnippet(content: string, query: string, halfWidth = 60): Snippet {
+  const q = query.toLowerCase();
+  const idx = content.toLowerCase().indexOf(q);
+  if (idx === -1 || !q) {
+    const head = content.slice(0, halfWidth * 2);
+    return { before: head, match: "", after: content.length > head.length ? "…" : "" };
+  }
+
+  const matchEnd = idx + q.length;
+  const rawBeforeStart = Math.max(0, idx - halfWidth);
+  const rawAfterEnd = Math.min(content.length, matchEnd + halfWidth);
+
+  // Snap left edge to a whitespace boundary if we're not already at the start.
+  let beforeStart = rawBeforeStart;
+  if (beforeStart > 0) {
+    const ws = content.indexOf(" ", beforeStart);
+    if (ws !== -1 && ws < idx) beforeStart = ws + 1;
+  }
+  // Snap right edge similarly.
+  let afterEnd = rawAfterEnd;
+  if (afterEnd < content.length) {
+    const ws = content.lastIndexOf(" ", afterEnd);
+    if (ws > matchEnd) afterEnd = ws;
+  }
+
+  const before = (beforeStart > 0 ? "…" : "") + content.slice(beforeStart, idx);
+  const match = content.slice(idx, matchEnd);
+  const after = content.slice(matchEnd, afterEnd) + (afterEnd < content.length ? "…" : "");
+  // Collapse newlines to spaces for compact display.
+  return {
+    before: before.replace(/\s+/g, " "),
+    match,
+    after: after.replace(/\s+/g, " "),
+  };
+}

--- a/apps/web/src/lib/docs-slug.ts
+++ b/apps/web/src/lib/docs-slug.ts
@@ -1,0 +1,32 @@
+/**
+ * Heading-slug utilities shared by:
+ *   - The docs renderer in @/app/docs/DocsClient (per-render, browser).
+ *   - The docs search indexer in @/lib/docs-index (per-request, server).
+ *
+ * Both sides MUST use the same algorithm so search results' anchor links
+ * resolve to the IDs the renderer actually puts into the DOM.
+ */
+
+export function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/**
+ * Returns a function that produces unique slugs for a stream of headings,
+ * appending `-1`, `-2`, ... to disambiguate repeats. State is per-instance
+ * so each document/render starts fresh.
+ */
+export function makeUniqueSlugger(): (text: string) => string {
+  const slugCounts = new Map<string, number>();
+  return (text: string) => {
+    const base = slugifyHeading(text) || "section";
+    const count = slugCounts.get(base) ?? 0;
+    slugCounts.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count}`;
+  };
+}

--- a/apps/web/tests/unit/docs-search.test.ts
+++ b/apps/web/tests/unit/docs-search.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ */
+import {
+  searchIndex,
+  makeSnippet,
+  type DocSection,
+} from "@/lib/docs-search";
+import { splitDocIntoSections } from "@/lib/docs-index";
+
+const mkSection = (
+  partial: Partial<DocSection> & { docSlug: string; sectionId: string },
+): DocSection => ({
+  docSlug: partial.docSlug,
+  docTitle: partial.docTitle ?? "Doc",
+  sectionId: partial.sectionId,
+  sectionTitle: partial.sectionTitle ?? "Section",
+  level: partial.level ?? 2,
+  content: partial.content ?? "",
+});
+
+describe("searchIndex", () => {
+  const corpus: DocSection[] = [
+    mkSection({
+      docSlug: "01-installation",
+      docTitle: "Installation",
+      sectionId: "docker",
+      sectionTitle: "Docker setup",
+      content: "Run docker compose up -d to start the stack.",
+    }),
+    mkSection({
+      docSlug: "06-speakers",
+      docTitle: "Speakers",
+      sectionId: "renaming",
+      sectionTitle: "Renaming a speaker",
+      content: "Click the speaker label and type a new name.",
+    }),
+    mkSection({
+      docSlug: "06-speakers",
+      docTitle: "Speakers",
+      sectionId: "merging",
+      sectionTitle: "Merging speakers",
+      content: "Use the speaker merge tool to combine two speaker labels.",
+    }),
+  ];
+
+  it("returns empty for whitespace-only query", () => {
+    expect(searchIndex("", corpus)).toEqual([]);
+    expect(searchIndex("   ", corpus)).toEqual([]);
+  });
+
+  it("matches on section title (case-insensitive)", () => {
+    const hits = searchIndex("DOCKER", corpus);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].section.sectionId).toBe("docker");
+    expect(hits[0].matchedIn).toBe("title");
+  });
+
+  it("matches on content when title doesn't match", () => {
+    const hits = searchIndex("compose up", corpus);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].section.sectionId).toBe("docker");
+    expect(hits[0].matchedIn).toBe("content");
+  });
+
+  it("ranks title matches before content matches", () => {
+    // 'speaker' appears in section titles AND content of multiple sections.
+    const hits = searchIndex("speaker", corpus);
+    // First two should be title matches.
+    expect(hits.slice(0, 2).every((h) => h.matchedIn === "title")).toBe(true);
+    // Section titles "Renaming a speaker" and "Merging speakers" both match.
+    expect(hits.slice(0, 2).map((h) => h.section.sectionId).sort()).toEqual([
+      "merging",
+      "renaming",
+    ]);
+  });
+
+  it("returns no hits when nothing matches", () => {
+    expect(searchIndex("nonexistent_token_xyz", corpus)).toEqual([]);
+  });
+
+  it("orders ties deterministically by docSlug then sectionId", () => {
+    const dup: DocSection[] = [
+      mkSection({ docSlug: "z", sectionId: "b", sectionTitle: "X", content: "x" }),
+      mkSection({ docSlug: "a", sectionId: "b", sectionTitle: "X", content: "x" }),
+      mkSection({ docSlug: "a", sectionId: "a", sectionTitle: "X", content: "x" }),
+    ];
+    const hits = searchIndex("x", dup);
+    expect(hits.map((h) => `${h.section.docSlug}#${h.section.sectionId}`)).toEqual([
+      "a#a",
+      "a#b",
+      "z#b",
+    ]);
+  });
+});
+
+describe("makeSnippet", () => {
+  it("returns empty match for non-matching content", () => {
+    const snippet = makeSnippet("hello world", "missing");
+    expect(snippet.match).toBe("");
+  });
+
+  it("preserves the matched substring exactly (case from source)", () => {
+    const snippet = makeSnippet("Hello World", "world");
+    // Match should be from the SOURCE casing, not the query.
+    expect(snippet.match).toBe("World");
+  });
+
+  it("trims around the match with ellipses", () => {
+    const longContent =
+      "a".repeat(200) + " needle " + "b".repeat(200);
+    const snippet = makeSnippet(longContent, "needle", 30);
+    expect(snippet.before.startsWith("…")).toBe(true);
+    expect(snippet.after.endsWith("…")).toBe(true);
+    expect(snippet.match).toBe("needle");
+  });
+
+  it("does not prepend ellipsis when match is at the start", () => {
+    const snippet = makeSnippet("needle in haystack", "needle");
+    expect(snippet.before.startsWith("…")).toBe(false);
+  });
+
+  it("does not append ellipsis when match is near the end", () => {
+    const snippet = makeSnippet("haystack and needle", "needle");
+    expect(snippet.after.endsWith("…")).toBe(false);
+  });
+
+  it("collapses internal whitespace for compact display", () => {
+    const snippet = makeSnippet(
+      "before  \n  match\n\n  after",
+      "match",
+    );
+    expect(snippet.before).not.toContain("\n");
+    expect(snippet.after).not.toContain("\n");
+  });
+});
+
+describe("splitDocIntoSections", () => {
+  it("splits at ## and ### headings, preserving section titles", () => {
+    const md = [
+      "Preamble paragraph.",
+      "",
+      "## First section",
+      "First section body.",
+      "",
+      "### Subsection",
+      "Subsection body.",
+      "",
+      "## Second section",
+      "Second section body.",
+    ].join("\n");
+
+    const sections = splitDocIntoSections("test-doc", "Test", md);
+    expect(sections.map((s) => s.sectionTitle)).toEqual([
+      "",
+      "First section",
+      "Subsection",
+      "Second section",
+    ]);
+    expect(sections[0].level).toBe(0);
+    expect(sections[1].level).toBe(2);
+    expect(sections[2].level).toBe(3);
+    expect(sections[3].level).toBe(2);
+  });
+
+  it("emits unique sectionIds for repeated heading text", () => {
+    const md = "## Setup\nBody A\n\n## Setup\nBody B\n";
+    const sections = splitDocIntoSections("d", "D", md);
+    const ids = sections.filter((s) => s.level === 2).map((s) => s.sectionId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("skips empty preambles", () => {
+    const md = "## Only section\nBody\n";
+    const sections = splitDocIntoSections("d", "D", md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].sectionTitle).toBe("Only section");
+  });
+
+  it("preserves docSlug and docTitle on every section", () => {
+    const md = "## A\n\n## B\n";
+    const sections = splitDocIntoSections("my-slug", "My Title", md);
+    expect(sections.every((s) => s.docSlug === "my-slug")).toBe(true);
+    expect(sections.every((s) => s.docTitle === "My Title")).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/docs.test.tsx
+++ b/apps/web/tests/unit/docs.test.tsx
@@ -51,7 +51,7 @@ describe("DocsClient", () => {
       text: () => Promise.resolve("# Test Doc\n\nHello world"),
     });
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     expect(screen.getByText("Knowledge base")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "README" })).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe("DocsClient", () => {
       text: () => Promise.resolve("# Test Doc\n\nHello world"),
     });
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Test Doc/)).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe("DocsClient", () => {
       () => new Promise(() => {}) // never resolves
     );
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -88,7 +88,7 @@ describe("DocsClient", () => {
       ok: false,
     });
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     await waitFor(() => {
       expect(screen.getByText("Could not load the requested page.")).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe("DocsClient", () => {
   });
 
   it("shows empty state when docs list is empty", async () => {
-    render(<DocsClient docs={[]} />);
+    render(<DocsClient docs={[]} searchIndex={[]} />);
     expect(screen.getByText("No markdown docs were found.")).toBeInTheDocument();
     expect(global.fetch).not.toHaveBeenCalled();
   });
@@ -110,7 +110,7 @@ describe("DocsClient", () => {
       text: () => Promise.resolve("# README"),
     });
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith("/docs?page=README");
@@ -125,7 +125,7 @@ describe("DocsClient", () => {
       ),
     });
 
-    render(<DocsClient docs={mockDocs} />);
+    render(<DocsClient docs={mockDocs} searchIndex={[]} />);
 
     await waitFor(() => {
       expect(screen.getByText("On this page")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
Adds keyword search to `/docs`, scoped per-section so results jump to the right heading anchor — not just the right file.

## Demo flow
1. Open `/docs`. New search input at the top of the sidebar.
2. Type a keyword (e.g. `speakers`). Sidebar replaces doc list with ranked section hits.
3. Each hit shows the doc title, section title, and a snippet with the matched substring `<mark>`-highlighted.
4. Click a hit → URL becomes `/docs?page=<slug>#<section-anchor>`, content loads (if different doc), page scrolls to that heading.
5. `Esc` or `X` clears the search and restores the normal sidebar.

## Architecture
- **Build server-side**: `apps/web/src/lib/docs-index.ts` reads all `docs/guide/*.md` at request time and emits a flat `DocSection[]` (one entry per `##` / `###` block, plus a synthetic preamble entry per file). Module-level memoized so `force-dynamic` page renders don't re-read the corpus on every hit.
- **Search runs client-side**: pure helpers in `apps/web/src/lib/docs-search.ts` filter the index in-memory on every keystroke. Ranking is `title-match → content-match → match-position → docSlug → sectionId` (deterministic).
- **Anchor IDs match**: extracted `slugifyHeading` + `makeUniqueSlugger` into `apps/web/src/lib/docs-slug.ts` so indexer (server) and renderer (client) share the exact slug algorithm. A result's `#anchor` is guaranteed to resolve to a real heading id in the DOM.
- **No new runtime deps.** Uses existing `lucide-react` for the `Search` / `X` icons.

## What I considered and skipped
- **rehype-slug + github-slugger:** would have worked, but the existing custom h2/h3 components in DocsClient already generate IDs deterministically. Two new deps for parity with code I can extract instead — extraction wins.
- **Fuse.js fuzzy matching:** issue title literally says "simple keyword search" — adding fuzzy seemed like premature feature creep. Substring is fine for 16 short files. If we want it later, it's a one-import drop-in.
- **`Cmd+K` overlay:** simpler always-visible input keeps the entrypoint obvious. Easy to graduate to an overlay later if there's demand.
- **POST/PUT body validation, etc.:** N/A — this is read-only.

## Bundle impact
- Index payload shipped per page load: ~85 KB total page size, of which the index is ~50 KB worth of `DocSection[]` (16 files × ~7 sections × short content). Well within the static-page envelope.

## Test plan
- [x] `npm test` — 526 tests pass (was 510; +16 new)
- [x] `npx tsc --noEmit` exits 0
- [x] ESLint clean for changed files
- [x] Local rebuild + `curl /docs` returns 200, search input is in the rendered HTML, index data is in the payload (112 docSlug refs)
- [ ] Manual on `main` after merge: type queries that should hit titles ("speakers", "queue") and content ("docker compose", "HF_TOKEN"); verify clicks scroll into the right anchor in the right doc; verify Esc clears

## Files
| File | Status |
|---|---|
| `apps/web/src/lib/docs-index.ts` | new — server-side indexer with module memo |
| `apps/web/src/lib/docs-search.ts` | new — pure search + snippet helpers |
| `apps/web/src/lib/docs-slug.ts` | new — extracted shared slug helpers |
| `apps/web/src/app/docs/page.tsx` | computes `searchIndex` and passes to DocsClient |
| `apps/web/src/app/docs/DocsClient.tsx` | search input + result list + anchor-scroll effect; reuses shared slug helpers |
| `apps/web/tests/unit/docs-search.test.ts` | new — 16 cases (ranking, casing, ties, snippet edges, section splitting, repeated-heading dedup) |
| `apps/web/tests/unit/docs.test.tsx` | updated to pass empty `searchIndex` prop on existing renders |

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
