### PR TITLE
feat(pipeline): classify Fireworks SSL upload-aborts as non-retryable (#600)

### DIFF
--- a/apps/pipeline/app/services/fireworks_audio.py
+++ b/apps/pipeline/app/services/fireworks_audio.py
@@ -49,6 +49,33 @@ def _classify_http_error(status_code: int) -> tuple[str, bool]:
     return "HTTP_ACCESS", True
 
 
+def _is_upload_rejected_signature(error_text: str) -> bool:
+    """Return True when a network error looks like an upstream proxy abort.
+
+    Fireworks (or its CDN) closes the TLS connection mid-upload when the
+    request exceeds an undocumented size/duration limit. The client sees a
+    TLS-layer alert — most commonly ``BAD_RECORD_MAC`` — instead of a clean
+    HTTP 413/400. Repeated retries with backoff hit the same wall, so it's
+    pointless to keep uploading; the user needs to know the file should be
+    transcribed locally instead. See issue #600.
+    """
+    needles = ("BAD_RECORD_MAC", "SSLV3_ALERT_BAD_RECORD_MAC")
+    return any(n in error_text for n in needles)
+
+
+def _format_upload_rejected_message(audio_path: str, original_error: str) -> str:
+    try:
+        size_bytes = Path(audio_path).stat().st_size
+        size_mb = size_bytes / (1024 * 1024)
+        size_str = f"{size_mb:.0f} MB"
+    except OSError:
+        size_str = "unknown size"
+    return (
+        f"Fireworks rejected the upload (likely size/duration cap on a {size_str} file). "
+        f"Re-run this episode on local inference. Underlying error: {original_error}"
+    )
+
+
 def transcribe(
     audio_path: str,
     *,
@@ -94,8 +121,15 @@ def transcribe(
                 retryable=True,
             ) from exc
         except httpx.NetworkError as exc:
+            error_text = str(exc)
+            if _is_upload_rejected_signature(error_text):
+                raise FireworksTranscriptionError(
+                    _format_upload_rejected_message(audio_path, error_text),
+                    error_class="FIREWORKS_UPLOAD_REJECTED",
+                    retryable=False,
+                ) from exc
             raise FireworksTranscriptionError(
-                f"Fireworks network error: {exc}",
+                f"Fireworks network error: {error_text}",
                 error_class="TRANSIENT_NETWORK",
                 retryable=True,
             ) from exc

--- a/apps/pipeline/app/services/notifications.py
+++ b/apps/pipeline/app/services/notifications.py
@@ -241,8 +241,31 @@ def format_done_telegram(event: EpisodeDoneEvent) -> str:
     )
 
 
+def _fmt_action_required_html(event: EpisodeFailedEvent) -> str:
+    """Render a yellow call-to-action banner for failures the user must act on."""
+    if event.error_class != "FIREWORKS_UPLOAD_REJECTED":
+        return ""
+    return (
+        '  <div style="margin-top: 16px; padding: 12px; border-radius: 6px; '
+        'background: #fef3c7; color: #78350f; border: 1px solid #fbbf24;">'
+        '<strong>Action required:</strong> Fireworks rejected this upload. '
+        'Re-enqueue this episode against local inference to process it.'
+        "</div>"
+    )
+
+
+def _fmt_action_required_telegram(event: EpisodeFailedEvent) -> str:
+    if event.error_class != "FIREWORKS_UPLOAD_REJECTED":
+        return ""
+    return (
+        "\n\n*⚠️ Action required:* Fireworks rejected this upload. "
+        "Re-enqueue this episode against local inference to process it."
+    )
+
+
 def format_failed_html(event: EpisodeFailedEvent) -> str:
     avg_html = _fmt_avg_section_html(event)
+    action_html = _fmt_action_required_html(event)
     return f"""\
 <html>
 <body style="font-family: -apple-system, Arial, sans-serif; color: #222; max-width: 520px; margin: 0 auto; padding: 16px;">
@@ -269,6 +292,7 @@ def format_failed_html(event: EpisodeFailedEvent) -> str:
     <tr><td style="padding: 4px 12px; color: #666;">Retries</td>
         <td style="padding: 4px 12px;">{event.retry_count}/{event.retry_max}</td></tr>
   </table>
+{action_html}
 {avg_html}
   <h3 style="margin-top: 20px; margin-bottom: 8px;">Queue Status</h3>
   <table style="border-collapse: collapse; width: 100%;">
@@ -286,6 +310,7 @@ def format_failed_html(event: EpisodeFailedEvent) -> str:
 
 def format_failed_telegram(event: EpisodeFailedEvent) -> str:
     avg_section = _fmt_avg_section_telegram(event)
+    action_section = _fmt_action_required_telegram(event)
     return (
         f"*❌ Episode Failed*\n\n"
         f"*Podcast:* {event.podcast_title}\n"
@@ -295,7 +320,8 @@ def format_failed_telegram(event: EpisodeFailedEvent) -> str:
         f"*Error*\n"
         f"`Class:    {event.error_class}`\n"
         f"`Details:  {event.error_message}`\n"
-        f"`Retries:  {event.retry_count}/{event.retry_max}`\n"
+        f"`Retries:  {event.retry_count}/{event.retry_max}`"
+        f"{action_section}\n"
         f"{avg_section}\n"
         f"*Queue:* {event.queue_remaining} remaining · Est. {_fmt_estimate_with_provider(event.queue_estimated_secs, getattr(event, 'queue_estimate_provider', None))}"
     )

--- a/apps/pipeline/app/tasks/helpers.py
+++ b/apps/pipeline/app/tasks/helpers.py
@@ -35,7 +35,7 @@ def mark_failed(db, episode_id: str, error_class: str, error_message: str) -> No
     # Emit failure notification on terminal failure:
     # - retries exhausted, OR
     # - non-retryable error class (DISK_FULL, OOM, SYSTEM_ERROR from zombies)
-    _NON_RETRYABLE = {"DISK_FULL", "OOM", "SYSTEM_ERROR"}
+    _NON_RETRYABLE = {"DISK_FULL", "OOM", "SYSTEM_ERROR", "FIREWORKS_UPLOAD_REJECTED"}
     episode = db.query(Episode).filter(Episode.id == episode_id).first()
     if episode and (error_class in _NON_RETRYABLE or episode.retry_count >= episode.retry_max):
         emit_episode_failed_event(

--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -137,7 +137,17 @@ def transcribe_episode(episode_id: str) -> str:
                         error_msg=str(exc),
                     )
                 else:
-                    _mark_failed(db, episode_id, exc.error_class, str(exc))
+                    msg = str(exc)
+                    if exc.error_class == "FIREWORKS_UPLOAD_REJECTED" and episode.duration_secs:
+                        h, rem = divmod(int(episode.duration_secs), 3600)
+                        m, _ = divmod(rem, 60)
+                        dur = f"{h}h {m:02d}m" if h else f"{m}m"
+                        msg = msg.replace(
+                            "Re-run this episode on local inference.",
+                            f"Episode is {dur} long. Re-run this episode on local inference.",
+                            1,
+                        )
+                    _mark_failed(db, episode_id, exc.error_class, msg)
                 logger.warning(
                     '"action": "fireworks_transcribe_error", "episode_id": "%s", '
                     '"error_class": "%s", "retryable": %s, "error": "%s"',

--- a/apps/pipeline/tests/unit/test_fireworks_audio_service.py
+++ b/apps/pipeline/tests/unit/test_fireworks_audio_service.py
@@ -229,6 +229,57 @@ def test_classify_http_error_marks_4xx_as_http_access_retryable():
     assert _classify_http_error(403) == ("HTTP_ACCESS", True)
 
 
+def test_transcribe_classifies_bad_record_mac_as_upload_rejected(tmp_path: Path):
+    """SSL `BAD_RECORD_MAC` mid-upload means an upstream proxy aborted us — issue #600."""
+    audio_path = tmp_path / "sample.mp3"
+    audio_path.write_bytes(b"x" * (5 * 1024 * 1024))  # 5 MB so the message has a real size
+
+    with patch("app.services.fireworks_audio.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.NetworkError(
+            "[SSL: SSLV3_ALERT_BAD_RECORD_MAC] ssl/tls alert bad record mac (_ssl.c:2590)"
+        )
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+
+        with pytest.raises(FireworksTranscriptionError) as excinfo:
+            transcribe(
+                str(audio_path),
+                api_key="fw_test",
+                audio_base_url="https://audio-turbo.api.fireworks.ai",
+                model_name="whisper-v3-large",
+                diarize=True,
+            )
+
+    exc = excinfo.value
+    assert exc.error_class == "FIREWORKS_UPLOAD_REJECTED"
+    assert exc.retryable is False
+    assert "Re-run this episode on local inference" in str(exc)
+    assert "5 MB" in str(exc)
+
+
+def test_transcribe_keeps_generic_network_error_as_transient(tmp_path: Path):
+    """Plain network errors without the SSL signature stay TRANSIENT_NETWORK."""
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"fake-audio")
+
+    with patch("app.services.fireworks_audio.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.NetworkError("connection reset by peer")
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+
+        with pytest.raises(FireworksTranscriptionError) as excinfo:
+            transcribe(
+                str(audio_path),
+                api_key="fw_test",
+                audio_base_url="https://audio-turbo.api.fireworks.ai",
+                model_name="whisper-v3-large",
+                diarize=True,
+            )
+
+    assert excinfo.value.error_class == "TRANSIENT_NETWORK"
+    assert excinfo.value.retryable is True
+
+
 def test_transcribe_wraps_429_as_retryable(tmp_path: Path):
     audio_path = tmp_path / "sample.wav"
     audio_path.write_bytes(b"fake-audio")

--- a/apps/pipeline/tests/unit/test_notification_formatting.py
+++ b/apps/pipeline/tests/unit/test_notification_formatting.py
@@ -81,6 +81,35 @@ def test_format_done_telegram_estimate_tagged_with_active_provider():
     assert "(local)" in md_local.split("Queue:")[1]
 
 
+def test_format_failed_html_action_banner_for_upload_rejected():
+    """Issue #600: distinct banner when Fireworks rejects the upload."""
+    event = _make_failed_event()
+    event.error_class = "FIREWORKS_UPLOAD_REJECTED"
+    html = format_failed_html(event)
+    assert "Action required" in html
+    assert "local inference" in html
+
+
+def test_format_failed_html_no_action_banner_for_generic_failures():
+    event = _make_failed_event()  # error_class="OOM"
+    html = format_failed_html(event)
+    assert "Action required" not in html
+
+
+def test_format_failed_telegram_action_banner_for_upload_rejected():
+    event = _make_failed_event()
+    event.error_class = "FIREWORKS_UPLOAD_REJECTED"
+    md = format_failed_telegram(event)
+    assert "Action required" in md
+    assert "local inference" in md
+
+
+def test_format_failed_telegram_no_action_banner_for_generic_failures():
+    event = _make_failed_event()
+    md = format_failed_telegram(event)
+    assert "Action required" not in md
+
+
 def test_format_done_telegram_estimate_no_tag_when_provider_unknown():
     event = _make_done_event()
     event.queue_estimate_provider = None

--- a/apps/pipeline/tests/unit/test_task_transcribe.py
+++ b/apps/pipeline/tests/unit/test_task_transcribe.py
@@ -303,6 +303,66 @@ class TestTranscribeEpisode:
     @patch("app.tasks.transcribe.update_episode")
     @patch("app.tasks.transcribe._convert_to_wav")
     @patch("app.tasks.transcribe.SessionLocal")
+    def test_fireworks_upload_rejected_fails_immediately_with_duration(
+        self, mock_session_cls, mock_convert, mock_update, mock_fail, mock_jq
+    ):
+        """Issue #600: FIREWORKS_UPLOAD_REJECTED skips the retry loop and surfaces duration."""
+        ep = _make_episode()
+        ep.retry_count = 0
+        ep.retry_max = 3
+        ep.duration_secs = 8388  # 2h 19m, the original incident
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = ep
+        mock_session_cls.return_value = db
+
+        with (
+            patch(
+                "app.services.fireworks_audio.transcribe",
+                side_effect=FireworksTranscriptionError(
+                    "Fireworks rejected the upload (likely size/duration cap on a 192 MB file). "
+                    "Re-run this episode on local inference. Underlying error: BAD_RECORD_MAC",
+                    error_class="FIREWORKS_UPLOAD_REJECTED",
+                    retryable=False,
+                ),
+            ),
+            patch(
+                "app.tasks.transcribe.get_runtime_inference_settings",
+                return_value={
+                    "inference_provider": "fireworks",
+                    "fireworks_api_key": "fw_test",
+                    "fireworks_audio_base_url": "https://audio-turbo.api.fireworks.ai",
+                    "fireworks_stt_model": "whisper-v3-large",
+                    "fireworks_stt_diarize": True,
+                    "fireworks_stt_cost_per_minute_usd": 0.006,
+                },
+            ),
+            patch("app.tasks.transcribe.settings") as mock_settings,
+        ):
+            mock_settings.retry_backoff_base = 30
+            mock_settings.retry_max = 3
+            mock_settings.fireworks_stt_model = "whisper-v3-large"
+            mock_settings.fireworks_audio_base_url = "https://audio-turbo.api.fireworks.ai"
+            mock_settings.fireworks_stt_cost_per_minute_usd = 0.006
+
+            from app.tasks.transcribe import transcribe_episode
+
+            result = transcribe_episode("ep1")
+
+        assert result == "ep1"
+        mock_convert.assert_not_called()
+        # Crucial: no retry enqueued — this is the regression we're guarding against.
+        mock_jq.enqueue.assert_not_called()
+        mock_fail.assert_called_once()
+        assert mock_fail.call_args[0][2] == "FIREWORKS_UPLOAD_REJECTED"
+        # The message should carry the duration so the user knows what they're re-running.
+        assert "2h 19m" in mock_fail.call_args[0][3]
+        assert "Re-run this episode on local inference" in mock_fail.call_args[0][3]
+
+    @patch("app.tasks.transcribe.job_queue")
+    @patch("app.tasks.transcribe._mark_failed")
+    @patch("app.tasks.transcribe.update_episode")
+    @patch("app.tasks.transcribe._convert_to_wav")
+    @patch("app.tasks.transcribe.SessionLocal")
     def test_fireworks_import_failure_marks_system_error(
         self, mock_session_cls, mock_convert, mock_update, mock_fail, mock_jq
     ):


### PR DESCRIPTION
Closes #600.

## Summary
- Detect the `BAD_RECORD_MAC` / `SSLV3_ALERT_BAD_RECORD_MAC` signature inside `httpx.NetworkError` in `fireworks_audio.transcribe`. When matched, raise `FireworksTranscriptionError` with a new `error_class="FIREWORKS_UPLOAD_REJECTED"` and `retryable=False`.
- Add `FIREWORKS_UPLOAD_REJECTED` to the `_NON_RETRYABLE` set in `tasks/helpers.py`, so the failure notification fires on the very first occurrence instead of after three more 192 MB retry uploads.
- The base error message includes the rejected file's size (read from disk in the service). The transcribe task enriches it with the episode's duration before passing to `_mark_failed`, producing a final message like:
  > Fireworks rejected the upload (likely size/duration cap on a 192 MB file). Episode is 2h 19m long. Re-run this episode on local inference.
- Notification templates (HTML email + Telegram Markdown) render a distinct **Action required** banner only when `error_class == "FIREWORKS_UPLOAD_REJECTED"` — visually separates "wait for retry" from "I need to do something."

## Out of scope (per the issue)
- Per-episode "re-run with provider X" UI button.
- Auto-failover from remote → local.
- Long-episode chunking on Fireworks.
- A general "detect repeated identical errors and stop retrying" mechanism.

## Test plan
- [x] `test_transcribe_classifies_bad_record_mac_as_upload_rejected` — feeds `httpx.NetworkError("[SSL: SSLV3_ALERT_BAD_RECORD_MAC] …")` through `transcribe()` and asserts the new class, `retryable=False`, and the actionable message including file size.
- [x] `test_transcribe_keeps_generic_network_error_as_transient` — guards against over-classification: a plain `connection reset by peer` still maps to `TRANSIENT_NETWORK`.
- [x] `test_fireworks_upload_rejected_fails_immediately_with_duration` — at task level, asserts `job_queue.enqueue` is **not** called (no retry burned) and the final message includes `2h 19m`.
- [x] Four notification-formatting tests — banner appears for the new class in both HTML + Telegram, doesn't appear for generic failures.
- [x] `pytest tests/unit/` — 693 passed (+7 new), 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)