### PR TITLE
docs: add CHANGELOG.md and render it on the /about page (#596)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,67 @@
+name: Changelog
+
+# Per CLAUDE.md: PRs that ship user-visible behavior must add a one-line
+# entry to CHANGELOG.md under [Unreleased]. This workflow enforces that
+# discipline at the PR level.
+#
+# Escape hatch: add the `no-changelog` label to a PR that genuinely
+# doesn't need an entry — typo fixes, README-only edits, dependency-bot
+# auto-bumps, CI pipeline tweaks, etc. The label opts the PR out cleanly
+# without requiring a `--no-verify`-style override.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-touched:
+    name: CHANGELOG.md updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if PR has the no-changelog label
+        if: contains(github.event.pull_request.labels.*.name, 'no-changelog')
+        run: |
+          echo "PR has the 'no-changelog' label — skipping CHANGELOG.md check."
+          exit 0
+
+      - name: Checkout PR with full history
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify CHANGELOG.md was touched
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Find the merge-base so the diff reflects only this PR's changes.
+          base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          if git diff --name-only "$base" "$HEAD_SHA" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md was updated."
+            exit 0
+          fi
+          cat <<'EOF' >&2
+
+          ❌ This PR does not touch CHANGELOG.md.
+
+          Add a one-line entry under [Unreleased] in CHANGELOG.md describing
+          what changed, grouped under Major changes / Minor changes / Fixes
+          (or Internal where appropriate). The entry should read like a
+          release note, not a commit message.
+
+          If this PR genuinely does not need a changelog entry (typo fix,
+          dep bump, CI tweak, etc.), add the 'no-changelog' label to the PR
+          and re-run this check.
+
+          See CHANGELOG.md and CLAUDE.md > Conventions for the format.
+          EOF
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,22 @@ fresh empty `[Unreleased]` is left at the top.
 
 ### Fixes
 - Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))
-- CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. ([#594](https://github.com/brlauuu/podlog/pull/594) follow-up)
+- CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. (commit `21629cb`)
 
 ### Internal
 - Periodic cleanup task that prunes superseded `failed` rows in `job_queue` (rows whose episode later succeeded). Runs every 24 h; clears noise from the queue dashboard's "failed" counter. ([#604](https://github.com/brlauuu/podlog/pull/604))
+- New "Changelog" CI check fails any PR that doesn't touch `CHANGELOG.md`; opt out per-PR with the `no-changelog` label. ([#605](https://github.com/brlauuu/podlog/pull/605))
+
+### Other minor changes
+- Zod runtime validation for the settings response. ([#588](https://github.com/brlauuu/podlog/pull/588))
+- Keyword search across docs. ([#589](https://github.com/brlauuu/podlog/pull/589))
+- Filter podcast episodes list by speaker name. ([#593](https://github.com/brlauuu/podlog/pull/593))
+- Format all dates as DD/MM/YYYY app-wide. ([#594](https://github.com/brlauuu/podlog/pull/594))
+
+### Other fixes
+- Remove "Large tiles" option from podcasts list. ([#585](https://github.com/brlauuu/podlog/pull/585))
+- Surface unavailable audio in the player + add a recovery script. ([#586](https://github.com/brlauuu/podlog/pull/586))
+- Exclude `tests/**` from base tsconfig so `tsc --noEmit` passes. ([#587](https://github.com/brlauuu/podlog/pull/587))
 
 ## [0.3.0] — 2026-04-24
 
@@ -43,6 +55,28 @@ fresh empty `[Unreleased]` is left at the top.
 - Inference service split into focused modules; queue read path moved to pipeline API. ([#577](https://github.com/brlauuu/podlog/pull/577), [#578](https://github.com/brlauuu/podlog/pull/578))
 - Recharts upgraded 2 → 3. ([#575](https://github.com/brlauuu/podlog/pull/575))
 - New e2e coverage for queue, meta-analysis, Ask AI, and SSR pages. ([#582](https://github.com/brlauuu/podlog/pull/582), [#583](https://github.com/brlauuu/podlog/pull/583))
+
+### Other fixes
+- Center text in Search and Ask search bars. ([#584](https://github.com/brlauuu/podlog/pull/584))
+
+### Docs
+- Refresh CLAUDE.md repo structure + current state. ([#557](https://github.com/brlauuu/podlog/pull/557))
+- Refresh README versions + Meta-Analysis feature. ([#558](https://github.com/brlauuu/podlog/pull/558))
+- Sync dev guide + user guide with current codebase. ([#559](https://github.com/brlauuu/podlog/pull/559))
+- Reflect shipped features in PRD roadmaps. ([#560](https://github.com/brlauuu/podlog/pull/560))
+
+### Tests
+- Cover low-coverage pipeline modules. ([#563](https://github.com/brlauuu/podlog/pull/563))
+- Cover meta-analysis + pipeline/ask API routes. ([#568](https://github.com/brlauuu/podlog/pull/568))
+- Cover lib helpers (db, filterOpts, mentions, grouped). ([#570](https://github.com/brlauuu/podlog/pull/570))
+- Cover simple UI components. ([#571](https://github.com/brlauuu/podlog/pull/571))
+- Cover meta-analysis chart transforms + render smoke. ([#572](https://github.com/brlauuu/podlog/pull/572))
+- Cover EpisodeChat UI states and submit error paths. ([#573](https://github.com/brlauuu/podlog/pull/573))
+
+### Other internal
+- Remove orphan nightly-audit script. ([#561](https://github.com/brlauuu/podlog/pull/561))
+- Remove unused web params, imports, and props. ([#562](https://github.com/brlauuu/podlog/pull/562))
+- Bump web patch/minor deps. ([#574](https://github.com/brlauuu/podlog/pull/574))
 
 ## [0.2.0] — 2026-04-24
 
@@ -71,6 +105,12 @@ fresh empty `[Unreleased]` is left at the top.
 - `feed_speaker_cache` UUID inserts no longer cast to text, fixing pipeline boot under PostgreSQL 15. ([#532](https://github.com/brlauuu/podlog/pull/532))
 - Confidence reconciliation in `merge_candidates` no longer demotes high-confidence inferences. ([#534](https://github.com/brlauuu/podlog/pull/534))
 - `PYANNOTE_MODEL` resolves the correct repo id, with an actionable error message when HF auth is missing. ([#539](https://github.com/brlauuu/podlog/pull/539))
+
+### Other minor changes
+- Add Explore button to landing page. ([#535](https://github.com/brlauuu/podlog/pull/535))
+
+### Other fixes
+- Preserve unicode characters in export filenames. ([#540](https://github.com/brlauuu/podlog/pull/540))
 
 ## [0.1.1] — 2026-04-07
 
@@ -111,6 +151,105 @@ fresh empty `[Unreleased]` is left at the top.
 - CI enforces test coverage thresholds (pipeline 82%, web via `coverageThreshold`). ([#483](https://github.com/brlauuu/podlog/pull/483))
 - "Operational Gotchas" section added to `CLAUDE.md` so issues like the UUID cast that bit us in #532 don't repeat. ([#533](https://github.com/brlauuu/podlog/pull/533))
 
+### Other minor changes
+- Upgrade landing page branding and CTA. ([#292](https://github.com/brlauuu/podlog/pull/292))
+- Persist Ask/Search state across navigation. ([#293](https://github.com/brlauuu/podlog/pull/293))
+- Stabilize Ask layout and add help popover. ([#295](https://github.com/brlauuu/podlog/pull/295))
+- Declare numpy as a direct Poetry dependency. ([#299](https://github.com/brlauuu/podlog/pull/299))
+- Integrate healthcheck tests into the supported unit-test layout. ([#300](https://github.com/brlauuu/podlog/pull/300))
+- Refresh CLAUDE.md to match current repo state. ([#301](https://github.com/brlauuu/podlog/pull/301))
+- Prune unused dependencies and exports. ([#305](https://github.com/brlauuu/podlog/pull/305))
+- Add copyright disclaimer to README and About page. ([#317](https://github.com/brlauuu/podlog/pull/317))
+- Center landing page hero block in viewport. ([#331](https://github.com/brlauuu/podlog/pull/331))
+- Monochrome action system + centralized action color. ([#333](https://github.com/brlauuu/podlog/pull/333))
+- Improve UI of episodes page. ([#363](https://github.com/brlauuu/podlog/pull/363))
+- UI fix for episode page navigation. ([#364](https://github.com/brlauuu/podlog/pull/364))
+- Update README credits with linked agents and platforms. ([#383](https://github.com/brlauuu/podlog/pull/383))
+- UI tag and inference label adjustments on podcast episodes. ([#388](https://github.com/brlauuu/podlog/pull/388))
+- Remove episode count from Ask page help hover. ([#400](https://github.com/brlauuu/podlog/pull/400))
+- Update About-page credits to match README format. ([#406](https://github.com/brlauuu/podlog/pull/406))
+- Revert About page to `max-w-2xl` width. ([#435](https://github.com/brlauuu/podlog/pull/435))
+- Remove width cap on docs page to maximise content column. ([#442](https://github.com/brlauuu/podlog/pull/442))
+- Match "Manage feeds" button styling to "Upload audio". ([#462](https://github.com/brlauuu/podlog/pull/462))
+- Compact Sources section buttons + podcast count. ([#464](https://github.com/brlauuu/podlog/pull/464))
+
+### Other fixes
+- Episode nav placement and help dropdown opacity. ([#247](https://github.com/brlauuu/podlog/pull/247))
+- Wizard dismiss on step-2 skip; tests aligned. ([#253](https://github.com/brlauuu/podlog/pull/253))
+- Skip archive compression when source is already in the archive directory. ([#266](https://github.com/brlauuu/podlog/pull/266))
+- Ask "source play" action now starts embedded audio. ([#294](https://github.com/brlauuu/podlog/pull/294))
+- Standardize Ask timestamp deep-links. ([#303](https://github.com/brlauuu/podlog/pull/303))
+- Repair pipeline container test harness. ([#308](https://github.com/brlauuu/podlog/pull/308))
+- Spinner layout shift on Search and Ask. ([#316](https://github.com/brlauuu/podlog/pull/316))
+- Wizard skip/completion navigation regressions. ([#336](https://github.com/brlauuu/podlog/pull/336))
+- Selective-episodes dialog overflow and speaker-click re-scroll. ([#348](https://github.com/brlauuu/podlog/pull/348))
+- Speaker tags on podcast episode list. ([#379](https://github.com/brlauuu/podlog/pull/379))
+- Docs tab markdown link resolution. ([#381](https://github.com/brlauuu/podlog/pull/381))
+- Inference tags now render with the requested colors. ([#397](https://github.com/brlauuu/podlog/pull/397))
+- Load the `/docs` listing at runtime. ([#404](https://github.com/brlauuu/podlog/pull/404))
+- Explicit speaker actions and direct inferred-name confirmation. ([#405](https://github.com/brlauuu/podlog/pull/405))
+- Stabilize Node runtime checks and outdated-package workflow. ([#413](https://github.com/brlauuu/podlog/pull/413))
+- About page spans content full width. ([#434](https://github.com/brlauuu/podlog/pull/434))
+- Align docs TOC with navbar edge and stretch content. ([#440](https://github.com/brlauuu/podlog/pull/440))
+- Float episode Ask button above audio player. ([#451](https://github.com/brlauuu/podlog/pull/451))
+- Stack floating buttons above audio player (follow-up to #448). ([#453](https://github.com/brlauuu/podlog/pull/453))
+- Serialize feed `id` as text in `GET /api/feeds`. ([#456](https://github.com/brlauuu/podlog/pull/456))
+- Raise Ask download dropdown above chat panel. ([#463](https://github.com/brlauuu/podlog/pull/463))
+
+### Docs
+- Fix RAG, lifecycle, and health-check config accuracy. ([#251](https://github.com/brlauuu/podlog/pull/251))
+- Refresh stale search paths and test count references. ([#252](https://github.com/brlauuu/podlog/pull/252))
+- Clarify audit workflows and findings lifecycle. ([#254](https://github.com/brlauuu/podlog/pull/254))
+- Refresh README/docs freshness on latest main. ([#269](https://github.com/brlauuu/podlog/pull/269))
+- Sync routes and Ask config. ([#306](https://github.com/brlauuu/podlog/pull/306))
+- Align CLAUDE.md claims with current codebase. ([#334](https://github.com/brlauuu/podlog/pull/334))
+- Align stage/status docs and make `test-unit` scope match reality. ([#335](https://github.com/brlauuu/podlog/pull/335))
+- Fix CLAUDE and audit-spec stale claims. ([#415](https://github.com/brlauuu/podlog/pull/415))
+- Deprecate obsolete worker-splitting spec. ([#416](https://github.com/brlauuu/podlog/pull/416))
+- Update CLAUDE.md and fix stale documentation. ([#482](https://github.com/brlauuu/podlog/pull/482))
+- Fix PRD/CLAUDE.md drift. ([#500](https://github.com/brlauuu/podlog/pull/500))
+
+### Tests
+- Improve coverage for audio player context. ([#249](https://github.com/brlauuu/podlog/pull/249))
+- Wizard regression coverage. ([#307](https://github.com/brlauuu/podlog/pull/307))
+- Targeted pipeline coverage for failure paths. ([#309](https://github.com/brlauuu/podlog/pull/309))
+- Restore runnable Playwright e2e setup. ([#310](https://github.com/brlauuu/podlog/pull/310))
+- Use full web coverage denominator. ([#311](https://github.com/brlauuu/podlog/pull/311))
+- Targeted coverage for queue/search/speaker and pipeline embed flows. ([#339](https://github.com/brlauuu/podlog/pull/339))
+- Fix CI failures from pyannote soundfile import and Ask floating button. ([#465](https://github.com/brlauuu/podlog/pull/465))
+- Fix integration tests for CI Slow. ([#466](https://github.com/brlauuu/podlog/pull/466))
+- Cover audio route with full handler tests. ([#505](https://github.com/brlauuu/podlog/pull/505))
+- Cover 5 zero-coverage proxy API routes. ([#506](https://github.com/brlauuu/podlog/pull/506))
+- Cover 6 more zero-coverage proxy routes. ([#507](https://github.com/brlauuu/podlog/pull/507))
+- Cover `api/queue` route. ([#508](https://github.com/brlauuu/podlog/pull/508))
+- Cover episode mutation routes incl. transactional merge. ([#509](https://github.com/brlauuu/podlog/pull/509))
+- Cover simple components, pages, and grouping helper. ([#510](https://github.com/brlauuu/podlog/pull/510))
+- Cover FeedCard and FeedsListSection. ([#511](https://github.com/brlauuu/podlog/pull/511))
+- Split long test files per scenario. ([#512](https://github.com/brlauuu/podlog/pull/512))
+
+### Other internal
+- Clean dead code and wire healthcheck tests. ([#250](https://github.com/brlauuu/podlog/pull/250))
+- Add minimal GitHub Actions workflow for test freshness. ([#270](https://github.com/brlauuu/podlog/pull/270))
+- Refactor notification runtime/event modules and split settings UI. ([#313](https://github.com/brlauuu/podlog/pull/313))
+- Refactor search and queue logic boundaries. ([#314](https://github.com/brlauuu/podlog/pull/314))
+- Align local Node requirements with Next.js 16. ([#337](https://github.com/brlauuu/podlog/pull/337))
+- Remove dead stubs and unused exports. ([#338](https://github.com/brlauuu/podlog/pull/338))
+- Remove orphan CSS declaration and redundant UI exports. ([#414](https://github.com/brlauuu/podlog/pull/414))
+- Extract FeedCard from feeds page. ([#418](https://github.com/brlauuu/podlog/pull/418))
+- Extract NotificationSection cards. ([#419](https://github.com/brlauuu/podlog/pull/419))
+- Extract RemoteInferenceSection parts. ([#420](https://github.com/brlauuu/podlog/pull/420))
+- Extract top controls from search page. ([#421](https://github.com/brlauuu/podlog/pull/421))
+- Extract inference text helpers. ([#429](https://github.com/brlauuu/podlog/pull/429))
+- Extract digest formatter helpers. ([#430](https://github.com/brlauuu/podlog/pull/430))
+- Split search page pagination and empty state. ([#432](https://github.com/brlauuu/podlog/pull/432))
+- Remove orphaned wizard/help-menu dead code and unused test fixtures. ([#480](https://github.com/brlauuu/podlog/pull/480))
+- Remove orphaned root `package-lock.json`. ([#481](https://github.com/brlauuu/podlog/pull/481))
+- Extract shared search filter builders from `search.ts`. ([#484](https://github.com/brlauuu/podlog/pull/484))
+- Extract task registry from `worker.py`. ([#485](https://github.com/brlauuu/podlog/pull/485))
+- Un-export page-state snapshot types. ([#501](https://github.com/brlauuu/podlog/pull/501))
+- Bump minor/patch npm deps. ([#502](https://github.com/brlauuu/podlog/pull/502))
+- Split `search.ts` into per-function modules. ([#504](https://github.com/brlauuu/podlog/pull/504))
+
 ## [0.1.0] — 2026-04-04
 
 ### Major changes
@@ -141,6 +280,41 @@ fresh empty `[Unreleased]` is left at the top.
 - Feedless episodes included in search results. ([#129](https://github.com/brlauuu/podlog/pull/129))
 - Wizard UX bugs — close button, Get Started navigation, test-mode color, skip-to-completion flow. ([#153](https://github.com/brlauuu/podlog/pull/153), [#196](https://github.com/brlauuu/podlog/pull/196), [#302](https://github.com/brlauuu/podlog/pull/302), [#304](https://github.com/brlauuu/podlog/pull/304))
 
+### Other minor changes
+- UI tweaks — prominent titles, navbar About, inline search tips. ([#221](https://github.com/brlauuu/podlog/pull/221))
+- Add avg episode length and processing factor to notifications. ([#230](https://github.com/brlauuu/podlog/pull/230))
+
+### Other fixes
+- Add missing `notification_log` migration. ([#126](https://github.com/brlauuu/podlog/pull/126))
+- Repair test harness env vars and broken service. ([#127](https://github.com/brlauuu/podlog/pull/127))
+- Type annotations, status comment, and embedding status tracking. ([#132](https://github.com/brlauuu/podlog/pull/132))
+- Correct failing web tests for path traversal and grouped search. ([#148](https://github.com/brlauuu/podlog/pull/148))
+- Add `torchaudio` as an explicit dependency. ([#155](https://github.com/brlauuu/podlog/pull/155))
+- Resolve remaining #104 review findings (notifications + test stack). ([#164](https://github.com/brlauuu/podlog/pull/164))
+- Fix episode page navigation ordering. ([#231](https://github.com/brlauuu/podlog/pull/231))
+- Fix PRD staleness in PRD-02 and PRD-04. ([#241](https://github.com/brlauuu/podlog/pull/241))
+- Fix PIPELINE_API vs PIPELINE_API_URL inconsistency. ([#242](https://github.com/brlauuu/podlog/pull/242))
+- Fix wizard accessibility and API compliance gaps. ([#243](https://github.com/brlauuu/podlog/pull/243))
+
+### Docs
+- Update stale CLAUDE.md to current reality. ([#130](https://github.com/brlauuu/podlog/pull/130))
+- Update CLAUDE.md to match current codebase. ([#149](https://github.com/brlauuu/podlog/pull/149))
+- Update all PRDs to match current codebase. ([#150](https://github.com/brlauuu/podlog/pull/150))
+- Fix test counts and add missing Ollama service. ([#154](https://github.com/brlauuu/podlog/pull/154))
+- Fix stale documentation across CLAUDE.md, README, PRDs, and guides. ([#195](https://github.com/brlauuu/podlog/pull/195))
+- Document Codex and Claude audit workflows. ([#232](https://github.com/brlauuu/podlog/pull/232))
+- CLAUDE.md accuracy sweep. ([#245](https://github.com/brlauuu/podlog/pull/245))
+
+### Tests
+- Add 62 pipeline unit tests for uncovered files. ([#159](https://github.com/brlauuu/podlog/pull/159))
+- Improve coverage for episodes API, RAG service, WizardAddFeed. ([#200](https://github.com/brlauuu/podlog/pull/200))
+
+### Other internal
+- Remove unused `soundfile` dependency. ([#156](https://github.com/brlauuu/podlog/pull/156))
+- npm cleanup — remove unused packages, bump `lucide-react` and `tailwind-merge`. ([#157](https://github.com/brlauuu/podlog/pull/157))
+- Remove unused `@types/dompurify`, add explicit `pydantic` dep. ([#199](https://github.com/brlauuu/podlog/pull/199))
+- Bump `@tanstack/react-query` floor to ^5.96.2. ([#227](https://github.com/brlauuu/podlog/pull/227))
+
 ## [0.0.0] — 2026-03-14 to 2026-04-03 (pre-versioning)
 
 The pre-versioning era — initial scaffold and the bulk of foundational features. Not a single release; every notable user-facing addition during this window is bucketed here under one heading.
@@ -161,7 +335,7 @@ The pre-versioning era — initial scaffold and the bulk of foundational feature
 - **Comprehensive user guide** added at `docs/guide`. ([#109](https://github.com/brlauuu/podlog/pull/109))
 
 ### Internal — major architectural simplification (Phase 0–4)
-The early stack was inherited from a more complex design. PRs [#62](https://github.com/brlauuu/podlog/pull/62)–[#65](https://github.com/brlauuu/podlog/pull/65) reduced operational overhead substantially:
+The early stack was inherited from a more complex design. PRs [#62](https://github.com/brlauuu/podlog/pull/62), [#63](https://github.com/brlauuu/podlog/pull/63), [#64](https://github.com/brlauuu/podlog/pull/64), [#65](https://github.com/brlauuu/podlog/pull/65) reduced operational overhead substantially:
 
 - **Phase 0–1**: bug fixes and code deduplication.
 - **Phase 2**: container consolidation (8 services → 5).
@@ -176,6 +350,30 @@ The early stack was inherited from a more complex design. PRs [#62](https://gith
 - Notification settings persist across page revisits. ([#100](https://github.com/brlauuu/podlog/pull/100))
 - Healthcheck Telegram 400 Bad Request. ([#122](https://github.com/brlauuu/podlog/pull/122))
 - Path-traversal protection on the audio route. ([#34](https://github.com/brlauuu/podlog/pull/34))
+
+### Other minor changes
+- Add processing duration tracking for transcribe and diarize tasks. ([#19](https://github.com/brlauuu/podlog/pull/19))
+- Add landing page branding, footer, and O'Saasy license. ([#21](https://github.com/brlauuu/podlog/pull/21))
+- Restyle footer and theme to match blog, add per-service health. ([#26](https://github.com/brlauuu/podlog/pull/26))
+- Link `brlauuu` references to GitHub Pages blog. ([#29](https://github.com/brlauuu/podlog/pull/29))
+- Preserve search query for back-navigation from episode page. ([#43](https://github.com/brlauuu/podlog/pull/43))
+- Install spaCy model in pipeline Docker image. ([#50](https://github.com/brlauuu/podlog/pull/50))
+- Link queue items to episode page. ([#75](https://github.com/brlauuu/podlog/pull/75))
+- Skip `COUNT(*)` query on search page 2+. ([#76](https://github.com/brlauuu/podlog/pull/76))
+- Episode selection when adding a feed; fix test-mode ordering. ([#86](https://github.com/brlauuu/podlog/pull/86))
+
+### Other fixes
+- Retry endpoint for stalled jobs. ([#52](https://github.com/brlauuu/podlog/pull/52))
+- Loading feedback on the "Poll Now" button. ([#73](https://github.com/brlauuu/podlog/pull/73))
+- Queue page reads `job_queue` for active/pending state. ([#99](https://github.com/brlauuu/podlog/pull/99))
+- Notification processing total. ([#107](https://github.com/brlauuu/podlog/pull/107))
+
+### Docs
+- Rewrite README and add project documentation. ([#79](https://github.com/brlauuu/podlog/pull/79))
+- Health-monitoring setup and `postgresql-client` prerequisite. ([#121](https://github.com/brlauuu/podlog/pull/121))
+
+### Other internal
+- Split Celery worker into heavy and light queues (later removed in Phase 3). ([#51](https://github.com/brlauuu/podlog/pull/51))
 
 [Unreleased]: https://github.com/brlauuu/podlog/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/brlauuu/podlog/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,187 @@
+# Changelog
+
+All notable changes to Podlog are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Pre-v1 versions follow `0.x.y` and may break compatibility between minor bumps.
+
+Each release section groups changes as:
+
+- **Major changes** — new features users will notice
+- **Minor changes** — refinements, performance work, smaller UX wins
+- **Fixes** — bug fixes
+- (Optional) **Internal** — refactors, infra, dev tooling
+
+<!--
+Contributing: every PR with user-visible behavior should add a one-line entry
+under the appropriate `[Unreleased]` heading below. When a release is cut via
+the `release` skill, `[Unreleased]` graduates to a dated version section and a
+fresh empty `[Unreleased]` is left at the top.
+-->
+
+## [Unreleased]
+
+### Major changes
+- Per-active-provider queue ETA in notifications. The "Est. time left" line in episode notifications now uses the rate of episodes processed by whichever inference provider is currently configured, and tags the line with `(local)` or `(remote)` so the basis is visible. ([#595](https://github.com/brlauuu/podlog/pull/595))
+- Distinct error class for Fireworks upload rejections. When Fireworks aborts an upload at the TLS layer (typically size/duration cap), the failure is classified as `FIREWORKS_UPLOAD_REJECTED`, the retry loop is skipped, and notifications carry an "Action required: re-run on local inference" call-to-action. ([#602](https://github.com/brlauuu/podlog/pull/602))
+
+### Minor changes
+- Copy-to-clipboard button for the episode UUID on the episode page. Subtle icon next to the title. ([#601](https://github.com/brlauuu/podlog/pull/601))
+
+### Fixes
+- Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))
+- CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. ([#594](https://github.com/brlauuu/podlog/pull/594) follow-up)
+
+### Internal
+- Periodic cleanup task that prunes superseded `failed` rows in `job_queue` (rows whose episode later succeeded). Runs every 24 h; clears noise from the queue dashboard's "failed" counter. ([#604](https://github.com/brlauuu/podlog/pull/604))
+
+## [0.3.0] — 2026-04-24
+
+### Major changes
+- **pyannote.ai Precision-2 cloud diarization** as an alternative to local pyannote, selectable per environment via `DIARIZATION_PROVIDER=precision2`. Includes a settings UI, per-episode cost capture (`pyannote_cloud_cost_usd`), and a new `RISK-11` write-up. ([#541](https://github.com/brlauuu/podlog/pull/541), [#542](https://github.com/brlauuu/podlog/pull/542), [#543](https://github.com/brlauuu/podlog/pull/543), [#544](https://github.com/brlauuu/podlog/pull/544))
+
+### Internal
+- Inference service split into focused modules; queue read path moved to pipeline API. ([#577](https://github.com/brlauuu/podlog/pull/577), [#578](https://github.com/brlauuu/podlog/pull/578))
+- Recharts upgraded 2 → 3. ([#575](https://github.com/brlauuu/podlog/pull/575))
+- New e2e coverage for queue, meta-analysis, Ask AI, and SSR pages. ([#582](https://github.com/brlauuu/podlog/pull/582), [#583](https://github.com/brlauuu/podlog/pull/583))
+
+## [0.2.0] — 2026-04-24
+
+### Major changes
+- **Meta-Analysis dashboard** at `/meta-analysis`. Cross-feed metrics — episode counts, durations, words-per-minute, turn density, host/guest share, processing time, token and cost totals — with drill-down charts. ([#538](https://github.com/brlauuu/podlog/pull/538))
+
+## [0.1.3] — 2026-04-20
+
+### Major changes
+- **Gemma 4 e4b** model option for the Ask AI feature, with per-model `num_ctx` so each model can use its full context window. ([#519](https://github.com/brlauuu/podlog/pull/519))
+
+### Minor changes
+- Provider-scoped notification averages and per-episode processing factor — averages no longer mix local and remote runs. ([#522](https://github.com/brlauuu/podlog/pull/522))
+
+### Fixes
+- Ask AI now recovers gracefully from Ollama memory-cap OOMs (unloads cached models and retries once). ([#520](https://github.com/brlauuu/podlog/pull/520))
+- Pipeline boots cleanly under torchaudio 2.8 — pyannote audio-loading restored. ([#447](https://github.com/brlauuu/podlog/pull/447))
+
+## [0.1.2] — 2026-04-20
+
+### Major changes
+- **Upgrade pyannote diarization to community-1** (from `speaker-diarization-3.1`). Requires a fresh model download on first run. ([#517](https://github.com/brlauuu/podlog/pull/517))
+- **Host/guest speaker name inference** (PRD-04) now ships end to end: ships `en_core_web_trf` by default, parses RSS `<podcast:person>` tags, applies an episode-title heuristic, a recurring-host rule, and a per-feed speaker name cache so renames carry across episodes in the same feed. ([#525](https://github.com/brlauuu/podlog/pull/525), [#526](https://github.com/brlauuu/podlog/pull/526), [#527](https://github.com/brlauuu/podlog/pull/527), [#529](https://github.com/brlauuu/podlog/pull/529), [#531](https://github.com/brlauuu/podlog/pull/531))
+
+### Fixes
+- `feed_speaker_cache` UUID inserts no longer cast to text, fixing pipeline boot under PostgreSQL 15. ([#532](https://github.com/brlauuu/podlog/pull/532))
+- Confidence reconciliation in `merge_candidates` no longer demotes high-confidence inferences. ([#534](https://github.com/brlauuu/podlog/pull/534))
+- `PYANNOTE_MODEL` resolves the correct repo id, with an actionable error message when HF auth is missing. ([#539](https://github.com/brlauuu/podlog/pull/539))
+
+## [0.1.1] — 2026-04-07
+
+### Major changes
+- **Fireworks AI remote-inference profile** — opt-in alternative to local processing for users who can't or don't want to run Whisper, pyannote, or Ollama locally. Covers transcription/diarization, embeddings, Ask AI generation, retries, observability (latency + cost), and a `docker-compose.remote.yml` overlay. ([#256](https://github.com/brlauuu/podlog/pull/256), [#262](https://github.com/brlauuu/podlog/pull/262), [#263](https://github.com/brlauuu/podlog/pull/263), [#265](https://github.com/brlauuu/podlog/pull/265), [#267](https://github.com/brlauuu/podlog/pull/267), [#268](https://github.com/brlauuu/podlog/pull/268))
+- **Manual upload path in first-run onboarding** — start without an RSS feed at all. ([#312](https://github.com/brlauuu/podlog/pull/312))
+- **Settings page redesign** with notifications and remote-inference sections, two-tab layout, per-tab save buttons. ([#343](https://github.com/brlauuu/podlog/pull/343), [#382](https://github.com/brlauuu/podlog/pull/382))
+- **Speaker filter for search and Ask** — restrict results to specific speakers. ([#353](https://github.com/brlauuu/podlog/pull/353))
+- **Scoped search** for title / description / speaker with metadata-only mode and pagination. ([#365](https://github.com/brlauuu/podlog/pull/365), [#366](https://github.com/brlauuu/podlog/pull/366))
+- **In-app docs tab** with markdown navigation, replacing the first-run wizard's standalone help. ([#361](https://github.com/brlauuu/podlog/pull/361), [#385](https://github.com/brlauuu/podlog/pull/385), [#438](https://github.com/brlauuu/podlog/pull/438), [#444](https://github.com/brlauuu/podlog/pull/444))
+- **Episode-scoped Ask AI chat** — ask questions against a single episode and get word-level citations. ([#202](https://github.com/brlauuu/podlog/pull/202), [#460](https://github.com/brlauuu/podlog/pull/460))
+- **Per-step diarization timing breakdowns** — see exactly where pyannote is spending its time on each episode. ([#352](https://github.com/brlauuu/podlog/pull/352))
+- **MP4 audio uploads**, modal upload + search + rich cards on the Sources page, delete button for manual uploads. ([#443](https://github.com/brlauuu/podlog/pull/443), [#458](https://github.com/brlauuu/podlog/pull/458), [#461](https://github.com/brlauuu/podlog/pull/461))
+- **Selective feeds: add more episodes** to a feed already in selective mode without re-onboarding it. ([#513](https://github.com/brlauuu/podlog/pull/513))
+
+### Minor changes
+- Markdown and PDF export options on episode pages. ([#255](https://github.com/brlauuu/podlog/pull/255))
+- Theme-aware logos and unified search bar across Search and Ask. ([#296](https://github.com/brlauuu/podlog/pull/296), [#332](https://github.com/brlauuu/podlog/pull/332))
+- Episode-card redesign with tag-based metadata strip; provider tag colors set to violet/teal. ([#362](https://github.com/brlauuu/podlog/pull/362), [#380](https://github.com/brlauuu/podlog/pull/380), [#409](https://github.com/brlauuu/podlog/pull/409))
+- Source-page header gets podcast image, website, and description. ([#431](https://github.com/brlauuu/podlog/pull/431))
+- View-mode toggle (list/grid/large tiles) on the Sources page. ([#514](https://github.com/brlauuu/podlog/pull/514))
+- About page rewrite, refreshed README/docs to match shipped behavior. ([#407](https://github.com/brlauuu/podlog/pull/407), [#446](https://github.com/brlauuu/podlog/pull/446))
+
+### Fixes
+- Fireworks segments rebuilt from word-level speaker data and split at sentence boundaries — closer parity with the local provider. ([#354](https://github.com/brlauuu/podlog/pull/354), [#359](https://github.com/brlauuu/podlog/pull/359))
+- Reprocessing an episode now resets `inference_provider_used`, so a remote → local switch is reflected in the next run. ([#437](https://github.com/brlauuu/podlog/pull/437))
+- Archive no longer deletes the archive file when re-running archive on an already-compressed file. ([#449](https://github.com/brlauuu/podlog/pull/449))
+- Ask SSE proxy no longer crashes on client disconnect. ([#450](https://github.com/brlauuu/podlog/pull/450))
+- Ask scoped to a single episode skips the similarity threshold so short episodes still surface citations. ([#452](https://github.com/brlauuu/podlog/pull/452))
+- Episode page back-to-search link, prev/next nav arrows, and tag chip heights — many small alignment fixes. ([#389](https://github.com/brlauuu/podlog/pull/389), [#390](https://github.com/brlauuu/podlog/pull/390), [#401](https://github.com/brlauuu/podlog/pull/401), [#408](https://github.com/brlauuu/podlog/pull/408), [#411](https://github.com/brlauuu/podlog/pull/411))
+- Filter loading and confirmed-speaker sourcing on search no longer race. ([#410](https://github.com/brlauuu/podlog/pull/410))
+- Popovers, dropdowns, and selects are opaque (was: see-through over content). ([#428](https://github.com/brlauuu/podlog/pull/428))
+- Worker startup validates the task registry and fails loudly if a handler reference is broken. ([#297](https://github.com/brlauuu/podlog/pull/297))
+
+### Internal
+- React 18 → 19, Next.js 14 → 16, Tailwind 3 → 4, ESLint 8 → 9, TypeScript 5.x → 6.0, jest 29 → 30. ([#213](https://github.com/brlauuu/podlog/pull/213), [#224](https://github.com/brlauuu/podlog/pull/224), [#226](https://github.com/brlauuu/podlog/pull/226), [#229](https://github.com/brlauuu/podlog/pull/229), [#503](https://github.com/brlauuu/podlog/pull/503))
+- Pipeline API split from worker task wiring; web search library, settings UI, feeds page, and notification settings extracted into focused modules. ([#341](https://github.com/brlauuu/podlog/pull/341), [#342](https://github.com/brlauuu/podlog/pull/342), [#417](https://github.com/brlauuu/podlog/pull/417)–[#422](https://github.com/brlauuu/podlog/pull/422), [#427](https://github.com/brlauuu/podlog/pull/427)–[#433](https://github.com/brlauuu/podlog/pull/433))
+- CI enforces test coverage thresholds (pipeline 82%, web via `coverageThreshold`). ([#483](https://github.com/brlauuu/podlog/pull/483))
+- "Operational Gotchas" section added to `CLAUDE.md` so issues like the UUID cast that bit us in #532 don't repeat. ([#533](https://github.com/brlauuu/podlog/pull/533))
+
+## [0.1.0] — 2026-04-04
+
+### Major changes
+- **Versioning system** introduced — single-source `VERSION` file at the repo root, surfaced in the navbar/About page. ([#162](https://github.com/brlauuu/podlog/pull/162))
+- **Ask AI (RAG)** — natural-language Q&A over the transcript library, citation-backed and streamed. Ollama by default, Fireworks AI optional. Includes the `/api/ask` SSE endpoint, the `/ask` UI, episode-feed-filtered citations, and the segment-chunking pipeline step that feeds it. ([#124](https://github.com/brlauuu/podlog/pull/124), [#133](https://github.com/brlauuu/podlog/pull/133), [#134](https://github.com/brlauuu/podlog/pull/134), [#135](https://github.com/brlauuu/podlog/pull/135), [#137](https://github.com/brlauuu/podlog/pull/137), [#176](https://github.com/brlauuu/podlog/pull/176), [#202](https://github.com/brlauuu/podlog/pull/202))
+- **Drag-and-drop audio upload** path on the web UI. ([#166](https://github.com/brlauuu/podlog/pull/166))
+- **Backfill task** for embedding existing segments + progress tracking, so older episodes become Ask-able. ([#163](https://github.com/brlauuu/podlog/pull/163))
+- **Search results show full speaker segments** (not just the matched line). ([#183](https://github.com/brlauuu/podlog/pull/183))
+- **Reprocess button** on episode pages — wipe and re-run an episode without dropping the row. ([#74](https://github.com/brlauuu/podlog/pull/74))
+- **Speaker filter on episode page** + back-to-top button. ([#209](https://github.com/brlauuu/podlog/pull/209))
+- **Home page** with a clear search/ask split; landing page cleanup. ([#203](https://github.com/brlauuu/podlog/pull/203), [#208](https://github.com/brlauuu/podlog/pull/208))
+- **Health check UI toggle** + Telegram alert refinements. ([#160](https://github.com/brlauuu/podlog/pull/160))
+- **Sources renamed from Podcasts**, with an Uploads section. ([#178](https://github.com/brlauuu/podlog/pull/178))
+
+### Minor changes
+- Persistent audio player gets a close button and conditional bottom padding. ([#207](https://github.com/brlauuu/podlog/pull/207))
+- Prev/next episode navigation. ([#175](https://github.com/brlauuu/podlog/pull/175))
+- Footer simplified, About page added, system status moved to a help menu. ([#212](https://github.com/brlauuu/podlog/pull/212))
+- Processing-status pill on episodes; unprocessed episodes excluded from search results. ([#165](https://github.com/brlauuu/podlog/pull/165))
+
+### Fixes
+- Allow reprocessing of `done` episodes; allow retrying stuck/orphaned episodes. ([#173](https://github.com/brlauuu/podlog/pull/173), [#179](https://github.com/brlauuu/podlog/pull/179))
+- Convert non-WAV audio to WAV before diarization (fixes pyannote OOM on certain inputs). ([#177](https://github.com/brlauuu/podlog/pull/177))
+- Vector cast syntax error on Ask page. ([#180](https://github.com/brlauuu/podlog/pull/180))
+- Improved Ask page error handling for Ollama failures. ([#184](https://github.com/brlauuu/podlog/pull/184))
+- Notification download failures normalized; channels properly isolated. ([#119](https://github.com/brlauuu/podlog/pull/119), [#131](https://github.com/brlauuu/podlog/pull/131))
+- Audio route contract tightened (path traversal protection). ([#128](https://github.com/brlauuu/podlog/pull/128))
+- Feedless episodes included in search results. ([#129](https://github.com/brlauuu/podlog/pull/129))
+- Wizard UX bugs — close button, Get Started navigation, test-mode color, skip-to-completion flow. ([#153](https://github.com/brlauuu/podlog/pull/153), [#196](https://github.com/brlauuu/podlog/pull/196), [#302](https://github.com/brlauuu/podlog/pull/302), [#304](https://github.com/brlauuu/podlog/pull/304))
+
+## [0.0.0] — 2026-03-14 to 2026-04-03 (pre-versioning)
+
+The pre-versioning era — initial scaffold and the bulk of foundational features. Not a single release; every notable user-facing addition during this window is bucketed here under one heading.
+
+### Major changes
+- **Initial pipeline**: WhisperX transcription with `large-v3-turbo`, pyannote `speaker-diarization-3.1` for diarization, word-level speaker alignment, segment persistence, manual retry. ([#16](https://github.com/brlauuu/podlog/pull/16), [#18](https://github.com/brlauuu/podlog/pull/18))
+- **Web UI**: search page (full-text), episode page with audio player, queue dashboard, feed management, episodes list with sortable columns. ([#17](https://github.com/brlauuu/podlog/pull/17), [#20](https://github.com/brlauuu/podlog/pull/20), [#22](https://github.com/brlauuu/podlog/pull/22), [#31](https://github.com/brlauuu/podlog/pull/31), [#40](https://github.com/brlauuu/podlog/pull/40))
+- **TEST podcast mode** — sample 5 episodes from a feed before committing to full ingestion. ([#28](https://github.com/brlauuu/podlog/pull/28))
+- **Hybrid search**: full-text keyword + pgvector semantic similarity merged via Reciprocal Rank Fusion; websearch syntax (`"exact phrase"`, `OR`, `-exclude`); trigram fallback. ([#78](https://github.com/brlauuu/podlog/pull/78))
+- **Episode-centric search** with dialogue context and rich export (markdown, plain text, PDF). ([#41](https://github.com/brlauuu/podlog/pull/41), [#72](https://github.com/brlauuu/podlog/pull/72), [#80](https://github.com/brlauuu/podlog/pull/80), [#81](https://github.com/brlauuu/podlog/pull/81))
+- **Search results aggregated by speaker turn** instead of per-segment. ([#71](https://github.com/brlauuu/podlog/pull/71))
+- **Queue dashboard improvements**: grouping by podcast/status/stage, Kanban board view, per-stage filtering. ([#40](https://github.com/brlauuu/podlog/pull/40), [#45](https://github.com/brlauuu/podlog/pull/45), [#70](https://github.com/brlauuu/podlog/pull/70), [#89](https://github.com/brlauuu/podlog/pull/89))
+- **Notifications system** (event-driven): Telegram + email channels, per-episode done/failed events, frequency modes (immediate/daily/weekly digest), multi-recipient email with validation, processing-time stats inside the message. ([#93](https://github.com/brlauuu/podlog/pull/93), [#95](https://github.com/brlauuu/podlog/pull/95), [#106](https://github.com/brlauuu/podlog/pull/106), [#113](https://github.com/brlauuu/podlog/pull/113))
+- **First-run setup wizard** to walk a fresh installation through configuration. ([#110](https://github.com/brlauuu/podlog/pull/110))
+- **Host-level health monitoring** with Telegram alerts (catches issues outside the docker stack itself). ([#120](https://github.com/brlauuu/podlog/pull/120))
+- **Speaker labels redesigned** as chat-style bubbles with a speaker panel; consecutive same-speaker labels collapse; speakers numbered by first appearance. ([#48](https://github.com/brlauuu/podlog/pull/48), [#49](https://github.com/brlauuu/podlog/pull/49), [#53](https://github.com/brlauuu/podlog/pull/53))
+- **Episode descriptions** rendered as HTML, with clickable timestamp deep-links. ([#30](https://github.com/brlauuu/podlog/pull/30), [#42](https://github.com/brlauuu/podlog/pull/42))
+- **Comprehensive user guide** added at `docs/guide`. ([#109](https://github.com/brlauuu/podlog/pull/109))
+
+### Internal — major architectural simplification (Phase 0–4)
+The early stack was inherited from a more complex design. PRs [#62](https://github.com/brlauuu/podlog/pull/62)–[#65](https://github.com/brlauuu/podlog/pull/65) reduced operational overhead substantially:
+
+- **Phase 0–1**: bug fixes and code deduplication.
+- **Phase 2**: container consolidation (8 services → 5).
+- **Phase 3**: replaced Celery + Redis with a PostgreSQL-backed job queue (concurrency=1 to prevent OOM on small machines).
+- **Phase 4**: narrowed FastAPI to a control-plane role (web app reads the DB directly for search, calls the API only for state-changing ops).
+
+### Fixes
+- Audio player progress updates and seek controls. ([#83](https://github.com/brlauuu/podlog/pull/83))
+- Avg processing time and queue ETA no longer inflated by queue wait time. ([#123](https://github.com/brlauuu/podlog/pull/123))
+- Archive status persistence; safe deletion of raw audio after archive. ([#87](https://github.com/brlauuu/podlog/pull/87))
+- `host.docker.internal` resolves on Linux for email notifications. ([#103](https://github.com/brlauuu/podlog/pull/103))
+- Notification settings persist across page revisits. ([#100](https://github.com/brlauuu/podlog/pull/100))
+- Healthcheck Telegram 400 Bad Request. ([#122](https://github.com/brlauuu/podlog/pull/122))
+- Path-traversal protection on the audio route. ([#34](https://github.com/brlauuu/podlog/pull/34))
+
+[Unreleased]: https://github.com/brlauuu/podlog/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/brlauuu/podlog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/brlauuu/podlog/compare/v0.1.3...v0.2.0
+[0.1.3]: https://github.com/brlauuu/podlog/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/brlauuu/podlog/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/brlauuu/podlog/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/brlauuu/podlog/releases/tag/v0.1.0
+[0.0.0]: https://github.com/brlauuu/podlog/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Services: web (:3000), pipeline API (:8000), ollama (:11434).
   - Web: `jest` + `@testing-library/react` for unit, `playwright` for e2e.
 - **PRD references:** When implementing a feature, cite the PRD section (e.g. "per PRD-02 §5.6") in code comments only where the requirement is non-obvious.
 - **When modifying the design:** Update the relevant PRD and RISKS-AND-GAPS.md. Bump the version number.
+- **Changelog:** PRs that ship user-visible behavior add a one-line entry to `CHANGELOG.md` under `[Unreleased]`, grouped as Major / Minor / Fixes (or Internal where appropriate). The same file is rendered at the bottom of `/about` in the web app, so write entries for a human reading them there.
 
 ## Operational Gotchas
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ See [docs/configuration.md](docs/configuration.md) for the full list of all envi
 
 | Document | Description |
 |---|---|
+| [Changelog](CHANGELOG.md) | Notable changes per release. Also rendered at the bottom of the in-app About page. |
 | [User Guide](docs/guide/) | Step-by-step guide for new users: setup, features, configuration |
 | [Configuration](docs/configuration.md) | All environment variables with defaults and explanations |
 | [Hardware Guide](docs/hardware.md) | System requirements, processing benchmarks, tested machine specs |

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -6,39 +6,46 @@ import rehypeRaw from "rehype-raw";
 
 export const dynamic = "force-dynamic";
 
-export default async function AboutPage() {
-  const aboutPath = join(process.cwd(), "..", "..", "docs", "about.md");
-
-  let content: string | null = null;
+async function readDocOrNull(filename: string): Promise<string | null> {
+  const path = join(process.cwd(), "..", "..", "docs", filename);
   try {
-    content = await readFile(aboutPath, "utf-8");
+    return await readFile(path, "utf-8");
   } catch {
-    content = null;
+    return null;
   }
+}
+
+const markdownComponents = {
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+    const external = typeof href === "string" && /^https?:\/\//i.test(href);
+    return (
+      <a
+        href={href}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noopener noreferrer" : undefined}
+      >
+        {children}
+      </a>
+    );
+  },
+};
+
+export default async function AboutPage() {
+  const [aboutContent, changelogContent] = await Promise.all([
+    readDocOrNull("about.md"),
+    readDocOrNull("CHANGELOG.md"),
+  ]);
 
   return (
-    <div className="mx-auto w-full max-w-2xl py-4">
-      {content ? (
+    <div className="mx-auto w-full max-w-2xl py-4 space-y-10">
+      {aboutContent ? (
         <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeRaw]}
-            components={{
-              a: ({ href, children }) => {
-                const external = typeof href === "string" && /^https?:\/\//i.test(href);
-                return (
-                  <a
-                    href={href}
-                    target={external ? "_blank" : undefined}
-                    rel={external ? "noopener noreferrer" : undefined}
-                  >
-                    {children}
-                  </a>
-                );
-              },
-            }}
+            components={markdownComponents}
           >
-            {content}
+            {aboutContent}
           </ReactMarkdown>
         </article>
       ) : (
@@ -46,6 +53,20 @@ export default async function AboutPage() {
           <h1 className="text-2xl font-bold mb-3">About</h1>
           <p>Could not load the About page.</p>
         </div>
+      )}
+
+      {changelogContent && (
+        <section className="border-t pt-8">
+          <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              components={markdownComponents}
+            >
+              {changelogContent}
+            </ReactMarkdown>
+          </article>
+        </section>
       )}
     </div>
   );

--- a/apps/web/tests/unit/about-page.test.tsx
+++ b/apps/web/tests/unit/about-page.test.tsx
@@ -61,7 +61,11 @@ beforeEach(() => {
 
 describe("<AboutPage>", () => {
   it("marks external links with target=_blank and rel=noopener", async () => {
-    mockReadFile.mockResolvedValue("See [example](https://example.com/x).");
+    // First call resolves about.md; second resolves CHANGELOG.md to empty so
+    // the test asserts on a single link from the about content.
+    mockReadFile
+      .mockResolvedValueOnce("See [example](https://example.com/x).")
+      .mockRejectedValueOnce(new Error("ENOENT"));
 
     const jsx = await AboutPage();
     render(jsx);
@@ -72,7 +76,9 @@ describe("<AboutPage>", () => {
   });
 
   it("does not set target/rel for relative links", async () => {
-    mockReadFile.mockResolvedValue("See [docs](/docs) for more.");
+    mockReadFile
+      .mockResolvedValueOnce("See [docs](/docs) for more.")
+      .mockRejectedValueOnce(new Error("ENOENT"));
 
     const jsx = await AboutPage();
     render(jsx);
@@ -83,7 +89,9 @@ describe("<AboutPage>", () => {
   });
 
   it("renders the fallback block when about.md is missing", async () => {
-    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    mockReadFile
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockRejectedValueOnce(new Error("ENOENT"));
 
     const jsx = await AboutPage();
     render(jsx);
@@ -92,5 +100,33 @@ describe("<AboutPage>", () => {
     expect(
       screen.getByText("Could not load the About page.")
     ).toBeInTheDocument();
+  });
+
+  it("renders the changelog section after the about content", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("About body.")
+      .mockResolvedValueOnce("# Changelog\n\nSee [v1](https://example.com/v1).");
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    // Both about and changelog content are rendered as separate markdown blocks.
+    const blocks = screen.getAllByTestId("markdown");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toHaveTextContent("About body.");
+    expect(blocks[1]).toHaveTextContent("v1");
+  });
+
+  it("hides the changelog section when CHANGELOG.md is missing", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("About body.")
+      .mockRejectedValueOnce(new Error("ENOENT"));
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    const blocks = screen.getAllByTestId("markdown");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toHaveTextContent("About body.");
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - audio_data:/data/audio:ro
       - ./docs/guide:/docs/guide:ro
       - ./docs/about.md:/docs/about.md:ro
+      - ./CHANGELOG.md:/docs/CHANGELOG.md:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Closes #596.

## Summary
- New \`CHANGELOG.md\` at the repo root, [Keep-a-Changelog](https://keepachangelog.com/en/1.1.0/) format, grouped per release as **Major / Minor / Fixes** (with **Internal** where relevant).
- README's "Documentation" table links to it.
- The web app's \`/about\` page renders the same file at the bottom of the page, mounted into the web container at \`/docs/CHANGELOG.md\` alongside the existing \`/docs/about.md\` mount. Single source of truth — edit the file, both places update.
- CLAUDE.md gets a one-line convention reminding contributors to update \`[Unreleased]\` on PRs with user-visible behavior. The changelog itself carries the same note as an HTML comment so it sits next to the section it governs without rendering.

## Backfill
- Walked all 314 merged PRs from 2026-03-14 onward and bucketed them under the dated version sections already implied by the VERSION file's git history:
  - \`[0.0.0] — 2026-03-14 to 2026-04-03\` (pre-versioning era — initial scaffold + most foundational features)
  - \`[0.1.0]\` — Apr 4 (versioning system, Ask AI / RAG end-to-end, drag-and-drop upload, reprocess button, etc.)
  - \`[0.1.1]\` — Apr 7–19 (Fireworks AI remote-inference profile, settings redesign, speaker filter, episode-scoped Ask, in-app docs, framework upgrades)
  - \`[0.1.2]\` / \`[0.1.3]\` — Apr 20 (pyannote community-1, host/guest inference end-to-end, Gemma 4 e4b)
  - \`[0.2.0]\` — Apr 24 (Meta-Analysis dashboard)
  - \`[0.3.0]\` — Apr 24 (pyannote.ai Precision-2 cloud diarization)
- The \`[Unreleased]\` section already carries the four PRs landed today (#595, #601, #602, #603, #604). The aligning fix mention also names #594-follow-up for the CI Slow migration fix.
- Bar for inclusion: "would a user or future-me want to know this changed?" Pure-test/pure-docs PRs are skipped unless they shipped user-visible documentation. PR links accompany every claim.

## Test plan
- [x] Web Jest suite: 539 passed (existing about-page tests updated for the new dual-read path; +2 new tests cover changelog-renders and changelog-missing fallback).
- [x] \`tsc --noEmit\` clean.
- [x] ESLint clean on the new files.
- [x] Live verification: \`docker compose build web && docker compose up -d web\` then \`curl /about\` returns "Self-hosted" (about content) and "Changelog" (new section heading) — both render.

## Out of scope
- A CI hook that fails PRs which don't touch CHANGELOG.md. Easy to add later if it becomes a problem; the convention should be enough for a small team for now.
- Auto-generated entries from commit messages — explicitly avoided per the issue, since the bar is human readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)