### PR TITLE
feat(pipeline): wire chunked Fireworks transcription into transcribe (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Periodic cleanup task that prunes superseded `failed` rows in `job_queue` (rows whose episode later succeeded). Runs every 24 h; clears noise from the queue dashboard's "failed" counter. ([#604](https://github.com/brlauuu/podlog/pull/604))
 - New "Changelog" CI check fails any PR that doesn't touch `CHANGELOG.md`; opt out per-PR with the `no-changelog` label. ([#605](https://github.com/brlauuu/podlog/pull/605))
 - Groundwork for chunked Fireworks transcription of long episodes ([#610](https://github.com/brlauuu/podlog/issues/610)): new chunking module (`plan_chunks` / `extract_chunk` / `stitch_responses`) and four runtime settings (`fireworks_chunked_transcription_enabled`, `fireworks_chunk_target_secs`, `fireworks_chunk_overlap_secs`, `fireworks_chunk_max_retries`). Not wired into the transcribe path yet — feature stays off until a follow-up PR lands.
+- `fireworks_audio.transcribe()` now accepts `chunked=True`, threading per-chunk upload + retry + bisect-on-cap through the existing call site in `transcribe.py`. Default remains `chunked=False`. New `FIREWORKS_CHUNK_FAILED` error class names the failing audio range. Settings UI toggle ships in a follow-up PR; the feature is off until then. ([#610](https://github.com/brlauuu/podlog/issues/610))
 
 ### Other minor changes
 - Zod runtime validation for the settings response. ([#588](https://github.com/brlauuu/podlog/pull/588))

--- a/apps/pipeline/app/services/fireworks_audio.py
+++ b/apps/pipeline/app/services/fireworks_audio.py
@@ -224,13 +224,19 @@ def _transcribe_range(
                 str(exc),
             )
 
-    assert last_error is not None  # loop body either returns or sets last_error
+    if last_error is None:
+        # Defensive: the retry loop body either returns successfully or sets
+        # last_error before breaking. Reaching here means a control-flow bug.
+        raise RuntimeError(
+            f"_transcribe_range exhausted retries without recording an error "
+            f"(label={chunk_label!r})"
+        )
 
     if last_error.error_class == "FIREWORKS_UPLOAD_REJECTED" and bisect_depth > 0:
         if range_duration < _MIN_BISECT_DURATION_SECS:
             raise FireworksTranscriptionError(
                 f"Fireworks rejected upload of a {range_duration:.0f}s chunk "
-                f"[{range_label(range_start, range_end)}]; below bisect floor "
+                f"[{_range_label(range_start, range_end)}]; below bisect floor "
                 f"({_MIN_BISECT_DURATION_SECS:.0f}s). Cap may not be size-related.",
                 error_class="FIREWORKS_CHUNK_FAILED",
                 retryable=False,
@@ -273,7 +279,7 @@ def _transcribe_range(
 
     if last_error.error_class == "FIREWORKS_UPLOAD_REJECTED":
         raise FireworksTranscriptionError(
-            f"Fireworks rejected upload of chunk [{range_label(range_start, range_end)}] "
+            f"Fireworks rejected upload of chunk [{_range_label(range_start, range_end)}] "
             f"after exhausting bisect depth. Re-run this episode on local inference.",
             error_class="FIREWORKS_CHUNK_FAILED",
             retryable=False,
@@ -281,14 +287,14 @@ def _transcribe_range(
 
     # Retry budget exhausted on a retryable error, or non-retryable error.
     raise FireworksTranscriptionError(
-        f"Chunk [{range_label(range_start, range_end)}] failed after "
+        f"Chunk [{_range_label(range_start, range_end)}] failed after "
         f"{max_retries + 1} attempts: {last_error}",
         error_class="FIREWORKS_CHUNK_FAILED",
         retryable=False,
     ) from last_error
 
 
-def range_label(start: float, end: float) -> str:
+def _range_label(start: float, end: float) -> str:
     """Format a range as ``MM:SS-MM:SS`` for log/error messages."""
 
     def fmt(secs: float) -> str:

--- a/apps/pipeline/app/services/fireworks_audio.py
+++ b/apps/pipeline/app/services/fireworks_audio.py
@@ -3,16 +3,35 @@ Fireworks audio transcription helpers.
 
 This service wraps Fireworks `/v1/audio/transcriptions` and normalizes the
 response shape used by Podlog tasks.
+
+For long episodes that exceed Fireworks's undocumented upload cap (#600),
+``transcribe`` can be called with ``chunked=True`` to split the file with
+:mod:`app.services.fireworks_audio_chunking` and stitch the per-chunk
+responses back together (#610). Default behavior is unchanged: one
+multipart upload, fail-fast on cap.
 """
 from __future__ import annotations
 
 import logging
+import tempfile
 from collections import Counter
 from pathlib import Path
 
 import httpx
 
+from app.services import fireworks_audio_chunking as chunking
+
 logger = logging.getLogger(__name__)
+
+
+# Maximum bisect depth for chunked uploads when a chunk hits
+# FIREWORKS_UPLOAD_REJECTED. Depth 2 means a chunk can split at most into
+# 4 sub-chunks (1 -> 2 -> 4) before we give up with FIREWORKS_CHUNK_FAILED.
+_BISECT_MAX_DEPTH = 2
+
+# Refuse to bisect a range below this duration: at some point the cap
+# isn't about size, and we should surface the failure to the user.
+_MIN_BISECT_DURATION_SECS = 30.0
 
 
 class FireworksTranscriptionError(RuntimeError):
@@ -76,23 +95,23 @@ def _format_upload_rejected_message(audio_path: str, original_error: str) -> str
     )
 
 
-def transcribe(
-    audio_path: str,
+def _post_transcription(
+    file_path: str | Path,
     *,
     api_key: str,
     audio_base_url: str,
     model_name: str,
     diarize: bool,
-) -> tuple[list[dict], str, dict]:
-    """
-    Transcribe audio with Fireworks.
+) -> dict:
+    """Single multipart upload to Fireworks ``/v1/audio/transcriptions``.
 
-    Returns `(segments, language, raw_response)` where segments follow Podlog's
-    existing format: `{"start": float, "end": float, "text": str}`.
+    Returns the raw response dict; raises :class:`FireworksTranscriptionError`
+    with retryability metadata on any HTTP/network failure. This is the
+    inner primitive used by both the single-shot and chunked code paths.
     """
-    path = Path(audio_path)
+    path = Path(file_path)
     if not path.exists():
-        raise RuntimeError(f"Audio file missing for Fireworks transcription: {audio_path}")
+        raise RuntimeError(f"Audio file missing for Fireworks transcription: {path}")
 
     data = {
         "model": model_name,
@@ -113,7 +132,7 @@ def transcribe(
                     _audio_url(audio_base_url), headers=headers, data=data, files=files
                 )
                 resp.raise_for_status()
-                result = resp.json()
+                return resp.json()
         except httpx.TimeoutException as exc:
             raise FireworksTranscriptionError(
                 f"Fireworks transcription timeout: {exc}",
@@ -124,7 +143,7 @@ def transcribe(
             error_text = str(exc)
             if _is_upload_rejected_signature(error_text):
                 raise FireworksTranscriptionError(
-                    _format_upload_rejected_message(audio_path, error_text),
+                    _format_upload_rejected_message(str(path), error_text),
                     error_class="FIREWORKS_UPLOAD_REJECTED",
                     retryable=False,
                 ) from exc
@@ -143,6 +162,192 @@ def transcribe(
                 status_code=status,
             ) from exc
 
+
+def _transcribe_range(
+    src_audio_path: Path,
+    range_start: float,
+    range_end: float,
+    *,
+    workdir: Path,
+    api_key: str,
+    audio_base_url: str,
+    model_name: str,
+    diarize: bool,
+    overlap_secs: int,
+    max_retries: int,
+    bisect_depth: int,
+    chunk_label: str,
+) -> dict:
+    """Transcribe a [start, end] range of the source audio.
+
+    Returns the raw response with timestamps in **range-local time**
+    (start of the range = 0). Recursively bisects the range when Fireworks
+    rejects the upload, until ``bisect_depth`` runs out.
+
+    Retryable errors are retried up to ``max_retries`` times with no
+    backoff (the request itself takes long enough; piling on backoff would
+    slow chunked transcription unnecessarily).
+    """
+    range_duration = range_end - range_start
+    chunk_filename = f"chunk_{chunk_label}.mp3"
+    chunk_path = workdir / chunk_filename
+    chunking.extract_chunk(
+        src_audio_path,
+        chunking.Chunk(index=0, start=range_start, end=range_end),
+        chunk_path,
+    )
+
+    last_error: FireworksTranscriptionError | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            return _post_transcription(
+                chunk_path,
+                api_key=api_key,
+                audio_base_url=audio_base_url,
+                model_name=model_name,
+                diarize=diarize,
+            )
+        except FireworksTranscriptionError as exc:
+            last_error = exc
+            if exc.error_class == "FIREWORKS_UPLOAD_REJECTED":
+                # Cap reached on this range; bisect or surface.
+                break
+            if not exc.retryable:
+                # Non-retryable terminal failure (e.g. HTTP_ACCESS-class).
+                break
+            logger.warning(
+                '"action": "fireworks_chunk_retry", "label": "%s", "attempt": %d, '
+                '"error_class": "%s", "error": "%s"',
+                chunk_label,
+                attempt + 1,
+                exc.error_class,
+                str(exc),
+            )
+
+    assert last_error is not None  # loop body either returns or sets last_error
+
+    if last_error.error_class == "FIREWORKS_UPLOAD_REJECTED" and bisect_depth > 0:
+        if range_duration < _MIN_BISECT_DURATION_SECS:
+            raise FireworksTranscriptionError(
+                f"Fireworks rejected upload of a {range_duration:.0f}s chunk "
+                f"[{range_label(range_start, range_end)}]; below bisect floor "
+                f"({_MIN_BISECT_DURATION_SECS:.0f}s). Cap may not be size-related.",
+                error_class="FIREWORKS_CHUNK_FAILED",
+                retryable=False,
+            ) from last_error
+
+        logger.warning(
+            '"action": "fireworks_chunk_bisect", "label": "%s", "duration_secs": %.1f, '
+            '"depth_remaining": %d',
+            chunk_label,
+            range_duration,
+            bisect_depth,
+        )
+        sub_chunks = chunking.plan_chunks(
+            duration_secs=range_duration,
+            target_secs=max(int(range_duration / 2) + overlap_secs, overlap_secs + 1),
+            overlap_secs=overlap_secs,
+        )
+        sub_responses: list[dict] = []
+        for sub in sub_chunks:
+            sub_response = _transcribe_range(
+                src_audio_path,
+                range_start=range_start + sub.start,
+                range_end=range_start + sub.end,
+                workdir=workdir,
+                api_key=api_key,
+                audio_base_url=audio_base_url,
+                model_name=model_name,
+                diarize=diarize,
+                overlap_secs=overlap_secs,
+                max_retries=max_retries,
+                bisect_depth=bisect_depth - 1,
+                chunk_label=f"{chunk_label}.{sub.index}",
+            )
+            sub_responses.append(sub_response)
+        # Stitch sub-responses into a single range-local response: each
+        # sub_response has times relative to its own sub-range start
+        # (which is sub.start within the parent range), so stitch_responses
+        # with the original sub_chunks directly produces range-local times.
+        return chunking.stitch_responses(sub_responses, sub_chunks)
+
+    if last_error.error_class == "FIREWORKS_UPLOAD_REJECTED":
+        raise FireworksTranscriptionError(
+            f"Fireworks rejected upload of chunk [{range_label(range_start, range_end)}] "
+            f"after exhausting bisect depth. Re-run this episode on local inference.",
+            error_class="FIREWORKS_CHUNK_FAILED",
+            retryable=False,
+        ) from last_error
+
+    # Retry budget exhausted on a retryable error, or non-retryable error.
+    raise FireworksTranscriptionError(
+        f"Chunk [{range_label(range_start, range_end)}] failed after "
+        f"{max_retries + 1} attempts: {last_error}",
+        error_class="FIREWORKS_CHUNK_FAILED",
+        retryable=False,
+    ) from last_error
+
+
+def range_label(start: float, end: float) -> str:
+    """Format a range as ``MM:SS-MM:SS`` for log/error messages."""
+
+    def fmt(secs: float) -> str:
+        m, s = divmod(int(secs), 60)
+        return f"{m}:{s:02d}"
+
+    return f"{fmt(start)}-{fmt(end)}"
+
+
+def transcribe(
+    audio_path: str,
+    *,
+    api_key: str,
+    audio_base_url: str,
+    model_name: str,
+    diarize: bool,
+    chunked: bool = False,
+    chunk_target_secs: int = 900,
+    chunk_overlap_secs: int = 3,
+    chunk_max_retries: int = 2,
+) -> tuple[list[dict], str, dict]:
+    """
+    Transcribe audio with Fireworks.
+
+    Returns ``(segments, language, raw_response)`` where segments follow
+    Podlog's existing format: ``{"start": float, "end": float, "text": str}``.
+
+    When ``chunked=False`` (default), behavior matches the historical
+    single-shot upload — one multipart POST, fail-fast on the upload cap
+    (#600). When ``chunked=True``, the file is split into pieces of
+    ``chunk_target_secs`` with ``chunk_overlap_secs`` overlap, each piece
+    is uploaded independently (with up to ``chunk_max_retries`` retries
+    and bisect-on-cap), and the per-chunk responses are stitched back
+    into a single response equivalent to one whole-file Fireworks call.
+    """
+    path = Path(audio_path)
+    if not path.exists():
+        raise RuntimeError(f"Audio file missing for Fireworks transcription: {audio_path}")
+
+    if chunked:
+        result = _transcribe_chunked(
+            path,
+            api_key=api_key,
+            audio_base_url=audio_base_url,
+            model_name=model_name,
+            diarize=diarize,
+            chunk_target_secs=chunk_target_secs,
+            chunk_overlap_secs=chunk_overlap_secs,
+            chunk_max_retries=chunk_max_retries,
+        )
+    else:
+        result = _post_transcription(
+            path,
+            api_key=api_key,
+            audio_base_url=audio_base_url,
+            model_name=model_name,
+            diarize=diarize,
+        )
+
     raw_segments = result.get("segments", []) or []
     segments: list[dict] = []
     for seg in raw_segments:
@@ -156,12 +361,69 @@ def transcribe(
 
     language = result.get("language", "unknown") or "unknown"
     logger.info(
-        '"action": "fireworks_transcribe_complete", "segments": %d, "language": "%s", "diarize": %s',
+        '"action": "fireworks_transcribe_complete", "segments": %d, "language": "%s", '
+        '"diarize": %s, "chunked": %s',
         len(segments),
         language,
         str(diarize).lower(),
+        str(chunked).lower(),
     )
     return segments, language, result
+
+
+def _transcribe_chunked(
+    audio_path: Path,
+    *,
+    api_key: str,
+    audio_base_url: str,
+    model_name: str,
+    diarize: bool,
+    chunk_target_secs: int,
+    chunk_overlap_secs: int,
+    chunk_max_retries: int,
+) -> dict:
+    """Chunked path: split, upload each chunk, stitch back. Issue #610.
+
+    Returns a single raw response in whole-file time, equivalent in shape
+    to one Fireworks call against the entire audio.
+    """
+    duration_secs = chunking.probe_duration_secs(audio_path)
+    chunks = chunking.plan_chunks(
+        duration_secs=duration_secs,
+        target_secs=chunk_target_secs,
+        overlap_secs=chunk_overlap_secs,
+    )
+    logger.info(
+        '"action": "fireworks_chunk_plan", "audio": "%s", "duration_secs": %.1f, '
+        '"chunks": %d, "target_secs": %d, "overlap_secs": %d',
+        audio_path.name,
+        duration_secs,
+        len(chunks),
+        chunk_target_secs,
+        chunk_overlap_secs,
+    )
+
+    chunk_responses: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix="fireworks_chunks_") as workdir_str:
+        workdir = Path(workdir_str)
+        for chunk in chunks:
+            chunk_response = _transcribe_range(
+                audio_path,
+                range_start=chunk.start,
+                range_end=chunk.end,
+                workdir=workdir,
+                api_key=api_key,
+                audio_base_url=audio_base_url,
+                model_name=model_name,
+                diarize=diarize,
+                overlap_secs=chunk_overlap_secs,
+                max_retries=chunk_max_retries,
+                bisect_depth=_BISECT_MAX_DEPTH,
+                chunk_label=str(chunk.index),
+            )
+            chunk_responses.append(chunk_response)
+
+    return chunking.stitch_responses(chunk_responses, chunks)
 
 
 def diarization_segments_from_transcription(raw: dict) -> list[dict]:

--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -93,6 +93,26 @@ def transcribe_episode(episode_id: str) -> str:
                     or settings.fireworks_audio_base_url,
                     model_name=runtime.get("fireworks_stt_model") or settings.fireworks_stt_model,
                     diarize=bool(runtime.get("fireworks_stt_diarize", True)),
+                    chunked=bool(
+                        runtime.get(
+                            "fireworks_chunked_transcription_enabled",
+                            settings.fireworks_chunked_transcription_enabled,
+                        )
+                    ),
+                    chunk_target_secs=int(
+                        runtime.get("fireworks_chunk_target_secs")
+                        or settings.fireworks_chunk_target_secs
+                    ),
+                    chunk_overlap_secs=int(
+                        runtime.get("fireworks_chunk_overlap_secs")
+                        if runtime.get("fireworks_chunk_overlap_secs") is not None
+                        else settings.fireworks_chunk_overlap_secs
+                    ),
+                    chunk_max_retries=int(
+                        runtime.get("fireworks_chunk_max_retries")
+                        if runtime.get("fireworks_chunk_max_retries") is not None
+                        else settings.fireworks_chunk_max_retries
+                    ),
                 )
                 transcribe_secs = round(time.monotonic() - t0, 1)
                 audio_secs = estimate_fireworks_usage(segments_data, episode.duration_secs)

--- a/apps/pipeline/app/tasks/transcribe.py
+++ b/apps/pipeline/app/tasks/transcribe.py
@@ -101,7 +101,8 @@ def transcribe_episode(episode_id: str) -> str:
                     ),
                     chunk_target_secs=int(
                         runtime.get("fireworks_chunk_target_secs")
-                        or settings.fireworks_chunk_target_secs
+                        if runtime.get("fireworks_chunk_target_secs") is not None
+                        else settings.fireworks_chunk_target_secs
                     ),
                     chunk_overlap_secs=int(
                         runtime.get("fireworks_chunk_overlap_secs")

--- a/apps/pipeline/tests/unit/test_fireworks_audio_service.py
+++ b/apps/pipeline/tests/unit/test_fireworks_audio_service.py
@@ -307,3 +307,232 @@ def test_transcribe_wraps_429_as_retryable(tmp_path: Path):
     assert exc.error_class == "TRANSIENT_NETWORK"
     assert exc.retryable is True
     assert exc.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Chunked transcription (Issue #610)
+# ---------------------------------------------------------------------------
+
+
+def _chunk_response(words: list[dict], segments: list[dict] | None = None, language: str = "en"):
+    """Build a fake Fireworks raw response in chunk-local time."""
+    return {
+        "language": language,
+        "segments": segments or [],
+        "words": words,
+    }
+
+
+def _patch_chunking_io(monkeypatch, duration_secs: float):
+    """Stub probe_duration_secs and extract_chunk so tests don't need ffmpeg."""
+    from app.services import fireworks_audio_chunking as chunking
+
+    monkeypatch.setattr(chunking, "probe_duration_secs", lambda _path: duration_secs)
+    monkeypatch.setattr(chunking, "extract_chunk", lambda _src, _chunk, dst: Path(dst))
+
+
+def test_transcribe_chunked_short_file_single_call(tmp_path: Path, monkeypatch):
+    """A file shorter than chunk_target_secs goes through one upload, stitched via chunk-of-1."""
+    audio_path = tmp_path / "short.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=120.0)
+
+    fake_response = _chunk_response(
+        words=[{"word": "hello", "start": 1.0, "end": 1.5, "speaker_id": "0"}],
+        segments=[{"start": 0.0, "end": 2.0, "text": "hello"}],
+    )
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        return_value=fake_response,
+    ) as mock_post:
+        segments, language, raw = transcribe(
+            str(audio_path),
+            api_key="fw_test",
+            audio_base_url="https://audio-turbo.api.fireworks.ai",
+            model_name="whisper-v3-turbo",
+            diarize=True,
+            chunked=True,
+            chunk_target_secs=900,
+            chunk_overlap_secs=3,
+            chunk_max_retries=2,
+        )
+
+    assert mock_post.call_count == 1
+    assert language == "en"
+    assert segments == [{"start": 0.0, "end": 2.0, "text": "hello"}]
+    assert raw["words"][0]["word"] == "hello"
+
+
+def test_transcribe_chunked_long_file_stitches_two_chunks(tmp_path: Path, monkeypatch):
+    """A 1500s file with 900s chunks produces two upload calls, stitched into whole-file time."""
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=1500.0)
+
+    # Each chunk's response has its own LOCAL timeline (start = 0).
+    chunk0 = _chunk_response(
+        words=[{"word": "first", "start": 50.0, "end": 50.5, "speaker_id": "0"}],
+        segments=[{"start": 50.0, "end": 51.0, "text": "first"}],
+    )
+    chunk1 = _chunk_response(
+        words=[{"word": "second", "start": 100.0, "end": 100.5, "speaker_id": "0"}],
+        segments=[{"start": 100.0, "end": 101.0, "text": "second"}],
+    )
+
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        side_effect=[chunk0, chunk1],
+    ) as mock_post:
+        segments, _language, raw = transcribe(
+            str(audio_path),
+            api_key="fw_test",
+            audio_base_url="https://audio-turbo.api.fireworks.ai",
+            model_name="whisper-v3-turbo",
+            diarize=True,
+            chunked=True,
+            chunk_target_secs=900,
+            chunk_overlap_secs=3,
+            chunk_max_retries=2,
+        )
+
+    assert mock_post.call_count == 2
+    # Chunk 1 starts at 897s in whole-file time (target 900 - overlap 3).
+    # Word "second" was at chunk-local 100s, so whole-file 997s.
+    second_word = next(w for w in raw["words"] if w["word"] == "second")
+    assert second_word["start"] == pytest.approx(997.0)
+    second_seg = next(s for s in segments if s["text"] == "second")
+    assert second_seg["start"] == pytest.approx(997.0)
+
+
+def test_transcribe_chunked_retries_on_transient_error(tmp_path: Path, monkeypatch):
+    """A retryable error on a chunk is retried up to max_retries before succeeding."""
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=120.0)
+
+    transient = FireworksTranscriptionError(
+        "transient blip", error_class="TRANSIENT_NETWORK", retryable=True
+    )
+    success = _chunk_response(words=[{"word": "ok", "start": 0.0, "end": 0.5}])
+
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        side_effect=[transient, transient, success],
+    ) as mock_post:
+        segments, _language, _raw = transcribe(
+            str(audio_path),
+            api_key="fw_test",
+            audio_base_url="https://audio-turbo.api.fireworks.ai",
+            model_name="whisper-v3-turbo",
+            diarize=True,
+            chunked=True,
+            chunk_target_secs=900,
+            chunk_overlap_secs=3,
+            chunk_max_retries=2,
+        )
+
+    assert mock_post.call_count == 3  # 1 try + 2 retries
+    assert segments == []  # no segments in the success response
+
+
+def test_transcribe_chunked_retry_exhaustion_raises_chunk_failed(tmp_path: Path, monkeypatch):
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=120.0)
+
+    transient = FireworksTranscriptionError(
+        "transient blip", error_class="TRANSIENT_NETWORK", retryable=True
+    )
+
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        side_effect=[transient] * 5,
+    ):
+        with pytest.raises(FireworksTranscriptionError) as excinfo:
+            transcribe(
+                str(audio_path),
+                api_key="fw_test",
+                audio_base_url="https://audio-turbo.api.fireworks.ai",
+                model_name="whisper-v3-turbo",
+                diarize=True,
+                chunked=True,
+                chunk_target_secs=900,
+                chunk_overlap_secs=3,
+                chunk_max_retries=2,
+            )
+    assert excinfo.value.error_class == "FIREWORKS_CHUNK_FAILED"
+    assert excinfo.value.retryable is False
+
+
+def test_transcribe_chunked_bisects_on_upload_rejected(tmp_path: Path, monkeypatch):
+    """When a chunk hits the cap, the range is bisected and sub-chunks succeed."""
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=1500.0)
+
+    rejected = FireworksTranscriptionError(
+        "Fireworks rejected upload",
+        error_class="FIREWORKS_UPLOAD_REJECTED",
+        retryable=False,
+    )
+    chunk_resp = _chunk_response(words=[{"word": "ok", "start": 0.0, "end": 0.5}])
+
+    # Chunk 0 succeeds; chunk 1 hits the cap (no retry on cap) and bisects
+    # into 2 sub-chunks that each succeed.
+    side = [
+        chunk_resp,  # chunk 0
+        rejected,    # chunk 1: cap → break retry loop → bisect
+        chunk_resp,  # sub-chunk 1.0
+        chunk_resp,  # sub-chunk 1.1
+    ]
+
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        side_effect=side,
+    ) as mock_post:
+        _segments, _language, _raw = transcribe(
+            str(audio_path),
+            api_key="fw_test",
+            audio_base_url="https://audio-turbo.api.fireworks.ai",
+            model_name="whisper-v3-turbo",
+            diarize=True,
+            chunked=True,
+            chunk_target_secs=900,
+            chunk_overlap_secs=3,
+            chunk_max_retries=2,
+        )
+
+    assert mock_post.call_count == 4
+
+
+def test_transcribe_chunked_bisect_exhaustion_raises_chunk_failed(tmp_path: Path, monkeypatch):
+    audio_path = tmp_path / "long.mp3"
+    audio_path.write_bytes(b"fake")
+    _patch_chunking_io(monkeypatch, duration_secs=1500.0)
+
+    rejected = FireworksTranscriptionError(
+        "Fireworks rejected upload",
+        error_class="FIREWORKS_UPLOAD_REJECTED",
+        retryable=False,
+    )
+
+    with patch(
+        "app.services.fireworks_audio._post_transcription",
+        side_effect=[rejected] * 100,  # everything fails with cap
+    ):
+        with pytest.raises(FireworksTranscriptionError) as excinfo:
+            transcribe(
+                str(audio_path),
+                api_key="fw_test",
+                audio_base_url="https://audio-turbo.api.fireworks.ai",
+                model_name="whisper-v3-turbo",
+                diarize=True,
+                chunked=True,
+                chunk_target_secs=900,
+                chunk_overlap_secs=3,
+                chunk_max_retries=2,
+            )
+    assert excinfo.value.error_class == "FIREWORKS_CHUNK_FAILED"
+    assert excinfo.value.retryable is False
+    # The error should name the failing range so the user knows what to look at.
+    assert "-" in str(excinfo.value) or "Re-run" in str(excinfo.value)


### PR DESCRIPTION
## Summary

PR 2 of 6 for #610. Stacks on #611. Wires the chunking module into `fireworks_audio.transcribe()` and threads the runtime settings through `transcribe.py`. Default behavior unchanged — feature stays off until the toggle is enabled in Settings (PR 4).

- **Refactor**: extract the existing single-shot HTTP+classify logic into `_post_transcription()`. Single-shot path is byte-identical to today.
- **New chunked path** in `transcribe(audio_path, ..., chunked=True)`:
  - `probe_duration_secs` → `plan_chunks` → per-chunk `extract_chunk` → `_post_transcription` → `stitch_responses`. Per-chunk artifacts go in a `tempfile.TemporaryDirectory` so cleanup is automatic on success and on any failure.
  - Per-chunk **retries** (`chunk_max_retries`) for retryable error classes.
  - **Bisect-on-cap**: when a chunk gets `FIREWORKS_UPLOAD_REJECTED`, the range recurses on its halves up to depth 2 (max 4 sub-chunks). Refuses to bisect below 30s — at that point the cap isn't size-related, so surface the failure.
  - Terminal failures raise the new **`FIREWORKS_CHUNK_FAILED`** class with the offending audio range named (`MM:SS-MM:SS`). Existing failure handler in `transcribe.py` is class-agnostic and surfaces the message via `_mark_failed`.
- **Wire** in `tasks/transcribe.py`: pass `chunked` + the three tunables from runtime settings, falling back to env defaults.

## Tests

- 6 new tests in `test_fireworks_audio_service.py`: short-file passthrough, two-chunk stitch with whole-file timestamps, retry-on-transient, retry exhaustion, bisect-on-cap success, bisect exhaustion. All mock `_post_transcription` + `chunking.probe_duration_secs` + `chunking.extract_chunk` so no real ffmpeg/network needed.
- Existing 25 single-shot tests pass unchanged (refactor is byte-equivalent on that path).
- Full unit suite: 725/725 (was 713 before #611, +12 across the two PRs).

## Test plan

- [x] `pytest tests/unit/test_fireworks_audio_service.py` — 31 passed (was 25).
- [x] `pytest tests/unit/` — 725 passed.
- [x] `ruff check app/services/fireworks_audio.py app/tasks/transcribe.py` — clean.
- [ ] No real-audio integration test in this PR. PR 3 covers diarization integration; a real-audio smoke run with chunked=True is something to do manually before flipping the toggle.

## Risk / safety

- Default `chunked=False` preserves single-shot behavior byte-for-byte.
- `tempfile.TemporaryDirectory` ensures chunk files are cleaned up on success and on any exception path.
- `_BISECT_MAX_DEPTH = 2` and `_MIN_BISECT_DURATION_SECS = 30.0` cap recursion depth and prevent runaway bisection on a non-size-related cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)