### PR TITLE
feat(web): link to Fireworks dashboard mirror of pyannote pattern (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Copy-to-clipboard button for the episode UUID on the episode page. Subtle icon next to the title. ([#601](https://github.com/brlauuu/podlog/pull/601))
 - "Releases" sidebar on `/about` (right rail, `xl:` and up) listing every changelog version with sticky scroll-spy. Header shows version count and the latest tagged release. ([#606](https://github.com/brlauuu/podlog/pull/606))
 - Episode page tag strip now shows the same metadata tags as the episode card on the podcast page: language (with flag), Local/Remote inference provider, and a "No labels" warning when diarization didn't produce speaker labels. Speaker name tags remain on the card only. ([#609](https://github.com/brlauuu/podlog/issues/609))
+- Settings → Remote Inference now links out to the Fireworks dashboard from both the API key field ("Generate at fireworks.ai/account/api-keys") and the "What are remote inference providers?" explainer, mirroring the existing pyannote.ai dashboard links. ([#618](https://github.com/brlauuu/podlog/issues/618))
 
 ### Fixes
 - Default `FIREWORKS_CHAT_MODEL` updated from `accounts/fireworks/models/llama-v3p1-8b-instruct` (deprecated by Fireworks, would 404 out of the box) to `accounts/fireworks/models/qwen2p5-7b-instruct`. Aligned with the curated Ask-page dropdown. Existing installs with the env var set explicitly keep their value. ([#608](https://github.com/brlauuu/podlog/issues/608))

--- a/apps/web/src/components/RemoteInferenceSectionParts.tsx
+++ b/apps/web/src/components/RemoteInferenceSectionParts.tsx
@@ -317,8 +317,17 @@ export function RemoteProviderIntro() {
                 <li>You want to free up local resources for other tasks</li>
               </ul>
               <p>
-                Currently, Fireworks AI is the supported provider. You need a
-                Fireworks API key to enable remote processing.
+                Currently,{" "}
+                <a
+                  href="https://fireworks.ai"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Fireworks AI
+                </a>{" "}
+                is the supported provider. You need a Fireworks API key to
+                enable remote processing.
               </p>
             </div>
           </CollapsibleContent>
@@ -342,6 +351,16 @@ export function FireworksApiKeyField({
       <label className="block text-sm font-medium mb-1">Fireworks API Key</label>
       <p className="text-xs text-muted-foreground mb-1.5">
         Required for remote inference. Stored securely and masked on read.
+        Generate at{" "}
+        <a
+          href="https://fireworks.ai/account/api-keys"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          fireworks.ai/account/api-keys
+        </a>
+        .
       </p>
       <div className="relative">
         <input

--- a/apps/web/tests/unit/notification-settings.test.tsx
+++ b/apps/web/tests/unit/notification-settings.test.tsx
@@ -175,6 +175,36 @@ describe("NotificationSettings", () => {
     expect(apiKeyLabel).toBeInTheDocument();
   });
 
+  it("links to the Fireworks dashboard for API key generation (#618)", async () => {
+    const user = userEvent.setup();
+    render(<NotificationSettings />);
+    const inferenceTab = await screen.findByRole("tab", { name: "Remote Inference" });
+    await user.click(inferenceTab);
+    await screen.findByText(/fireworks api key/i);
+
+    // The "Generate at fireworks.ai/account/api-keys" link in the helper text.
+    const apiKeysLink = screen.getByRole("link", {
+      name: /fireworks\.ai\/account\/api-keys/i,
+    });
+    expect(apiKeysLink).toHaveAttribute(
+      "href",
+      "https://fireworks.ai/account/api-keys",
+    );
+    expect(apiKeysLink).toHaveAttribute("target", "_blank");
+
+    // The "Fireworks AI" link lives inside the "What are remote inference
+    // providers?" collapsible — open it first.
+    await user.click(
+      screen.getByRole("button", {
+        name: /What are remote inference providers/i,
+      }),
+    );
+    const explainerLink = await screen.findByRole("link", {
+      name: /^Fireworks AI$/,
+    });
+    expect(explainerLink).toHaveAttribute("href", "https://fireworks.ai");
+  });
+
   it("shows pyannote cloud API key field and explainer in Remote Inference tab", async () => {
     const user = userEvent.setup();
     render(<NotificationSettings />);


### PR DESCRIPTION
## Summary

Closes #618. The pyannote integration links out to `dashboard.pyannote.ai` from both the API key field's helper text and the "What is pyannote cloud?" collapsible. The Fireworks side had no equivalent in-app pointer, so new users had to find the dashboard themselves.

## Changes

- **`FireworksApiKeyField`** helper text now ends with **"Generate at [fireworks.ai/account/api-keys](https://fireworks.ai/account/api-keys)"** (clickable, opens in new tab) — one-for-one mirror of the pyannote API key field copy.
- **"What are remote inference providers?"** collapsible: the "Fireworks AI" mention is now a link to `https://fireworks.ai`.

## Tests

- New regression test in `notification-settings.test.tsx`: opens the Remote Inference tab, asserts both links are present with the correct `href` and `target=_blank`. The explainer link requires expanding the collapsible first (verified).
- Web suite: 571 passed (was 570, +1).
- `npx tsc --noEmit` clean. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)