### PR TITLE
feat(web): Releases TOC sidebar on /about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ fresh empty `[Unreleased]` is left at the top.
 
 ### Minor changes
 - Copy-to-clipboard button for the episode UUID on the episode page. Subtle icon next to the title. ([#601](https://github.com/brlauuu/podlog/pull/601))
+- "Releases" sidebar on `/about` (right rail, `xl:` and up) listing every changelog version with sticky scroll-spy. Header shows version count and the latest tagged release. ([#606](https://github.com/brlauuu/podlog/pull/606))
 
 ### Fixes
 - Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -4,6 +4,9 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 
+import ChangelogToc, { type ChangelogTocItem } from "@/components/ChangelogToc";
+import { makeUniqueSlugger } from "@/lib/docs-slug";
+
 export const dynamic = "force-dynamic";
 
 async function readDocOrNull(filename: string): Promise<string | null> {
@@ -30,44 +33,104 @@ const markdownComponents = {
   },
 };
 
+/**
+ * Pull the changelog's version-section H2s — lines like
+ * `## [0.3.0] — 2026-04-24` or `## [Unreleased]`. Skips other H2s
+ * (e.g. the contribution-flow comment helper if one is ever added).
+ *
+ * Pairs each entry with the slug the markdown renderer will produce so
+ * the right-rail anchor links resolve to real DOM ids.
+ */
+function extractChangelogVersions(markdown: string): ChangelogTocItem[] {
+  // Slug every H2, but only emit version-shaped ones. Slugging every heading
+  // keeps this slugger's collision counts in lockstep with the renderer's
+  // slugger, so the produced ids match what ends up in the DOM even if a
+  // non-version H2 (e.g. "## Notes") is added between version sections.
+  const slugger = makeUniqueSlugger();
+  const out: ChangelogTocItem[] = [];
+  for (const line of markdown.split("\n")) {
+    const m = line.match(/^##\s+(.+)$/);
+    if (!m) continue;
+    const text = m[1].trim();
+    const id = slugger(text);
+    if (text.startsWith("[")) out.push({ id, text });
+  }
+  return out;
+}
+
 export default async function AboutPage() {
   const [aboutContent, changelogContent] = await Promise.all([
     readDocOrNull("about.md"),
     readDocOrNull("CHANGELOG.md"),
   ]);
 
-  return (
-    <div className="mx-auto w-full max-w-2xl py-4 space-y-10">
-      {aboutContent ? (
-        <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
-            components={markdownComponents}
-          >
-            {aboutContent}
-          </ReactMarkdown>
-        </article>
-      ) : (
-        <div className="text-muted-foreground">
-          <h1 className="text-2xl font-bold mb-3">About</h1>
-          <p>Could not load the About page.</p>
-        </div>
-      )}
+  const versions = changelogContent ? extractChangelogVersions(changelogContent) : [];
 
-      {changelogContent && (
-        <section className="border-t pt-8">
-          <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw]}
-              components={markdownComponents}
-            >
-              {changelogContent}
-            </ReactMarkdown>
-          </article>
-        </section>
-      )}
+  // The renderer needs a stateful slugger so heading ids are stable and
+  // unique across the rendered changelog. Same scheme the docs page uses.
+  const renderHeadingId = makeUniqueSlugger();
+  const changelogComponents = {
+    ...markdownComponents,
+    h2: ({ children }: { children?: React.ReactNode }) => {
+      const text = textFromNode(children).trim();
+      const id = renderHeadingId(text);
+      return <h2 id={id}>{children}</h2>;
+    },
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-7xl py-4">
+      <div
+        className={`grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,42rem)_minmax(8rem,1fr)] ${versions.length === 0 ? "xl:grid-cols-1" : ""} xl:justify-center`}
+      >
+        <div className="mx-auto w-full max-w-2xl space-y-10 xl:mx-0">
+          {aboutContent ? (
+            <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={markdownComponents}
+              >
+                {aboutContent}
+              </ReactMarkdown>
+            </article>
+          ) : (
+            <div className="text-muted-foreground">
+              <h1 className="text-2xl font-bold mb-3">About</h1>
+              <p>Could not load the About page.</p>
+            </div>
+          )}
+
+          {changelogContent && (
+            <section className="border-t pt-8">
+              <article className="prose prose-sm dark:prose-invert max-w-none leading-7">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                  components={changelogComponents}
+                >
+                  {changelogContent}
+                </ReactMarkdown>
+              </article>
+            </section>
+          )}
+        </div>
+
+        <ChangelogToc items={versions} />
+      </div>
     </div>
   );
+}
+
+/**
+ * Recursively flatten a ReactMarkdown heading's children into a plain string.
+ * Mirrors the helper used by the docs renderer; small enough to live alongside.
+ */
+function textFromNode(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textFromNode).join("");
+  if (node && typeof node === "object" && "props" in node) {
+    return textFromNode((node as { props?: { children?: React.ReactNode } }).props?.children);
+  }
+  return "";
 }

--- a/apps/web/src/components/ChangelogToc.tsx
+++ b/apps/web/src/components/ChangelogToc.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface ChangelogTocItem {
+  /** Slugified id matching the heading's `id` attribute on the page. */
+  id: string;
+  /** Section label, e.g. `[0.3.0] — 2026-04-24` or `[Unreleased]`. */
+  text: string;
+}
+
+interface Props {
+  items: ChangelogTocItem[];
+}
+
+export default function ChangelogToc({ items }: Props) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // Scroll-spy: highlight the version closest to the top of the viewport.
+  // Mirrors the docs page's right-rail behavior.
+  useEffect(() => {
+    if (!items.length) return;
+
+    const updateActive = () => {
+      const topOffset = 120;
+      let active = items[0]?.id ?? null;
+      for (const item of items) {
+        const el = document.getElementById(item.id);
+        if (!el) continue;
+        if (el.getBoundingClientRect().top - topOffset <= 0) {
+          active = item.id;
+        } else {
+          break;
+        }
+      }
+      setActiveId(active);
+    };
+
+    updateActive();
+    window.addEventListener("scroll", updateActive, { passive: true });
+    window.addEventListener("resize", updateActive);
+    return () => {
+      window.removeEventListener("scroll", updateActive);
+      window.removeEventListener("resize", updateActive);
+    };
+  }, [items]);
+
+  if (items.length === 0) return null;
+
+  // The first non-Unreleased item, by convention, is the latest tagged release.
+  const latest = items.find((item) => !item.text.toLowerCase().includes("unreleased"));
+
+  return (
+    <aside className="hidden xl:block">
+      <div className="sticky top-20">
+        <h2 className="mb-1 text-sm font-semibold text-muted-foreground">Releases</h2>
+        <p className="mb-2 text-xs text-muted-foreground">
+          {items.length} {items.length === 1 ? "version" : "versions"}
+          {latest ? ` · latest ${stripDate(latest.text)}` : ""}
+        </p>
+        <nav className="space-y-1">
+          {items.map((item) => (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              className={`block text-sm transition-colors hover:text-foreground ${
+                activeId === item.id
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {item.text}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}
+
+/**
+ * `[0.3.0] — 2026-04-24` → `[0.3.0]`. Used in the "latest …" hint where the
+ * date would be redundant noise next to the version number.
+ */
+function stripDate(text: string): string {
+  return text.replace(/\s*[—–-]\s*\d{4}-\d{2}-\d{2}.*$/, "").trim();
+}

--- a/apps/web/tests/unit/about-page.test.tsx
+++ b/apps/web/tests/unit/about-page.test.tsx
@@ -129,4 +129,34 @@ describe("<AboutPage>", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toHaveTextContent("About body.");
   });
+
+  it("renders a Releases sidebar listing each changelog version", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("About body.")
+      .mockResolvedValueOnce(
+        "# Changelog\n\n## [Unreleased]\n\n- foo\n\n## [0.3.0] — 2026-04-24\n\n- bar\n"
+      );
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    expect(screen.getByText("Releases")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 versions · latest [0.3.0]")
+    ).toBeInTheDocument();
+    // The version anchors carry slugified ids matching the heading slugger.
+    const unreleased = screen.getByRole("link", { name: "[Unreleased]" });
+    expect(unreleased).toHaveAttribute("href", "#unreleased");
+  });
+
+  it("does not render the Releases sidebar when CHANGELOG.md is missing", async () => {
+    mockReadFile
+      .mockResolvedValueOnce("About body.")
+      .mockRejectedValueOnce(new Error("ENOENT"));
+
+    const jsx = await AboutPage();
+    render(jsx);
+
+    expect(screen.queryByText("Releases")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/unit/changelog-toc.test.tsx
+++ b/apps/web/tests/unit/changelog-toc.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ChangelogToc from "@/components/ChangelogToc";
+
+const SAMPLE = [
+  { id: "unreleased", text: "[Unreleased]" },
+  { id: "0-3-0-2026-04-24", text: "[0.3.0] — 2026-04-24" },
+  { id: "0-2-0-2026-04-24", text: "[0.2.0] — 2026-04-24" },
+];
+
+describe("<ChangelogToc>", () => {
+  it("renders nothing when there are no versions", () => {
+    const { container } = render(<ChangelogToc items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one anchor per version, in order", () => {
+    render(<ChangelogToc items={SAMPLE} />);
+    const links = screen.getAllByRole("link");
+    expect(links.map((a) => a.textContent)).toEqual([
+      "[Unreleased]",
+      "[0.3.0] — 2026-04-24",
+      "[0.2.0] — 2026-04-24",
+    ]);
+    expect(links[0]).toHaveAttribute("href", "#unreleased");
+    expect(links[1]).toHaveAttribute("href", "#0-3-0-2026-04-24");
+  });
+
+  it("shows version count and the latest tagged release in the header", () => {
+    render(<ChangelogToc items={SAMPLE} />);
+    expect(screen.getByText("Releases")).toBeInTheDocument();
+    // 3 versions, latest is the first non-Unreleased entry, with the date stripped.
+    expect(
+      screen.getByText("3 versions · latest [0.3.0]")
+    ).toBeInTheDocument();
+  });
+
+  it("uses singular when there is only one version", () => {
+    render(<ChangelogToc items={[SAMPLE[1]]} />);
+    expect(screen.getByText("1 version · latest [0.3.0]")).toBeInTheDocument();
+  });
+
+  it("omits the latest hint when only [Unreleased] exists", () => {
+    render(<ChangelogToc items={[SAMPLE[0]]} />);
+    // No "latest …" suffix because there's no tagged release yet.
+    expect(screen.getByText("1 version")).toBeInTheDocument();
+  });
+
+  it("highlights the active version on scroll", () => {
+    // Mount stub headings the scroll-spy can find.
+    document.body.innerHTML = `
+      <h2 id="unreleased">A</h2>
+      <h2 id="0-3-0-2026-04-24">B</h2>
+    `;
+    document.body.appendChild(document.createElement("div"));
+
+    // Stub getBoundingClientRect: first heading scrolled past the offset, second still below.
+    const stub = (top: number) => ({
+      top,
+      bottom: top + 20,
+      height: 20,
+      width: 100,
+      left: 0,
+      right: 100,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const map: Record<string, number> = {
+      unreleased: 50, // 50 - 120 ≤ 0 → active
+      "0-3-0-2026-04-24": 500, // 500 - 120 > 0 → not yet active
+    };
+    for (const id of Object.keys(map)) {
+      const el = document.getElementById(id) as HTMLElement;
+      el.getBoundingClientRect = () => stub(map[id]);
+    }
+
+    render(<ChangelogToc items={SAMPLE} />);
+    fireEvent.scroll(window);
+
+    const unreleasedLink = screen.getByRole("link", { name: "[Unreleased]" });
+    expect(unreleasedLink.className).toMatch(/font-medium/);
+  });
+});


### PR DESCRIPTION
Per [the design discussion](https://github.com/brlauuu/podlog/issues): adds a right-rail "Releases" TOC to the About page so the user can quickly see how many versions exist and which is the latest, and jump to any of them.

## Summary
- Mirrors the docs page's right-rail "On this page" pattern, scoped to changelog version sections.
- Header shows version count + latest tagged release ("8 versions · latest [0.3.0]").
- One sticky scroll-spy nav entry per version.
- Only renders on \`xl:\` and up (same breakpoint as the docs TOC) to avoid crowding the centered About content on narrower viewports.

## Implementation notes
- Server component extracts version-shaped H2s ("[x] — date" / "[Unreleased]") while slugging *every* H2 it sees, so slugger collision counts stay in lockstep with the renderer's slugger and links resolve to the IDs the markdown actually puts in the DOM.
- New \`<ChangelogToc>\` client component holds the scroll-spy logic. Renders nothing when there are no versions, so it's safe to mount even if CHANGELOG.md is missing.
- About page layout becomes a 2-col grid on \`xl:\` (centered content + right rail). Below \`xl:\` it stays a single centered column, identical to the previous layout.

## Test plan
- [x] 6 new \`<ChangelogToc>\` unit tests: empty state, anchor list, version count + latest hint, singular vs plural, Unreleased-only edge case, scroll-spy active highlight.
- [x] 2 new about-page integration tests: Releases sidebar renders with the right version count when CHANGELOG.md is present; doesn't render when CHANGELOG.md is missing.
- [x] Full web jest suite: 547 passed (+8 new).
- [x] \`tsc --noEmit\` clean. ESLint clean.
- [x] Live browser verification on rebuilt web container — \`/about\` returns the rendered TOC with 8 version anchors matching the heading IDs in the changelog body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)