### PR TITLE
fix(web): make cost-tag tooltips opaque on episode + podcast pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Subtle status indicator for the explore service at the bottom of the Meta-Analysis page. When the container is running, links to the Jupyter URL with a token-fetch hint; when not running, links to the explore guide in the docs. No start/stop UI controls — managed via `make explore` from the CLI by design. ([#607](https://github.com/brlauuu/podlog/issues/607))
 
 ### Fixes
+- Cost-tag tooltips on the episode page (Fireworks STT, pyannote cloud) had a transparent background — caused by a `bg-popover` Tailwind class whose `--popover` CSS variable is not defined in `globals.css`. Switched to the defined `bg-card` / `text-card-foreground`. Same fix applied to the duplicate tooltips on podcast-page episode cards.
 - Default `FIREWORKS_CHAT_MODEL` updated from `accounts/fireworks/models/llama-v3p1-8b-instruct` (deprecated by Fireworks, would 404 out of the box) to `accounts/fireworks/models/qwen2p5-7b-instruct`. Aligned with the curated Ask-page dropdown. Existing installs with the env var set explicitly keep their value. ([#608](https://github.com/brlauuu/podlog/issues/608))
 - Archive task now captures the tail of `ffmpeg`'s stderr when compression fails, instead of storing the placeholder `"ffmpeg error (see stderr output for detail)"`. ([#603](https://github.com/brlauuu/podlog/pull/603))
 - CI Slow's web e2e job now runs `alembic upgrade head` against `db_test` before serving, fixing the `relation "feeds" does not exist` failure introduced when the SSR e2e specs landed. (commit `21629cb`)

--- a/apps/web/src/components/EpisodeCard.tsx
+++ b/apps/web/src/components/EpisodeCard.tsx
@@ -116,7 +116,7 @@ function PyannoteCloudCostTag({ costUsd }: { costUsd: number }) {
         pyannote cloud: {label}
       </Tag>
       {showTooltip && (
-        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-64 p-2 rounded-md bg-popover text-popover-foreground text-xs shadow-md border">
+        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-64 p-2 rounded-md bg-card text-card-foreground text-xs shadow-md border">
           <div className="font-medium mb-1">pyannote cloud (Precision-2)</div>
           {costUsd > 0 ? (
             <div>Estimated cost: ${costUsd.toFixed(4)}</div>
@@ -149,7 +149,7 @@ function FireworksCostTag({ costUsd, audioMinutes }: { costUsd: number; audioMin
         Fireworks STT: ${costUsd.toFixed(2)}
       </Tag>
       {showTooltip && (
-        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-48 p-2 rounded-md bg-popover text-popover-foreground text-xs shadow-md border">
+        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-48 p-2 rounded-md bg-card text-card-foreground text-xs shadow-md border">
           <div className="font-medium mb-1">Fireworks STT Details</div>
           {audioMinutes != null && <div>Audio: {audioMinutes.toFixed(1)} min</div>}
           <div>Cost: ${costUsd.toFixed(4)}</div>

--- a/apps/web/src/components/EpisodeMetaTags.tsx
+++ b/apps/web/src/components/EpisodeMetaTags.tsx
@@ -109,7 +109,7 @@ function PyannoteCloudCostTag({ costUsd }: { costUsd: number }) {
         pyannote cloud: {label}
       </Tag>
       {showTooltip && (
-        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-64 p-2 rounded-md bg-popover text-popover-foreground text-xs shadow-md border">
+        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-64 p-2 rounded-md bg-card text-card-foreground text-xs shadow-md border">
           <div className="font-medium mb-1">pyannote cloud (Precision-2)</div>
           {costUsd > 0 ? (
             <div>Estimated cost: ${costUsd.toFixed(4)}</div>
@@ -148,7 +148,7 @@ function FireworksCostTag({
         Fireworks STT: ${costUsd.toFixed(2)}
       </Tag>
       {showTooltip && (
-        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-48 p-2 rounded-md bg-popover text-popover-foreground text-xs shadow-md border">
+        <div className="absolute z-50 bottom-full mb-1 left-1/2 -translate-x-1/2 w-48 p-2 rounded-md bg-card text-card-foreground text-xs shadow-md border">
           <div className="font-medium mb-1">Fireworks STT Details</div>
           {audioMinutes != null && <div>Audio: {audioMinutes.toFixed(1)} min</div>}
           <div>Cost: ${costUsd.toFixed(4)}</div>


### PR DESCRIPTION
## Summary

The Fireworks STT and pyannote cloud cost tooltips on the episode page (and the duplicate ones on podcast-page episode cards) had a **transparent background** — content behind the tooltip showed through, making it unreadable.

## Cause

The tooltips used Tailwind class `bg-popover`, which references the CSS variable `--popover`. But that variable is **not defined** in `apps/web/src/app/globals.css`. `hsl(var(--popover))` resolved to nothing → background unset → transparent.

## Fix

One-line replacement in 4 places: `bg-popover text-popover-foreground` → `bg-card text-card-foreground`. The `--card` and `--card-foreground` variables ARE defined in `globals.css`, so the tooltip now has a solid background that matches the rest of the card-style surfaces in the app.

Other shadcn `ui/*` components that reference `text-popover-foreground` are unaffected — they pair it with `bg-background` (defined), so their backgrounds were already opaque.

## Files

- `apps/web/src/components/EpisodeMetaTags.tsx` — `FireworksCostTag` + `PyannoteCloudCostTag` tooltips on `/episodes/[id]`.
- `apps/web/src/components/EpisodeCard.tsx` — same two tooltip components, duplicated as documented in #609.

## Test plan

- [x] `npm test` — 565 passed, no regressions.
- [x] `npx tsc --noEmit` — clean (after a stale `.next/types/validator.ts` cleanup unrelated to this change).
- [x] `npm run build` + `docker compose up -d --force-recreate web` succeeds; `/settings`, `/podcasts`, `/episodes/[id]` all return 200.
- [ ] Manual: hover the Fireworks STT tag on an episode page — tooltip background should be solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)