### PR TITLE
fix(pipeline): declare huggingface-hub as a direct dependency (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- `huggingface-hub` is now declared as a direct pipeline dependency. Previously it was only present transitively via `pyannote-audio` and `whisperx`; `app/services/pyannote.py` imports from it directly, so pinning the version here protects pipeline boot from a future upstream change. Resolved version unchanged. ([#657](https://github.com/brlauuu/podlog/issues/657))
+
 ### Major changes
 - Per-active-provider queue ETA in notifications. The "Est. time left" line in episode notifications now uses the rate of episodes processed by whichever inference provider is currently configured, and tags the line with `(local)` or `(remote)` so the basis is visible. ([#595](https://github.com/brlauuu/podlog/pull/595))
 - Distinct error class for Fireworks upload rejections. When Fireworks aborts an upload at the TLS layer (typically size/duration cap), the failure is classified as `FIREWORKS_UPLOAD_REJECTED`, the retry loop is skipped, and notifications carry an "Action required: re-run on local inference" call-to-action. ([#602](https://github.com/brlauuu/podlog/pull/602))

--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -6460,4 +6460,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "9ac9323380e36da03d0e5501f006ef7a4c62fe3c1825b82fed9b533652c12c7e"
+content-hash = "6162d784e261b0bf72e41b8c233bccef76916b00c05b59f8c708c1d17028156b"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -50,6 +50,12 @@ soundfile = "^0.12.1"
 # pyannote diarization (>=4.0 required by whisperx)
 pyannote-audio = ">=3.1.0"
 
+# Imported directly by app/services/pyannote.py for typed exception classes.
+# Pinned to match the range already required transitively by whisperx (>=0.28.1)
+# and transformers (<1.0); declaring it here protects us from a future upstream
+# change that drops the transitive dep. See issue #657.
+huggingface-hub = ">=0.28.1,<1.0"
+
 # spaCy NER for host/guest inference (PRD-04)
 spacy = "^3.7"
 


### PR DESCRIPTION
## Summary
Resolves #657.

`app/services/pyannote.py` imports `from huggingface_hub.errors import (...)` but `huggingface-hub` was not declared in `apps/pipeline/pyproject.toml` — it worked only because `pyannote-audio` and `whisperx` pull it transitively. Declaring it explicitly protects pipeline boot from a future upstream change.

- Added `huggingface-hub = ">=0.28.1,<1.0"` under `[tool.poetry.group.ml.dependencies]` (matches existing transitive constraints from whisperx and transformers).
- Re-ran `poetry lock`; resolved version unchanged at 0.36.2 (only the content-hash moved).

## Test plan
- [x] `poetry lock` succeeds and does not move the resolved version
- [x] `from app.services.pyannote import diarize` imports cleanly inside the test container
- [x] Pyannote unit tests pass (`pytest -k pyannote` → 44 passed)