### PR TITLE
fix(web): wrap error details text on podcast page episode cards (#635)

### DIFF
--- a/apps/web/src/components/EpisodeCard.tsx
+++ b/apps/web/src/components/EpisodeCard.tsx
@@ -357,7 +357,7 @@ export default function EpisodeCard({
             )}
           </div>
           {expandedError && ep.error_message && (
-            <pre className="text-xs bg-muted p-2 rounded overflow-x-auto max-h-32">
+            <pre className="text-xs bg-muted p-2 rounded whitespace-pre-wrap break-words overflow-y-auto max-h-32">
               {ep.error_message}
             </pre>
           )}


### PR DESCRIPTION
## Summary
- Error message text in the \"Show details\" section on podcast page episode cards now wraps instead of causing horizontal scroll.

## Changes
- `EpisodeCard.tsx`: replaced `overflow-x-auto` with `whitespace-pre-wrap break-words overflow-y-auto` on the error `<pre>` element.

## Testing
- Visual fix — error messages with long lines now wrap within the card.

Closes #635