### PR TITLE
docs: chunked Fireworks transcription guide (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ fresh empty `[Unreleased]` is left at the top.
 - Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))
 - CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. (commit `21629cb`)
 
+### Docs
+- New guide page **Chunked Fireworks Transcription** explaining when to enable the toggle, how the split-transcribe-stitch flow works, the diarization-on-whole-file design, the bulk-retry workflow, the bisect-on-cap behavior, and cost. New `FIREWORKS_CHUNKED_TRANSCRIPTION_ENABLED` and the three tunables documented in `docs/configuration.md`. Queue dashboard guide cross-links the bulk-retry workflow. ([#610](https://github.com/brlauuu/podlog/issues/610))
+
 ### Internal
 - Periodic cleanup task that prunes superseded `failed` rows in `job_queue` (rows whose episode later succeeded). Runs every 24 h; clears noise from the queue dashboard's "failed" counter. ([#604](https://github.com/brlauuu/podlog/pull/604))
 - New "Changelog" CI check fails any PR that doesn't touch `CHANGELOG.md`; opt out per-PR with the `no-changelog` label. ([#605](https://github.com/brlauuu/podlog/pull/605))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,10 @@ The worker monitors running jobs and marks them as failed if they exceed expecte
 | `FIREWORKS_CHAT_BASE_URL` | `https://api.fireworks.ai/inference/v1` | Base URL for Fireworks OpenAI-compatible chat completions used by Ask generation. |
 | `FIREWORKS_CHAT_MODEL` | `accounts/fireworks/models/llama-v3p1-8b-instruct` | Fireworks chat model used when `INFERENCE_PROVIDER=fireworks` for Ask generation. |
 | `FIREWORKS_STT_COST_PER_MINUTE_USD` | `0.006` | Cost estimate assumption used for per-episode observability (`estimated_cost_usd = billed_minutes * rate`). |
+| `FIREWORKS_CHUNKED_TRANSCRIPTION_ENABLED` | `false` | Issue #610: split long audio into chunks for upload, then stitch the per-chunk transcripts back. Works around the undocumented Fireworks upload cap (#600). See the [Chunked Fireworks guide](guide/14-chunked-fireworks.md). |
+| `FIREWORKS_CHUNK_TARGET_SECS` | `900` | Target chunk duration when chunked transcription is enabled (15 min). Minimum 60. |
+| `FIREWORKS_CHUNK_OVERLAP_SECS` | `3` | Overlap between adjacent chunks. Resolves words that straddle a cut. |
+| `FIREWORKS_CHUNK_MAX_RETRIES` | `2` | Per-chunk retries on transient errors. Upload-cap rejections trigger bisection instead. |
 | `EMBEDDING_PROVIDER` | `local` | Runtime provider for query + segment/chunk embeddings (`local` or `fireworks`). |
 | `EMBEDDING_MODEL` | `all-MiniLM-L6-v2` | Local sentence-transformers model used when `EMBEDDING_PROVIDER=local`. |
 | `FIREWORKS_EMBEDDING_BASE_URL` | `https://api.fireworks.ai/inference/v1` | Base URL for Fireworks embeddings API. |

--- a/docs/guide/08-queue.md
+++ b/docs/guide/08-queue.md
@@ -40,6 +40,8 @@ When an episode fails, the error is classified to determine whether it can be re
 
 **Manual retry:** Click the **Retry** button on a failed episode to re-queue it. Non-retryable errors (DISK_FULL, OOM) show a message explaining what to fix first.
 
+**Bulk retry for upload-rejected episodes:** When Fireworks rejects long-episode uploads (`FIREWORKS_UPLOAD_REJECTED` or pre-#600 `TRANSIENT_NETWORK` with the SSL `BAD_RECORD_MAC` signature), a banner at the top of the queue dashboard offers a one-click retry for the whole batch using chunked transcription. The button is disabled until you enable **Chunk long episodes** in Settings → Remote Inference → Transcription. See [Chunked Fireworks Transcription](14-chunked-fireworks.md) for the full workflow.
+
 ## Stuck Episodes
 
 An episode may appear as **Stuck** if it's not in a done/failed state but has no active job in the queue. This can happen if:

--- a/docs/guide/13-pyannote-cloud.md
+++ b/docs/guide/13-pyannote-cloud.md
@@ -114,4 +114,4 @@ Pairing **local Fireworks-less transcription** with **pyannote cloud diarization
 
 ---
 
-**Next:** [Meta-Analysis Dashboard](14-meta-analysis.md) | **Back:** [Ask AI (RAG Search)](12-rag-search.md) | **Home:** [Guide](README.md)
+**Next:** [Chunked Fireworks Transcription](14-chunked-fireworks.md) | **Back:** [Ask AI (RAG Search)](12-rag-search.md) | **Home:** [Guide](README.md)

--- a/docs/guide/14-chunked-fireworks.md
+++ b/docs/guide/14-chunked-fireworks.md
@@ -1,0 +1,99 @@
+# Chunked Fireworks Transcription (Long Episodes)
+
+Fireworks AI's transcription endpoint enforces an undocumented upload cap that aborts large files mid-upload at the TLS layer. Long podcast episodes (typically over ~2 hours) hit this and fail with a `FIREWORKS_UPLOAD_REJECTED` error. The actionable fallback used to be "re-run on local inference," which works but is slow if you have many such episodes.
+
+**Chunked Fireworks transcription** is the alternative: Podlog splits the audio into smaller pieces, transcribes each separately on Fireworks, and stitches the results back into a single transcript. Diarization runs once on the original whole file via your configured diarization provider — chunking is purely a transcription-side workaround.
+
+This is opt-in. The default is single-shot upload, byte-identical to the historical behavior.
+
+## When to enable it
+
+Turn it on when:
+
+- You have a backlog of episodes that failed with `FIREWORKS_UPLOAD_REJECTED` (or pre-#600 `TRANSIENT_NETWORK` failures whose error message contains the SSL `BAD_RECORD_MAC` signature — same root cause).
+- You want to keep transcription on Fireworks for speed/cost reasons rather than falling back to local for long episodes.
+- You're processing podcasts where episodes routinely exceed ~2 hours.
+
+Keep it off when:
+
+- You don't use Fireworks for transcription at all.
+- You only have short episodes (under ~1 hour) and you've never seen the upload-cap failure.
+- You're fine running long episodes on local inference.
+
+## How it works
+
+1. **Plan**: Podlog probes the audio duration and computes a chunk schedule (default chunk size 15 min, default 3 s overlap between adjacent chunks).
+2. **Extract & upload**: Each chunk is extracted with ffmpeg `-c copy` (no re-encode, fast and lossless) into a tempdir, then uploaded to Fireworks's transcription endpoint.
+3. **Retry & bisect**: If a chunk fails with a transient error, it's retried (default 2 retries). If a chunk hits the upload cap itself, it's bisected — split into halves with the same overlap, recursed up to depth 2 (max 4 sub-chunks). A bisect floor of 30 s prevents infinite recursion when the failure isn't size-related.
+4. **Stitch**: All per-chunk responses are concatenated with timestamps shifted to whole-episode time. In each overlap window, duplicate words are resolved by midpoint split — the earlier chunk owns the first half of the seam, the later chunk owns the second half.
+5. **Diarize**: Diarization runs separately on the **whole file** via the provider configured for the Diarization step (local pyannote or pyannote.ai precision-2 cloud). Per-chunk Fireworks speaker IDs are not used because they cannot be reconciled across chunks (each chunk's `SPEAKER_00` is a different person).
+
+The resulting database row is indistinguishable from a single-shot Fireworks run.
+
+## Setup
+
+### 1. Make sure Fireworks transcription is configured
+
+Open Settings (**http://localhost:3000/settings**) → **Remote Inference** tab. The Transcription step's switch must be set to "Remote" (Fireworks) and a valid Fireworks API key must be saved. If you're new to remote inference, see the existing remote inference docs for getting an API key.
+
+### 2. Enable chunked transcription
+
+Under the Transcription step card you'll now see **Chunk long episodes**. Flip it on. The default tunables work for most cases.
+
+If you want to override defaults, expand **Advanced tunables**:
+
+| Setting | Default | Notes |
+|---|---|---|
+| Chunk size (sec) | 900 (15 min) | Smaller = more uploads but lower risk of hitting the cap. Minimum 60. |
+| Overlap (sec) | 3 | Buffer for words that straddle a cut. 0 makes chunks contiguous (more risk of splitting words). |
+| Per-chunk retries | 2 | Retries on transient errors. Does **not** retry on the upload cap (that triggers bisection instead). |
+
+### 3. Pick a diarization provider
+
+Chunked transcription delegates diarization to your configured provider. Two options:
+
+- **pyannote.ai precision-2 cloud** (recommended for long episodes): no local CPU/RAM cost, no per-chunk reconciliation needed, and pyannote.ai's upload path is presigned-URL PUT (S3-style) which doesn't share Fireworks's cap. See the [pyannote Cloud guide](13-pyannote-cloud.md) for setup.
+- **Local pyannote**: works, but defeats some of the speedup since long episodes are exactly the ones where local diarization is slowest. Use only if you don't want to add another paid service.
+
+> **Open question.** pyannote.ai precision-2's exact size cap is not publicly documented. Podlog's working assumption is that it's effectively unbounded for typical podcast files (architectural signal: presigned-URL upload, no API gateway gating). If you find an episode that fails diarization on precision-2 with a size error, please open an issue — the fallback is local pyannote on the whole file, but no automatic switch is implemented.
+
+### 4. Bulk-retry your backlog
+
+If you already have failed episodes piling up, the Queue dashboard shows a banner with the count and Fireworks cost estimate:
+
+> **245 episodes failed because Fireworks rejected the upload.** Total 21629 min · estimated $129.78 on Fireworks STT.
+
+The "Retry with chunking" button is enabled only after you've turned on chunked transcription in Settings. Click it, confirm the dialog, and Podlog re-enqueues every matching episode. Both post-#600 (`FIREWORKS_UPLOAD_REJECTED`) and pre-#600 (`TRANSIENT_NETWORK` with `BAD_RECORD_MAC`) failures are caught.
+
+## Failure handling
+
+Each chunk has its own failure handling, and the whole episode fails with a clean message naming the offending audio range when something terminal happens.
+
+| Situation | Behavior |
+|---|---|
+| Chunk hits a transient error (`TRANSIENT_NETWORK`, `HTTP_ACCESS`) | Retry up to `chunk_max_retries` times, then bisect or fail. |
+| Chunk hits the upload cap | Bisect into halves, retry. Up to depth 2 (max 4 sub-chunks per original chunk). |
+| Chunk smaller than 30 s still hits the cap | Refuse to bisect further (the cap isn't size-related at that point). Episode fails with `FIREWORKS_CHUNK_FAILED` and the failing audio range. |
+| All bisects exhausted | Episode fails with `FIREWORKS_CHUNK_FAILED` and the original chunk's audio range. **No automatic fallback to local** — surfacing the failure is the design (you decide whether to flip transcription to local for that episode). |
+
+## Cost
+
+Costs are linear in audio minutes regardless of how many chunks you split into — chunking does not duplicate audio billing. The estimated cost shown in the bulk-retry banner is `total_minutes × fireworks_stt_cost_per_minute_usd` (the per-minute rate you configured in Settings → Remote Inference). For 245 episodes totaling ~360 hours at the default $0.006/min rate, that's roughly $130.
+
+A bisect that succeeds adds the bisected sub-chunks' minutes on top of the original chunk's minutes — but bisects are rare in practice unless you're actively hitting the cap, and the duplication is bounded by depth 2.
+
+## Caveats
+
+- **Diarization on local pyannote runs on the whole long file.** If your hardware can't handle whole-file local pyannote, switch the Diarization step to pyannote.ai cloud.
+- **Per-chunk speaker IDs from Fireworks are discarded** when chunked transcription is on. Don't enable Fireworks's `diarize=true` flag (the wiring already overrides it) and don't expect to see speaker labels in the raw Fireworks artifact.
+- **Tempdir disk usage**: each chunk briefly lives on disk during transcription. With 15-minute chunks at typical podcast bitrates, that's ~22 MB per chunk. The tempdir is automatically cleaned up on success or failure.
+- **The worker is single-threaded.** Chunks for one episode upload sequentially, not in parallel. Cross-episode parallelism is unchanged (still one episode at a time per the existing `concurrency=1` design).
+
+## Related
+
+- [Issue #600](https://github.com/brlauuu/podlog/issues/600) — the upstream root cause and `FIREWORKS_UPLOAD_REJECTED` classifier this builds on.
+- [Issue #610](https://github.com/brlauuu/podlog/issues/610) — design discussion and acceptance criteria for the chunked path.
+
+---
+
+**Next:** [Meta-Analysis Dashboard](15-meta-analysis.md) | **Back:** [pyannote Cloud Diarization](13-pyannote-cloud.md) | **Home:** [Guide](README.md)

--- a/docs/guide/15-meta-analysis.md
+++ b/docs/guide/15-meta-analysis.md
@@ -44,4 +44,4 @@ Staleness indicators show the snapshot age next to the refresh button.
 
 ---
 
-**Next:** [Troubleshooting](15-troubleshooting.md) | **Back:** [pyannote Cloud Diarization](13-pyannote-cloud.md) | **Home:** [Guide](README.md)
+**Next:** [Troubleshooting](16-troubleshooting.md) | **Back:** [Chunked Fireworks Transcription](14-chunked-fireworks.md) | **Home:** [Guide](README.md)

--- a/docs/guide/16-troubleshooting.md
+++ b/docs/guide/16-troubleshooting.md
@@ -108,4 +108,4 @@ The host-level health check (`make health-install`) runs the same probes every 1
 
 ---
 
-**Back:** [Meta-Analysis Dashboard](14-meta-analysis.md) | **Home:** [Guide](README.md)
+**Back:** [Meta-Analysis Dashboard](15-meta-analysis.md) | **Home:** [Guide](README.md)

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -17,8 +17,9 @@ Podlog is a self-hosted podcast transcription and search app. It downloads episo
 11. [Hardware & Performance](11-hardware.md) — Processing times, storage estimates
 12. [Ask AI (RAG Search)](12-rag-search.md) — AI-powered Q&A over transcripts
 13. [pyannote Cloud Diarization](13-pyannote-cloud.md) — Optional Precision-2 paid cloud provider
-14. [Meta-Analysis Dashboard](14-meta-analysis.md) — Cross-feed metrics and charts
-15. [Troubleshooting](15-troubleshooting.md) — Common issues and fixes
+14. [Chunked Fireworks Transcription](14-chunked-fireworks.md) — Long-episode workaround for the Fireworks upload cap
+15. [Meta-Analysis Dashboard](15-meta-analysis.md) — Cross-feed metrics and charts
+16. [Troubleshooting](16-troubleshooting.md) — Common issues and fixes
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

PR 6 of 6 — wraps up the #610 sequence. Documents the chunked transcription feature shipped in PRs 1-5.

- **New** `docs/guide/14-chunked-fireworks.md` covering when to enable, the split-transcribe-stitch flow, the whole-file diarization design, setup walkthrough, bulk-retry workflow, failure handling table, cost notes, and caveats including the documented working assumption about pyannote.ai precision-2's cap (no public spec, architectural signal supports unbounded for typical files; flagged in the doc as something to revisit if a real-world test surfaces a limit).
- **Renumber** existing docs to slot the new page into the remote-inference cluster:
  - `14-meta-analysis.md` → `15-meta-analysis.md`
  - `15-troubleshooting.md` → `16-troubleshooting.md`
  - All Next/Back/Home cross-references updated, plus the README index.
- **`docs/configuration.md`** — add the four new env vars to the Fireworks Provider table with a link to the new guide.
- **`docs/guide/08-queue.md`** — cross-reference the bulk-retry workflow from the Queue Dashboard page.

## #610 sequence — done

| PR | Title | Status |
|----|-------|--------|
| #611 | chunked Fireworks transcription scaffolding | merged |
| #614 | wire chunked transcription into `transcribe()` | merged |
| #613 | route diarization to whole-file pass for chunked Fireworks | merged |
| #615 | Settings UI for chunked Fireworks transcription | merged |
| #616 | bulk-retry for upload-rejected episodes | merged |
| this | chunked Fireworks transcription guide | open |

After this lands, the feature is complete end-to-end: backend, settings UI, queue UX, and docs.

## Test plan

- [x] `grep -rn` confirms no stale `14-meta-analysis` / `15-troubleshooting` references remain after the renumber.
- [x] All Next/Back/Home links in the renumbered files point to the new file numbers.
- [ ] Manual: render the `/about` page (which renders CHANGELOG) and confirm the Docs entry shows.
- [ ] Manual: open `/docs` and confirm the new guide appears in the list with the right next/prev links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)