### PR TITLE
fix(web): make About-page TOC links land on the right release (#644)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,8 +1,8 @@
 name: Changelog
 
 # Per CLAUDE.md: PRs that ship user-visible behavior must add a one-line
-# entry to CHANGELOG.md under [Unreleased]. This workflow enforces that
-# discipline at the PR level.
+# entry to CHANGELOG.md under the Unreleased heading. This workflow
+# enforces that discipline at the PR level.
 #
 # Escape hatch: add the `no-changelog` label to a PR that genuinely
 # doesn't need an entry — typo fixes, README-only edits, dependency-bot
@@ -53,7 +53,7 @@ jobs:
 
           ❌ This PR does not touch CHANGELOG.md.
 
-          Add a one-line entry under [Unreleased] in CHANGELOG.md describing
+          Add a one-line entry under the "Unreleased" heading in CHANGELOG.md describing
           what changed, grouped under Major changes / Minor changes / Fixes
           (or Internal where appropriate). The entry should read like a
           release note, not a commit message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ Each release section groups changes as:
 
 <!--
 Contributing: every PR with user-visible behavior should add a one-line entry
-under the appropriate `[Unreleased]` heading below. When a release is cut via
-the `release` skill, `[Unreleased]` graduates to a dated version section and a
-fresh empty `[Unreleased]` is left at the top.
+under the appropriate `Unreleased` heading below. When a release is cut via
+the `release` skill, `Unreleased` graduates to a dated version section and a
+fresh empty `Unreleased` is left at the top.
 -->
 
-## [Unreleased]
+## Unreleased
 
 ### Major changes
 - Per-active-provider queue ETA in notifications. The "Est. time left" line in episode notifications now uses the rate of episodes processed by whichever inference provider is currently configured, and tags the line with `(local)` or `(remote)` so the basis is visible. ([#595](https://github.com/brlauuu/podlog/pull/595))
@@ -38,6 +38,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Subtle status indicator for the explore service at the bottom of the Meta-Analysis page. When the container is running, links to the Jupyter URL with a token-fetch hint; when not running, links to the explore guide in the docs. No start/stop UI controls — managed via `make explore` from the CLI by design. ([#607](https://github.com/brlauuu/podlog/issues/607))
 
 ### Fixes
+- Right-rail TOC links on the About page now scroll to the right release. The version headings (`## [0.3.0] — ...`) used markdown reference-link syntax, which made react-markdown render `[0.3.0]` as an anchor pointing to a non-resolvable GitHub compare URL and caused the rendered heading text to drift from the slug used by the TOC, leaving each `<h2>` with no `id`. Reference-link syntax is dropped from version headings (`## 0.3.0 — ...`), the broken compare-URL link defs at the bottom of the file are removed, and the About page version filter is updated to match the new format. ([#644](https://github.com/brlauuu/podlog/issues/644))
 - Curated Fireworks chat models in Settings → Remote Inference → RAG / Ask refreshed. The previous picks (`qwen2p5-7b-instruct`, `llama-v3p1-70b-instruct`, `qwen2p5-72b-instruct`) all returned 404 from Fireworks's serverless endpoint, and the obvious next-generation replacements (`qwen3-8b`, `llama-v3p3-70b-instruct`, `deepseek-v3p1`) were announced as obsolete in a May 2026 Fireworks deprecation notice. Curated trio now follows Fireworks's stated migration targets: `gpt-oss-20b` (Fast), `gpt-oss-120b` (Balanced), `glm-5p1` (Quality). Default `FIREWORKS_CHAT_MODEL` follows. Existing installs with the env var or stored setting set explicitly keep their value. ([#636](https://github.com/brlauuu/podlog/issues/636))
 - Local RAG model selection in Settings → Remote Inference now works. Picking a model from the RAG / Ask step's dropdown persists the choice as `rag_local_model`; the Ask page and episode chat use this as the default when no per-session selection has been made. ([#637](https://github.com/brlauuu/podlog/issues/637))
 - `FIREWORKS_UPLOAD_REJECTED` is now retryable. The TLS-abort signature (`BAD_RECORD_MAC`) was originally classified as non-retryable on the assumption it indicated a hard size/duration cap (#600). Bulk-reprocessing data showed it's actually transient (~14% per-attempt failure rate at any episode size, ~99% recovery on retry), so the standard `retry_max` budget now applies. Episodes only land in `failed` after retries are exhausted; the failure notification copy is updated to reflect this. ([#641](https://github.com/brlauuu/podlog/issues/641))
@@ -63,7 +64,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Surface unavailable audio in the player + add a recovery script. ([#586](https://github.com/brlauuu/podlog/pull/586))
 - Exclude `tests/**` from base tsconfig so `tsc --noEmit` passes. ([#587](https://github.com/brlauuu/podlog/pull/587))
 
-## [0.3.0] — 2026-04-24
+## 0.3.0 — 2026-04-24
 
 ### Major changes
 - **pyannote.ai Precision-2 cloud diarization** as an alternative to local pyannote, selectable per environment via `DIARIZATION_PROVIDER=precision2`. Includes a settings UI, per-episode cost capture (`pyannote_cloud_cost_usd`), and a new `RISK-11` write-up. ([#541](https://github.com/brlauuu/podlog/pull/541), [#542](https://github.com/brlauuu/podlog/pull/542), [#543](https://github.com/brlauuu/podlog/pull/543), [#544](https://github.com/brlauuu/podlog/pull/544))
@@ -95,12 +96,12 @@ fresh empty `[Unreleased]` is left at the top.
 - Remove unused web params, imports, and props. ([#562](https://github.com/brlauuu/podlog/pull/562))
 - Bump web patch/minor deps. ([#574](https://github.com/brlauuu/podlog/pull/574))
 
-## [0.2.0] — 2026-04-24
+## 0.2.0 — 2026-04-24
 
 ### Major changes
 - **Meta-Analysis dashboard** at `/meta-analysis`. Cross-feed metrics — episode counts, durations, words-per-minute, turn density, host/guest share, processing time, token and cost totals — with drill-down charts. ([#538](https://github.com/brlauuu/podlog/pull/538))
 
-## [0.1.3] — 2026-04-20
+## 0.1.3 — 2026-04-20
 
 ### Major changes
 - **Gemma 4 e4b** model option for the Ask AI feature, with per-model `num_ctx` so each model can use its full context window. ([#519](https://github.com/brlauuu/podlog/pull/519))
@@ -112,7 +113,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Ask AI now recovers gracefully from Ollama memory-cap OOMs (unloads cached models and retries once). ([#520](https://github.com/brlauuu/podlog/pull/520))
 - Pipeline boots cleanly under torchaudio 2.8 — pyannote audio-loading restored. ([#447](https://github.com/brlauuu/podlog/pull/447))
 
-## [0.1.2] — 2026-04-20
+## 0.1.2 — 2026-04-20
 
 ### Major changes
 - **Upgrade pyannote diarization to community-1** (from `speaker-diarization-3.1`). Requires a fresh model download on first run. ([#517](https://github.com/brlauuu/podlog/pull/517))
@@ -129,7 +130,7 @@ fresh empty `[Unreleased]` is left at the top.
 ### Other fixes
 - Preserve unicode characters in export filenames. ([#540](https://github.com/brlauuu/podlog/pull/540))
 
-## [0.1.1] — 2026-04-07
+## 0.1.1 — 2026-04-07
 
 ### Major changes
 - **Fireworks AI remote-inference profile** — opt-in alternative to local processing for users who can't or don't want to run Whisper, pyannote, or Ollama locally. Covers transcription/diarization, embeddings, Ask AI generation, retries, observability (latency + cost), and a `docker-compose.remote.yml` overlay. ([#256](https://github.com/brlauuu/podlog/pull/256), [#262](https://github.com/brlauuu/podlog/pull/262), [#263](https://github.com/brlauuu/podlog/pull/263), [#265](https://github.com/brlauuu/podlog/pull/265), [#267](https://github.com/brlauuu/podlog/pull/267), [#268](https://github.com/brlauuu/podlog/pull/268))
@@ -267,7 +268,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Bump minor/patch npm deps. ([#502](https://github.com/brlauuu/podlog/pull/502))
 - Split `search.ts` into per-function modules. ([#504](https://github.com/brlauuu/podlog/pull/504))
 
-## [0.1.0] — 2026-04-04
+## 0.1.0 — 2026-04-04
 
 ### Major changes
 - **Versioning system** introduced — single-source `VERSION` file at the repo root, surfaced in the navbar/About page. ([#162](https://github.com/brlauuu/podlog/pull/162))
@@ -332,7 +333,7 @@ fresh empty `[Unreleased]` is left at the top.
 - Remove unused `@types/dompurify`, add explicit `pydantic` dep. ([#199](https://github.com/brlauuu/podlog/pull/199))
 - Bump `@tanstack/react-query` floor to ^5.96.2. ([#227](https://github.com/brlauuu/podlog/pull/227))
 
-## [0.0.0] — 2026-03-14 to 2026-04-03 (pre-versioning)
+## 0.0.0 — 2026-03-14 to 2026-04-03 (pre-versioning)
 
 The pre-versioning era — initial scaffold and the bulk of foundational features. Not a single release; every notable user-facing addition during this window is bucketed here under one heading.
 
@@ -391,12 +392,3 @@ The early stack was inherited from a more complex design. PRs [#62](https://gith
 
 ### Other internal
 - Split Celery worker into heavy and light queues (later removed in Phase 3). ([#51](https://github.com/brlauuu/podlog/pull/51))
-
-[Unreleased]: https://github.com/brlauuu/podlog/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/brlauuu/podlog/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/brlauuu/podlog/compare/v0.1.3...v0.2.0
-[0.1.3]: https://github.com/brlauuu/podlog/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/brlauuu/podlog/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/brlauuu/podlog/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/brlauuu/podlog/releases/tag/v0.1.0
-[0.0.0]: https://github.com/brlauuu/podlog/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Services: web (:3000), pipeline API (:8000), ollama (:11434).
   - Web: `jest` + `@testing-library/react` for unit, `playwright` for e2e.
 - **PRD references:** When implementing a feature, cite the PRD section (e.g. "per PRD-02 §5.6") in code comments only where the requirement is non-obvious.
 - **When modifying the design:** Update the relevant PRD and RISKS-AND-GAPS.md. Bump the version number.
-- **Changelog:** PRs that ship user-visible behavior add a one-line entry to `CHANGELOG.md` under `[Unreleased]`, grouped as Major / Minor / Fixes (or Internal where appropriate). The same file is rendered at the bottom of `/about` in the web app, so write entries for a human reading them there.
+- **Changelog:** PRs that ship user-visible behavior add a one-line entry to `CHANGELOG.md` under `## Unreleased`, grouped as Major / Minor / Fixes (or Internal where appropriate). Version headings are bare semver (`## 0.3.0 — 2026-04-24`), not the keepachangelog reference-link form (`## [0.3.0]`) — the latter breaks the About-page anchor lookup (#644). The same file is rendered at the bottom of `/about` in the web app, so write entries for a human reading them there.
 
 ## Operational Gotchas
 

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -91,8 +91,15 @@ export default async function AboutPage() {
   const aboutH1 = aboutHeadings.find((h) => h.level === 1);
   const changelogH1 = changelogHeadings.find((h) => h.level === 1);
 
+  // Match version headings — either "Unreleased" or a leading semver
+  // component. Filters out the H1 ("Changelog") and any H2s the markdown
+  // might pick up that aren't releases.
   const versions: AboutTocItem[] = changelogHeadings
-    .filter((h) => h.level === 2 && h.text.startsWith("["))
+    .filter(
+      (h) =>
+        h.level === 2 &&
+        (h.text === "Unreleased" || /^\d+\.\d+\.\d+/.test(h.text)),
+    )
     .map((h) => ({ id: h.id, text: h.text }));
 
   const aboutIdByText = firstOccurrenceMap(aboutHeadings);

--- a/apps/web/src/components/AboutToc.tsx
+++ b/apps/web/src/components/AboutToc.tsx
@@ -101,7 +101,7 @@ export default function AboutToc({ about, changelog }: Props) {
 }
 
 /**
- * `[0.3.0] — 2026-04-24` → `[0.3.0]`. Per #620, the changelog rail shows
+ * `0.3.0 — 2026-04-24` → `0.3.0`. Per #620, the changelog rail shows
  * versions only as numbers; the date sits next to the rendered heading
  * itself anyway so it's redundant in the rail.
  */

--- a/apps/web/tests/unit/about-page.test.tsx
+++ b/apps/web/tests/unit/about-page.test.tsx
@@ -134,7 +134,7 @@ describe("<AboutPage>", () => {
     mockReadFile
       .mockResolvedValueOnce("# About Podlog\n\nAbout body.")
       .mockResolvedValueOnce(
-        "# Changelog\n\n## [Unreleased]\n\n- foo\n\n## [0.3.0] — 2026-04-24\n\n- bar\n"
+        "# Changelog\n\n## Unreleased\n\n- foo\n\n## 0.3.0 — 2026-04-24\n\n- bar\n"
       );
 
     const jsx = await AboutPage();
@@ -150,9 +150,9 @@ describe("<AboutPage>", () => {
     expect(changelogLink).toHaveAttribute("href", "#changelog");
 
     // Nested versions, date stripped, ids match the renderer slugger.
-    const unreleased = screen.getByRole("link", { name: "[Unreleased]" });
+    const unreleased = screen.getByRole("link", { name: "Unreleased" });
     expect(unreleased).toHaveAttribute("href", "#unreleased");
-    const v030 = screen.getByRole("link", { name: "[0.3.0]" });
+    const v030 = screen.getByRole("link", { name: "0.3.0" });
     expect(v030).toHaveAttribute("href", "#030-2026-04-24");
   });
 

--- a/apps/web/tests/unit/about-toc.test.tsx
+++ b/apps/web/tests/unit/about-toc.test.tsx
@@ -12,9 +12,9 @@ describe("<AboutToc>", () => {
       id: "changelog",
       label: "Changelog",
       versions: [
-        { id: "unreleased", text: "[Unreleased]" },
-        { id: "0-3-0-2026-04-24", text: "[0.3.0] — 2026-04-24" },
-        { id: "0-2-0-2026-04-24", text: "[0.2.0] — 2026-04-24" },
+        { id: "unreleased", text: "Unreleased" },
+        { id: "0-3-0-2026-04-24", text: "0.3.0 — 2026-04-24" },
+        { id: "0-2-0-2026-04-24", text: "0.2.0 — 2026-04-24" },
       ],
     },
   };
@@ -33,19 +33,19 @@ describe("<AboutToc>", () => {
     render(<AboutToc {...baseProps} />);
     // Version label is the date-stripped version number, not the raw heading.
     expect(
-      screen.getByRole("link", { name: "[0.3.0]" }),
+      screen.getByRole("link", { name: "0.3.0" }),
     ).toHaveAttribute("href", "#0-3-0-2026-04-24");
     expect(
-      screen.getByRole("link", { name: "[0.2.0]" }),
+      screen.getByRole("link", { name: "0.2.0" }),
     ).toHaveAttribute("href", "#0-2-0-2026-04-24");
     // No date suffix should appear in the rail.
     expect(screen.queryByText(/2026-04-24/)).toBeNull();
   });
 
-  it("preserves the [Unreleased] label as-is (no date to strip)", () => {
+  it("preserves the Unreleased label as-is (no date to strip)", () => {
     render(<AboutToc {...baseProps} />);
     expect(
-      screen.getByRole("link", { name: "[Unreleased]" }),
+      screen.getByRole("link", { name: "Unreleased" }),
     ).toHaveAttribute("href", "#unreleased");
   });
 
@@ -57,7 +57,7 @@ describe("<AboutToc>", () => {
       />,
     );
     expect(
-      screen.queryByRole("link", { name: /\[\d/ }),
+      screen.queryByRole("link", { name: /^\d/ }),
     ).toBeNull();
     // Top-level entries still render.
     expect(screen.getByRole("link", { name: "About" })).toBeInTheDocument();
@@ -67,18 +67,18 @@ describe("<AboutToc>", () => {
 
 describe("stripDate()", () => {
   it("removes em-dash + ISO date suffix", () => {
-    expect(stripDate("[0.3.0] — 2026-04-24")).toBe("[0.3.0]");
+    expect(stripDate("0.3.0 — 2026-04-24")).toBe("0.3.0");
   });
 
   it("removes en-dash + ISO date suffix", () => {
-    expect(stripDate("[0.3.0] – 2026-04-24")).toBe("[0.3.0]");
+    expect(stripDate("0.3.0 – 2026-04-24")).toBe("0.3.0");
   });
 
   it("removes hyphen + ISO date suffix", () => {
-    expect(stripDate("[0.3.0] - 2026-04-24")).toBe("[0.3.0]");
+    expect(stripDate("0.3.0 - 2026-04-24")).toBe("0.3.0");
   });
 
-  it("leaves [Unreleased] untouched", () => {
-    expect(stripDate("[Unreleased]")).toBe("[Unreleased]");
+  it("leaves Unreleased untouched", () => {
+    expect(stripDate("Unreleased")).toBe("Unreleased");
   });
 });

--- a/apps/web/tests/unit/changelog-format.test.ts
+++ b/apps/web/tests/unit/changelog-format.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Locks in the heading format the About page depends on (#644).
+ *
+ * react-markdown renders `## [0.3.0] — 2026-04-24` with the bracketed
+ * portion as an `<a>` element (because of keepachangelog reference-link
+ * defs). The h2 component callback then receives text without the
+ * brackets, but the slug map in `apps/web/src/app/about/page.tsx` is
+ * keyed by the raw markdown text — including the brackets. The lookup
+ * misses, the heading renders without an `id`, and the right-rail TOC
+ * #-anchors point at nothing.
+ *
+ * Keeping version headings as bare semver (no reference-link syntax)
+ * sidesteps the drift entirely.
+ */
+describe("CHANGELOG.md heading format", () => {
+  const path = join(__dirname, "..", "..", "..", "..", "CHANGELOG.md");
+  const content = readFileSync(path, "utf-8");
+
+  const versionHeadings = content
+    .split("\n")
+    .filter((line) => /^## /.test(line));
+
+  it("has at least one version-level heading", () => {
+    expect(versionHeadings.length).toBeGreaterThan(0);
+  });
+
+  it("uses bare semver / 'Unreleased' for every version heading (no bracketed reference-link syntax)", () => {
+    const offenders = versionHeadings.filter((line) => /\[|\]/.test(line));
+    expect(offenders).toEqual([]);
+  });
+
+  it("does not contain reference-link definitions pointing at non-existent compare URLs", () => {
+    // Lines like `[0.3.0]: https://github.com/.../compare/v0.2.0...v0.3.0`.
+    // The project has no `v*` git tags, so each one resolved to a 404
+    // (#644). They should stay deleted.
+    const refLinkDefs = content
+      .split("\n")
+      .filter((line) => /^\[[^\]]+\]:\s*https?:\/\//.test(line));
+    expect(refLinkDefs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #644. Two related complaints from the issue:

1. The right-rail TOC links on the About page were inert — clicking a version did nothing.
2. The version headings themselves were hyperlinks to "not very useful place on github."

Both stem from CHANGELOG.md using keepachangelog reference-link syntax:

```
## [0.3.0] — 2026-04-24
...
[0.3.0]: https://github.com/brlauuu/podlog/compare/v0.2.0...v0.3.0
```

`react-markdown` rendered `[0.3.0]` as an `<a>`. The h2-component callback saw text `"0.3.0 — 2026-04-24"` (brackets stripped by the renderer), but the slug map in `AboutPage` was keyed by the raw markdown text `"[0.3.0] — 2026-04-24"`. Lookup missed → heading rendered with no `id` → `#`-anchors never resolved. The compare URLs also didn't go anywhere useful — the project has no `v*` git tags, so each one was a GitHub 404 / empty-diff page.

## Changes

- `CHANGELOG.md` — drop reference-link syntax from version headings (`## 0.3.0 — ...`); delete the broken compare-URL definitions at the bottom.
- `apps/web/src/app/about/page.tsx` — version-detection filter no longer uses `text.startsWith("[")`; matches `Unreleased` or a leading semver.
- `apps/web/src/components/AboutToc.tsx` — comment refresh; `stripDate` is unchanged.
- Tests refreshed for the new label format.

## Test plan

- [ ] Open `/about`, click each version in the right-rail TOC, verify the page scrolls to the matching `<h2>`
- [ ] Verify version headings render as plain text (no anchor)
- [ ] All web unit tests pass

Closes #644

🤖 Generated with [Claude Code](https://claude.ai/code)
