### PR TITLE
feat(notifications): scope queue ETA to the active inference provider

### DIFF
--- a/apps/pipeline/app/services/digest.py
+++ b/apps/pipeline/app/services/digest.py
@@ -100,6 +100,7 @@ class DigestData:
     avg_duration_secs: float | None = None
     processing_factor: float | None = None
     provider_averages: list[ProviderAverages] = field(default_factory=list)
+    queue_estimate_provider: str | None = None
 
 
 def _serialize_event(event: Event) -> str:
@@ -185,7 +186,8 @@ def send_digest_if_due(now: datetime | None = None) -> None:
             _update_last_sent(db, state_row, now)
             return
 
-        remaining, estimated, factor = estimate_queue_status(db)
+        active_provider = ns.get("inference_provider")
+        remaining, estimated, factor = estimate_queue_status(db, provider=active_provider)
         avg_t, avg_d, avg_total = compute_avg_processing_stats(db)
         avg_dur = compute_avg_duration(db)
         items = []
@@ -245,6 +247,7 @@ def send_digest_if_due(now: datetime | None = None) -> None:
             avg_duration_secs=avg_dur,
             processing_factor=factor,
             provider_averages=provider_averages,
+            queue_estimate_provider=active_provider,
         )
 
         _send_digest(digest, ns)

--- a/apps/pipeline/app/services/digest_formatters.py
+++ b/apps/pipeline/app/services/digest_formatters.py
@@ -6,7 +6,7 @@ from html import escape
 from app.services.notifications import (
     _fmt_duration,
     _fmt_short_duration,
-    _fmt_estimate,
+    _fmt_estimate_with_provider,
     _fmt_factor,
     _provider_label,
 )
@@ -117,7 +117,9 @@ def format_digest_html(data) -> str:
             f'<td style="padding: 6px 12px; color: #666;">{escape(detail)}</td></tr>\n'
         )
 
-    est = _fmt_estimate(data.queue_estimated_secs)
+    est = _fmt_estimate_with_provider(
+        data.queue_estimated_secs, getattr(data, "queue_estimate_provider", None)
+    )
 
     provider_avgs_html = ""
     for pa in getattr(data, "provider_averages", []) or []:
@@ -217,6 +219,8 @@ def format_digest_telegram(data) -> str:
         if fallback:
             lines.append(fallback)
 
-    est = _fmt_estimate(data.queue_estimated_secs)
+    est = _fmt_estimate_with_provider(
+        data.queue_estimated_secs, getattr(data, "queue_estimate_provider", None)
+    )
     lines.append(f"\n*Queue:* {data.queue_remaining} remaining · Est. {est}")
     return "\n".join(lines)

--- a/apps/pipeline/app/services/notification_events.py
+++ b/apps/pipeline/app/services/notification_events.py
@@ -20,6 +20,7 @@ class EpisodeDoneEvent(Event):
     episode_processing_factor: float | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
+    queue_estimate_provider: str | None = None
     avg_transcribe_secs: float | None = None
     avg_diarize_secs: float | None = None
     avg_total_secs: float | None = None
@@ -41,6 +42,7 @@ class EpisodeFailedEvent(Event):
     inference_provider_used: str | None = None
     queue_remaining: int = 0
     queue_estimated_secs: float | None = None
+    queue_estimate_provider: str | None = None
     avg_transcribe_secs: float | None = None
     avg_diarize_secs: float | None = None
     avg_total_secs: float | None = None

--- a/apps/pipeline/app/services/notification_runtime.py
+++ b/apps/pipeline/app/services/notification_runtime.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from app.models import Episode
 from app.services.events import bus
 from app.services.notification_events import EpisodeDoneEvent, EpisodeFailedEvent
+from app.services.notification_settings import get_runtime_inference_settings
 
 
 def compute_avg_processing_stats(
@@ -84,12 +85,17 @@ def compute_avg_processing_factor(db: Session, provider: str | None = None) -> f
     return total_processing / total_audio
 
 
-def estimate_queue_status(db: Session) -> tuple[int, float | None, float | None]:
+def estimate_queue_status(
+    db: Session, provider: str | None = None
+) -> tuple[int, float | None, float | None]:
     """Return (remaining_count, estimated_seconds_to_complete, processing_factor).
 
-    processing_factor here reflects the duration-weighted rate of the 10 most
-    recent completed episodes regardless of provider — used for the queue ETA,
-    which processes whatever comes next.
+    The rate is the duration-weighted average of the 10 most recent completed
+    episodes. If ``provider`` is set, the sample is restricted to episodes
+    processed by that inference provider so the ETA reflects the active
+    setting (a queue that will run on Fireworks shouldn't be estimated from
+    slow local-CPU history, and vice versa). Falls back to all-providers
+    when there is no provider-matching history yet.
     """
     remaining = (
         db.query(Episode)
@@ -97,17 +103,19 @@ def estimate_queue_status(db: Session) -> tuple[int, float | None, float | None]
         .count()
     )
 
-    recent = (
-        db.query(Episode)
-        .filter(
+    def _recent_for(p: str | None):
+        q = db.query(Episode).filter(
             Episode.status == "done",
             Episode.processed_at.isnot(None),
             Episode.duration_secs.isnot(None),
         )
-        .order_by(Episode.processed_at.desc())
-        .limit(10)
-        .all()
-    )
+        if p is not None:
+            q = q.filter(Episode.inference_provider_used == p)
+        return q.order_by(Episode.processed_at.desc()).limit(10).all()
+
+    recent = _recent_for(provider) if provider else _recent_for(None)
+    if provider and not recent:
+        recent = _recent_for(None)
 
     if not recent:
         return remaining, None, None
@@ -162,7 +170,8 @@ def emit_episode_done_event(db: Session, episode: Episode) -> None:
     runs don't skew the average shown next to a slow local run (or vice versa).
     """
     provider = episode.inference_provider_used
-    remaining, estimated, _ = estimate_queue_status(db)
+    active_provider = get_runtime_inference_settings(db).get("inference_provider")
+    remaining, estimated, _ = estimate_queue_status(db, provider=active_provider)
     avg_t, avg_d, avg_total = compute_avg_processing_stats(db, provider=provider)
     avg_dur = compute_avg_duration(db, provider=provider)
     avg_factor = compute_avg_processing_factor(db, provider=provider)
@@ -183,6 +192,7 @@ def emit_episode_done_event(db: Session, episode: Episode) -> None:
             episode_processing_factor=episode_factor,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
+            queue_estimate_provider=active_provider,
             avg_transcribe_secs=avg_t,
             avg_diarize_secs=avg_d,
             avg_total_secs=avg_total,
@@ -201,7 +211,8 @@ def emit_episode_failed_event(
 ) -> None:
     """Emit EpisodeFailedEvent using runtime queue/average stats."""
     provider = episode.inference_provider_used
-    remaining, estimated, _ = estimate_queue_status(db)
+    active_provider = get_runtime_inference_settings(db).get("inference_provider")
+    remaining, estimated, _ = estimate_queue_status(db, provider=active_provider)
     avg_t, avg_d, avg_total = compute_avg_processing_stats(db, provider=provider)
     avg_dur = compute_avg_duration(db, provider=provider)
     avg_factor = compute_avg_processing_factor(db, provider=provider)
@@ -219,6 +230,7 @@ def emit_episode_failed_event(
             inference_provider_used=provider,
             queue_remaining=remaining,
             queue_estimated_secs=estimated,
+            queue_estimate_provider=active_provider,
             avg_transcribe_secs=avg_t,
             avg_diarize_secs=avg_d,
             avg_total_secs=avg_total,

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -66,6 +66,23 @@ def _provider_label(provider: str | None) -> str:
     return "all episodes"
 
 
+def _provider_tag(provider: str | None) -> str:
+    """Compact label for the active inference provider, e.g. 'local' or 'remote'."""
+    if provider == "local":
+        return "local"
+    if provider == "fireworks":
+        return "remote"
+    return provider or ""
+
+
+def _fmt_estimate_with_provider(secs: float | None, provider: str | None) -> str:
+    base = _fmt_estimate(secs)
+    tag = _provider_tag(provider)
+    if not tag or secs is None:
+        return base
+    return f"{base} ({tag})"
+
+
 def _fmt_diarize_steps_html(step_durations: dict[str, float] | None) -> str:
     if not step_durations:
         return ""
@@ -191,7 +208,7 @@ def format_done_html(event: EpisodeDoneEvent) -> str:
         <td style="padding: 4px 12px;">{event.queue_remaining} episodes</td></tr>
     <tr style="background: #f9f9f9;">
         <td style="padding: 4px 12px; color: #666;">Est. time left</td>
-        <td style="padding: 4px 12px;">{_fmt_estimate(event.queue_estimated_secs)}</td></tr>
+        <td style="padding: 4px 12px;">{_fmt_estimate_with_provider(event.queue_estimated_secs, getattr(event, "queue_estimate_provider", None))}</td></tr>
   </table>
   <hr style="margin-top: 24px; border: none; border-top: 1px solid #eee;">
   <p style="font-size: 12px; color: #999;">Sent by Podlog</p>
@@ -220,7 +237,7 @@ def format_done_telegram(event: EpisodeDoneEvent) -> str:
         f"{episode_factor_line}"
         f"{diarize_steps_section}"
         f"{avg_section}\n"
-        f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"
+        f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate_with_provider(event.queue_estimated_secs, getattr(event, 'queue_estimate_provider', None))}"
     )
 
 
@@ -259,7 +276,7 @@ def format_failed_html(event: EpisodeFailedEvent) -> str:
         <td style="padding: 4px 12px;">{event.queue_remaining} episodes</td></tr>
     <tr style="background: #f9f9f9;">
         <td style="padding: 4px 12px; color: #666;">Est. time left</td>
-        <td style="padding: 4px 12px;">{_fmt_estimate(event.queue_estimated_secs)}</td></tr>
+        <td style="padding: 4px 12px;">{_fmt_estimate_with_provider(event.queue_estimated_secs, getattr(event, "queue_estimate_provider", None))}</td></tr>
   </table>
   <hr style="margin-top: 24px; border: none; border-top: 1px solid #eee;">
   <p style="font-size: 12px; color: #999;">Sent by Podlog</p>
@@ -280,7 +297,7 @@ def format_failed_telegram(event: EpisodeFailedEvent) -> str:
         f"`Details:  {event.error_message}`\n"
         f"`Retries:  {event.retry_count}/{event.retry_max}`\n"
         f"{avg_section}\n"
-        f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate(event.queue_estimated_secs)}"
+        f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate_with_provider(event.queue_estimated_secs, getattr(event, 'queue_estimate_provider', None))}"
     )
 
 

--- a/apps/pipeline/tests/unit/test_digest_formatting.py
+++ b/apps/pipeline/tests/unit/test_digest_formatting.py
@@ -89,6 +89,16 @@ def test_format_digest_html_unknown_queue_estimate():
     assert "unknown" in html.lower()
 
 
+def test_format_digest_telegram_estimate_tagged_with_active_provider():
+    data = _make_digest_data()
+    data.queue_estimate_provider = "fireworks"
+    md = format_digest_telegram(data)
+    assert "(remote)" in md.split("Queue:")[1]
+
+    data.queue_estimate_provider = "local"
+    assert "(local)" in format_digest_telegram(data).split("Queue:")[1]
+
+
 def test_format_digest_html_contains_averages():
     data = _make_digest_data()
     data.avg_transcribe_secs = 125.0

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -69,6 +69,26 @@ def test_format_done_telegram_contains_key_info():
     assert "5" in md
 
 
+def test_format_done_telegram_estimate_tagged_with_active_provider():
+    """The Queue line carries the active provider so the user can read the ETA in context."""
+    event = _make_done_event()
+    event.queue_estimate_provider = "fireworks"
+    md = format_done_telegram(event)
+    assert "(remote)" in md.split("Queue:")[1]
+
+    event.queue_estimate_provider = "local"
+    md_local = format_done_telegram(event)
+    assert "(local)" in md_local.split("Queue:")[1]
+
+
+def test_format_done_telegram_estimate_no_tag_when_provider_unknown():
+    event = _make_done_event()
+    event.queue_estimate_provider = None
+    md = format_done_telegram(event)
+    queue_line = md.split("Queue:")[1]
+    assert "(local)" not in queue_line and "(remote)" not in queue_line
+
+
 def test_format_done_html_contains_diarization_step_breakdown():
     html = format_done_html(_make_done_event())
     assert "Diarization Step Breakdown" in html

--- a/apps/pipeline/tests/unit/test_notifications.py
+++ b/apps/pipeline/tests/unit/test_notifications.py
@@ -244,6 +244,63 @@ def test_episode_processing_factor_helper():
     assert _compute_episode_processing_factor(900.0, 0) is None
 
 
+def _make_chain(*, recent_episodes_per_call: list, queued_count: int, queued_audio_durations: list[int]):
+    """Build a self-chaining query mock.
+
+    `db.query(...).filter(...).filter(...)...` always returns the same chain object so
+    arbitrary `.filter()` chains resolve. Each call to `.limit().all()` consumes the
+    next list from `recent_episodes_per_call`. `.count()` and the bare `.all()` (no
+    `.limit()` in between) return queued data.
+    """
+    recent_iter = iter(recent_episodes_per_call)
+    queued_episodes = [MagicMock(duration_secs=d) for d in queued_audio_durations]
+
+    chain = MagicMock()
+    chain.filter.return_value = chain
+    chain.order_by.return_value = chain
+    chain.count.return_value = queued_count
+    chain.all.return_value = queued_episodes  # used by queued_episodes path
+
+    limit_chain = MagicMock()
+    limit_chain.all = MagicMock(side_effect=lambda: next(recent_iter, []))
+    chain.limit.return_value = limit_chain
+
+    db = MagicMock()
+    db.query.return_value = chain
+    return db
+
+
+def test_estimate_queue_status_filters_recent_by_provider():
+    """When provider is set, only matching episodes seed the rate."""
+    fast_remote = MagicMock(duration_secs=1800, transcribe_duration_secs=20.0, diarize_duration_secs=10.0)
+    db = _make_chain(
+        recent_episodes_per_call=[[fast_remote]],
+        queued_count=1,
+        queued_audio_durations=[1800],
+    )
+
+    remaining, estimated, factor = estimate_queue_status(db, provider="fireworks")
+    assert remaining == 1
+    # 30s processing / 1800s audio = 1/60 ⇒ 1800 * 1/60 = 30s ETA
+    assert estimated == 30.0
+    assert factor is not None and abs(factor - (1 / 60)) < 1e-9
+
+
+def test_estimate_queue_status_provider_falls_back_when_no_history():
+    """If the active provider has no recent episodes, fall back to all-providers."""
+    slow_local = MagicMock(duration_secs=1800, transcribe_duration_secs=600.0, diarize_duration_secs=300.0)
+    db = _make_chain(
+        recent_episodes_per_call=[[], [slow_local]],  # provider-narrowed empty, fallback hit
+        queued_count=1,
+        queued_audio_durations=[1800],
+    )
+
+    remaining, estimated, _ = estimate_queue_status(db, provider="fireworks")
+    assert remaining == 1
+    # 900 / 1800 = 0.5; queued audio = 1800 ⇒ ETA 900s.
+    assert estimated == 900.0
+
+
 def test_estimate_queue_status_no_history():
     """Without recent completed episodes, estimated_secs is None."""
     db = MagicMock()


### PR DESCRIPTION
## Summary
- The Telegram/email "Est. time left" line was computed from the 10 most-recent completed episodes regardless of provider, so a queue that will run on Fireworks could be estimated from slow local-CPU history (or vice versa).
- `estimate_queue_status(db, provider=...)` now narrows the recent-rate sample to the active inference provider, falling back to all-providers when there's no provider-matching history yet.
- The Queue line is now tagged with the active provider — e.g. `Est. 12m 00s (remote)` / `(local)` — so the basis of the estimate is visible in the message.
- Settings changes propagate naturally: each emission re-reads settings, so the next notification reflects the new provider.

## Files
- `apps/pipeline/app/services/notification_runtime.py` — provider-narrowed sampling + fallback; emit helpers resolve the active provider via `get_runtime_inference_settings`.
- `apps/pipeline/app/services/notification_events.py` — `queue_estimate_provider` field on `EpisodeDoneEvent` / `EpisodeFailedEvent`.
- `apps/pipeline/app/services/digest.py` — reuses the existing `get_notification_settings` call to read the active provider; passes it through.
- `apps/pipeline/app/services/notifications.py` — `_provider_tag` + `_fmt_estimate_with_provider` helpers; Queue lines append the tag.
- `apps/pipeline/app/services/digest_formatters.py` — same tag in digest output.

## Test plan
- [x] `pytest tests/unit/` — 685 passed (+4 new tests for provider-narrowed sampling, all-providers fallback, and the `(local)` / `(remote)` Telegram tag)
- [ ] Verify a real Telegram notification once a queued episode finishes — Queue line should read `Est. … (local)` or `Est. … (remote)` matching the current Settings value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)