### PR TITLE
fix(config): align default FIREWORKS_CHAT_MODEL with curated dropdown (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ fresh empty `[Unreleased]` is left at the top.
 - "Releases" sidebar on `/about` (right rail, `xl:` and up) listing every changelog version with sticky scroll-spy. Header shows version count and the latest tagged release. ([#606](https://github.com/brlauuu/podlog/pull/606))
 
 ### Fixes
+- Default `FIREWORKS_CHAT_MODEL` updated from `accounts/fireworks/models/llama-v3p1-8b-instruct` (deprecated by Fireworks, would 404 out of the box) to `accounts/fireworks/models/qwen2p5-7b-instruct`. Aligned with the curated Ask-page dropdown. Existing installs with the env var set explicitly keep their value. ([#608](https://github.com/brlauuu/podlog/issues/608))
 - Settings → Remote Inference: changes to chunked-transcription toggle, advanced tunables, and diarization provider/key fields now save correctly. They were previously routed to the Notifications tab's dirty bag, so the Inference Save button stayed disabled and changes were silently dropped. ([#610](https://github.com/brlauuu/podlog/issues/610))
 - Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))
 - CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. (commit `21629cb`)

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -82,7 +82,13 @@ class Settings(BaseSettings):
     fireworks_stt_model: str = "whisper-v3-turbo"
     fireworks_stt_diarize: bool = True
     fireworks_chat_base_url: str = "https://api.fireworks.ai/inference/v1"
-    fireworks_chat_model: str = "accounts/fireworks/models/llama-v3p1-8b-instruct"
+    # Aligned with the curated dropdown in apps/web/src/lib/rag-models.ts
+    # (DEFAULT_FIREWORKS_CHAT_MODEL). The previous default
+    # `llama-v3p1-8b-instruct` was deprecated by Fireworks and 404'd
+    # out of the box (#608). Existing installs with FIREWORKS_CHAT_MODEL
+    # set explicitly in .env keep their value; only no-override installs
+    # are auto-upgraded.
+    fireworks_chat_model: str = "accounts/fireworks/models/qwen2p5-7b-instruct"
     # Cost estimate input for observability (Issue #261).
     # Keep this explicit because provider pricing can change.
     fireworks_stt_cost_per_minute_usd: float = 0.006

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ The worker monitors running jobs and marks them as failed if they exceed expecte
 | `FIREWORKS_STT_MODEL` | `whisper-v3-large` | Fireworks speech-to-text model ID. |
 | `FIREWORKS_STT_DIARIZE` | `true` | Request speaker diarization metadata from Fireworks transcription API. |
 | `FIREWORKS_CHAT_BASE_URL` | `https://api.fireworks.ai/inference/v1` | Base URL for Fireworks OpenAI-compatible chat completions used by Ask generation. |
-| `FIREWORKS_CHAT_MODEL` | `accounts/fireworks/models/llama-v3p1-8b-instruct` | Fireworks chat model used when `RAG_PROVIDER=fireworks` for Ask generation. The Settings UI exposes a curated dropdown of currently-deployed models; this env var supplies the default. |
+| `FIREWORKS_CHAT_MODEL` | `accounts/fireworks/models/qwen2p5-7b-instruct` | Fireworks chat model used when `RAG_PROVIDER=fireworks` for Ask generation. The Settings UI exposes a curated dropdown of currently-deployed models; this env var supplies the default. |
 | `RAG_PROVIDER` | `local` | Issue #608: dedicated provider for the Ask / RAG step. Decoupled from `INFERENCE_PROVIDER` (transcription) so enabling Fireworks for transcription does not silently send retrieved transcript chunks to Fireworks for answer generation. Set to `fireworks` to opt in. |
 | `FIREWORKS_STT_COST_PER_MINUTE_USD` | `0.006` | Cost estimate assumption used for per-episode observability (`estimated_cost_usd = billed_minutes * rate`). |
 | `FIREWORKS_CHUNKED_TRANSCRIPTION_ENABLED` | `false` | Issue #610: split long audio into chunks for upload, then stitch the per-chunk transcripts back. Works around the undocumented Fireworks upload cap (#600). See the [Chunked Fireworks guide](guide/14-chunked-fireworks.md). |


### PR DESCRIPTION
## Summary

Follow-up to the merged #608 sequence. The default `FIREWORKS_CHAT_MODEL` was still pointing at `accounts/fireworks/models/llama-v3p1-8b-instruct` — the model that originally caused the 404 bug — while the web's curated dropdown (#622) shipped `qwen2p5-7b-instruct` as `DEFAULT_FIREWORKS_CHAT_MODEL`. This PR aligns the env default with the web default.

## Why

A fresh install that toggles RAG to Fireworks would persist the deprecated model path on first save, then 404 on the first Ask request — exactly the bug the #608 sequence was supposed to eliminate. The Ask-page UI hides this because the curated dropdown forces the user to pick from a working list, but the underlying default was still wrong.

## Behavior

- **Fresh installs**: get a working default out of the box (`qwen2p5-7b-instruct`).
- **Existing installs with `FIREWORKS_CHAT_MODEL` set in `.env`**: keep their value — pydantic-settings env-var override semantics. No surprise switching.
- **Existing installs *without* the env var**: auto-upgraded from the deprecated path to a working one on next pipeline restart.

## Tests

- Pipeline: 736 pass (no test was asserting the literal default — fixtures mock the value).
- Web: 563 pass.
- `docs/configuration.md` updated to show the new default in the env-var table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)