### PR TITLE
feat(web): filter podcast episodes list by speaker name (#591)

### DIFF
--- a/apps/web/src/components/EpisodesList.tsx
+++ b/apps/web/src/components/EpisodesList.tsx
@@ -116,7 +116,13 @@ export default function EpisodesList({ episodes }: Props) {
   const filteredAndSorted = useMemo(() => {
     const normalizedQuery = searchQuery.toLowerCase();
     const filtered = searchQuery
-      ? episodes.filter((ep) => ep.title?.toLowerCase().includes(normalizedQuery))
+      ? episodes.filter(
+          (ep) =>
+            ep.title?.toLowerCase().includes(normalizedQuery) ||
+            ep.speaker_name_tags?.some((sn) =>
+              sn.display_name.toLowerCase().includes(normalizedQuery)
+            )
+        )
       : episodes;
 
     const arr = [...filtered];
@@ -183,11 +189,11 @@ export default function EpisodesList({ episodes }: Props) {
         <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="text"
-          placeholder="Search episodes..."
+          placeholder="Search episodes by title or speaker..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="pl-10 pr-10"
-          aria-label="Search episodes by title"
+          aria-label="Search episodes by title or speaker"
         />
         {searchQuery && (
           <button

--- a/apps/web/tests/unit/EpisodesList.filter.test.tsx
+++ b/apps/web/tests/unit/EpisodesList.filter.test.tsx
@@ -50,7 +50,7 @@ describe("EpisodesList — search / filter", () => {
   it("filters episodes by title case-insensitively", () => {
     render(<EpisodesList episodes={twoEpisodes} feedId="feed-1" />);
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "test" } });
 
     expect(screen.getByText("Test Episode One")).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("EpisodesList — search / filter", () => {
   it("filters episodes by partial title match", () => {
     render(<EpisodesList episodes={twoEpisodes} feedId="feed-1" />);
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "ep" } });
 
     expect(screen.getByText("Test Episode One")).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe("EpisodesList — search / filter", () => {
   it("shows empty state when no episodes match search", () => {
     render(<EpisodesList episodes={[twoEpisodes[0]]} feedId="feed-1" />);
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "xyz" } });
 
     expect(screen.getByText("No episodes match your search")).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe("EpisodesList — search / filter", () => {
   it("clear button resets search and shows all episodes", () => {
     render(<EpisodesList episodes={twoEpisodes} feedId="feed-1" />);
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "test" } });
 
     expect(screen.getByText("Test Episode One")).toBeInTheDocument();
@@ -102,10 +102,41 @@ describe("EpisodesList — search / filter", () => {
 
     expect(screen.getByText(/2 episodes/)).toBeInTheDocument();
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "test" } });
 
     expect(screen.getByText(/Showing 1 of 2 episodes/)).toBeInTheDocument();
+  });
+
+  it("filters episodes by speaker display name case-insensitively", () => {
+    const withSpeakers: EnrichedEpisode[] = [
+      makeEpisode({
+        id: "ep-1",
+        title: "Test Episode One",
+        speaker_name_tags: [
+          { display_name: "Alice Johnson", inferred: false, confirmed_by_user: true },
+        ],
+      }),
+      makeEpisode({
+        id: "ep-2",
+        title: "Another Episode",
+        published_at: "2026-04-02T10:00:00.000Z",
+        speaker_name_tags: [
+          { display_name: "Bob Smith", inferred: true, confirmed_by_user: false },
+        ],
+      }),
+    ];
+    render(<EpisodesList episodes={withSpeakers} feedId="feed-1" />);
+
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
+    fireEvent.change(searchInput, { target: { value: "alice" } });
+
+    expect(screen.getByText("Test Episode One")).toBeInTheDocument();
+    expect(screen.queryByText("Another Episode")).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "SMITH" } });
+    expect(screen.queryByText("Test Episode One")).not.toBeInTheDocument();
+    expect(screen.getByText("Another Episode")).toBeInTheDocument();
   });
 
   it("shows all episodes when search query is empty", () => {
@@ -114,7 +145,7 @@ describe("EpisodesList — search / filter", () => {
     expect(screen.getByText("Test Episode One")).toBeInTheDocument();
     expect(screen.getByText("Another Episode")).toBeInTheDocument();
 
-    const searchInput = screen.getByLabelText("Search episodes by title");
+    const searchInput = screen.getByLabelText("Search episodes by title or speaker");
     fireEvent.change(searchInput, { target: { value: "test" } });
     fireEvent.change(searchInput, { target: { value: "" } });
 


### PR DESCRIPTION
## Summary
- Extends the search bar in `EpisodesList` (the episode list on `/podcasts/[id]`) to also match against speaker display names, in addition to episode titles.
- Updates placeholder and aria-label to reflect the broadened search scope.

## Changes
- `apps/web/src/components/EpisodesList.tsx`: filter now matches on `ep.speaker_name_tags[].display_name` (case-insensitive) in addition to `ep.title`. Placeholder updated to "Search episodes by title or speaker..." and aria-label updated accordingly.
- `apps/web/tests/unit/EpisodesList.filter.test.tsx`: aria-label lookups updated; new test verifies case-insensitive filtering by speaker display name.

## Test plan
- [x] `npx jest tests/unit/EpisodesList` — 16/16 passing (existing 15 + 1 new speaker-filter test)
- [ ] Manual: load `/podcasts/<id>` and confirm typing a speaker name filters the episode list

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)