### PR TITLE
fix(archive): surface ffmpeg stderr tail in compression failure (#597)

### DIFF
--- a/apps/pipeline/app/tasks/archive.py
+++ b/apps/pipeline/app/tasks/archive.py
@@ -119,6 +119,9 @@ def archive_episode(episode_id: str) -> str:
         db.close()
 
 
+_FFMPEG_STDERR_TAIL_BYTES = 1024
+
+
 def _compress_audio(raw_path: Path, episode_id: str) -> Path:
     import ffmpeg
 
@@ -135,11 +138,24 @@ def _compress_audio(raw_path: Path, episode_id: str) -> Path:
         )
         return dest
 
-    ffmpeg.input(str(raw_path)).output(
-        str(dest),
-        audio_bitrate=settings.audio_archive_bitrate,
-        acodec="libmp3lame",
-    ).overwrite_output().run(capture_stdout=True, capture_stderr=True)
+    try:
+        ffmpeg.input(str(raw_path)).output(
+            str(dest),
+            audio_bitrate=settings.audio_archive_bitrate,
+            acodec="libmp3lame",
+        ).overwrite_output().run(capture_stdout=True, capture_stderr=True)
+    except ffmpeg.Error as exc:
+        # Issue #597: ffmpeg.Error.__str__ deliberately tells you to look at the
+        # stderr attribute. Surface the tail of stderr in the error message so
+        # the failure row in job_queue is debuggable instead of the useless
+        # "see stderr output for detail".
+        stderr_tail = ""
+        if exc.stderr:
+            decoded = exc.stderr.decode(errors="replace").strip()
+            stderr_tail = decoded[-_FFMPEG_STDERR_TAIL_BYTES:]
+        raise RuntimeError(
+            f"ffmpeg failed compressing {raw_path.name}: {stderr_tail or 'no stderr captured'}"
+        ) from exc
 
     return dest
 

--- a/apps/pipeline/tests/unit/test_task_archive.py
+++ b/apps/pipeline/tests/unit/test_task_archive.py
@@ -185,6 +185,69 @@ class TestArchiveEpisode:
         assert archive_file.exists(), "archive file must not be deleted on re-run"
         assert archive_file.read_bytes() == b"real-archive-bytes"
 
+    def test_compress_surfaces_ffmpeg_stderr_in_runtime_error(self, tmp_path):
+        """Issue #597: ffmpeg.Error must be re-raised with the stderr tail in the message."""
+        import ffmpeg
+
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        raw = tmp_path / "raw" / "ep1.mp3"
+        raw.parent.mkdir()
+        raw.write_bytes(b"not-actually-audio")
+
+        # The stderr that python-ffmpeg's Error.stderr would carry on a real failure.
+        fake_stderr = (
+            b"ffmpeg version 6.0 Copyright (c) 2000-2023\n"
+            b"[mp3 @ 0x55e0f7] Header missing\n"
+            b"[in#0 @ 0x55e000] Error opening input: Invalid data found when processing input\n"
+        )
+        boom = ffmpeg.Error("ffmpeg", b"", fake_stderr)
+
+        with patch("app.tasks.archive.settings") as mock_settings:
+            mock_settings.audio_archive_dir = str(archive_dir)
+            mock_settings.audio_archive_bitrate = "64k"
+
+            with patch.object(ffmpeg.nodes.OutputStream, "run", side_effect=boom):
+                from app.tasks.archive import _compress_audio
+
+                with pytest.raises(RuntimeError) as excinfo:
+                    _compress_audio(raw, "ep1")
+
+        msg = str(excinfo.value)
+        assert "ep1.mp3" in msg
+        assert "Invalid data found when processing input" in msg
+        # The original ffmpeg.Error is preserved as the cause for traceability.
+        assert isinstance(excinfo.value.__cause__, ffmpeg.Error)
+
+    def test_compress_truncates_long_ffmpeg_stderr(self, tmp_path):
+        """Stderr tail is bounded so a chatty ffmpeg run doesn't bloat the DB row."""
+        import ffmpeg
+
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+        raw = tmp_path / "raw" / "ep2.mp3"
+        raw.parent.mkdir()
+        raw.write_bytes(b"x")
+
+        long_stderr = (b"chatty ffmpeg log line\n" * 5000) + b"FINAL_DIAGNOSTIC_LINE\n"
+        boom = ffmpeg.Error("ffmpeg", b"", long_stderr)
+
+        with patch("app.tasks.archive.settings") as mock_settings:
+            mock_settings.audio_archive_dir = str(archive_dir)
+            mock_settings.audio_archive_bitrate = "64k"
+
+            with patch.object(ffmpeg.nodes.OutputStream, "run", side_effect=boom):
+                from app.tasks.archive import _compress_audio
+
+                with pytest.raises(RuntimeError) as excinfo:
+                    _compress_audio(raw, "ep2")
+
+        msg = str(excinfo.value)
+        # The most recent line — what you'd actually want to see — is preserved.
+        assert "FINAL_DIAGNOSTIC_LINE" in msg
+        # And the message is bounded.
+        assert len(msg) < 2_000
+
     def test_compress_skips_when_already_in_archive_dir(self, tmp_path):
         """_compress_audio should skip ffmpeg when source is already the dest."""
         archive_dir = tmp_path / "archive"


### PR DESCRIPTION
Closes #597.

## Summary
- \`_compress_audio\` now wraps the ffmpeg \`.run()\` call in \`try/except ffmpeg.Error\`, decodes \`exc.stderr\` (replacing undecodable bytes), keeps the last 1 KB, and re-raises as \`RuntimeError\` with that tail in the message. The original \`ffmpeg.Error\` is preserved as \`__cause__\` so tracebacks still surface it.
- The 1 KB cap means a chatty ffmpeg run can't bloat the \`job_queue.error\` column. The tail is the part you actually want — the most recent line is almost always the diagnostic.
- The existing \`OSError\` → \`DISK_FULL\` catch upstream is untouched. Disk-full surfaces as \`OSError\` from the syscall, not from ffmpeg.
- Per the issue: no retry-classification changes. Most ffmpeg failures are permanent (corrupt source) or environmental (disk, codecs); just preserve the diagnostic.

## Test plan
- [x] \`test_compress_surfaces_ffmpeg_stderr_in_runtime_error\` — feeds a fake \`ffmpeg.Error\` with a realistic stderr through \`_compress_audio\`, asserts the resulting \`RuntimeError\` carries the diagnostic line, includes the file name, and chains the original \`ffmpeg.Error\` as \`__cause__\`.
- [x] \`test_compress_truncates_long_ffmpeg_stderr\` — feeds 5000 chatty lines + a final marker, asserts the marker is preserved and the message is bounded under 2 KB.
- [x] \`pytest tests/unit/\` — 695 passed (+2 new), 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)