### PR TITLE
feat(web): copy-to-clipboard button for episode ID (#599)

### DIFF
--- a/apps/web/src/app/episodes/[id]/page.tsx
+++ b/apps/web/src/app/episodes/[id]/page.tsx
@@ -11,6 +11,7 @@ import TranscriptSection from "@/components/TranscriptSection";
 import BackToSearchLink from "@/components/BackToSearchLink";
 import EpisodeChat from "@/components/EpisodeChat";
 import EpisodeMetaTags from "@/components/EpisodeMetaTags";
+import CopyIdButton from "@/components/CopyIdButton";
 
 export const dynamic = "force-dynamic";
 
@@ -148,7 +149,10 @@ export default async function EpisodePage({ params }: { params: Promise<{ id: st
           </Link>
         )}
         <div className="mt-2 space-y-2">
-          <h1 className="text-xl font-semibold">{episode.title ?? "Untitled Episode"}</h1>
+          <div className="flex items-start gap-1.5">
+            <h1 className="text-xl font-semibold">{episode.title ?? "Untitled Episode"}</h1>
+            <CopyIdButton value={episode.id} label="Copy episode ID" />
+          </div>
           <EpisodeMetaTags
             status={episode.status}
             publishedAt={episode.published_at}

--- a/apps/web/src/components/CopyIdButton.tsx
+++ b/apps/web/src/components/CopyIdButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+interface CopyIdButtonProps {
+  value: string;
+  label?: string;
+}
+
+export default function CopyIdButton({ value, label = "Copy ID" }: CopyIdButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function onClick() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable (insecure context, denied permission). No-op.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={copied ? "Copied" : label}
+      aria-label={copied ? "Copied" : label}
+      className="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+    >
+      {copied ? (
+        <Check size={14} className="text-green-600 dark:text-green-400" />
+      ) : (
+        <Copy size={14} />
+      )}
+    </button>
+  );
+}

--- a/apps/web/tests/unit/copy-id-button.test.tsx
+++ b/apps/web/tests/unit/copy-id-button.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CopyIdButton from "@/components/CopyIdButton";
+
+function mockClipboard(impl: jest.Mock) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: impl },
+    configurable: true,
+  });
+}
+
+describe("CopyIdButton", () => {
+  it("writes the value to the clipboard and flashes a confirmation", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    render(<CopyIdButton value="abc-123" label="Copy episode ID" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy episode ID" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("abc-123");
+      expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    });
+  });
+
+  it("reverts the confirmation after the timeout elapses", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    render(<CopyIdButton value="abc-123" label="Copy episode ID" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy episode ID" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument()
+    );
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole("button", { name: "Copy episode ID" })).toBeInTheDocument(),
+      { timeout: 3000 }
+    );
+  });
+
+  it("silently no-ops when the clipboard API rejects", async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+
+    render(<CopyIdButton value="xyz" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy ID" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("xyz"));
+    // Stays in the default state — no "Copied" flash
+    expect(screen.getByRole("button", { name: "Copy ID" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #599.

## Summary
- New `<CopyIdButton>` client component renders a small icon-only button (`lucide-react` `Copy` → `Check`) that writes the episode UUID to the clipboard.
- Wired into the episode-page header, sitting flush next to the H1 title. Muted by default, swaps to a green check for 1.5s after a successful copy. Silent no-op when the Clipboard API is unavailable (insecure context, denied permission).
- Generic enough to reuse anywhere we want a "copy this opaque identifier" affordance — the component is named `CopyIdButton` and accepts any `value` + custom `label`.

## Test plan
- [x] Unit tests (`apps/web/tests/unit/copy-id-button.test.tsx`): writes the value to clipboard, flips to "Copied" state, reverts after timeout, no-ops on rejection — 3 tests.
- [x] Full web jest suite: 537 passed.
- [x] `tsc --noEmit` clean.
- [x] ESLint clean (the only finding is a pre-existing `<img>` warning unrelated to this change).
- [x] Live verification: `curl http://localhost:3000/episodes/<uuid>` returns the rendered button with `aria-label="Copy episode ID"`.
- [ ] Manual browser sanity check (skipped — Chrome not installed in this dev sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)