### PR TITLE
docs(claude.md): refresh repo-structure tree (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ fresh empty `Unreleased` is left at the top.
 
 ### Internal
 - `huggingface-hub` is now declared as a direct pipeline dependency. Previously it was only present transitively via `pyannote-audio` and `whisperx`; `app/services/pyannote.py` imports from it directly, so pinning the version here protects pipeline boot from a future upstream change. Resolved version unchanged. ([#657](https://github.com/brlauuu/podlog/issues/657))
+- CLAUDE.md repo-structure tree refreshed to match the current on-disk layout — adds `backups/` and `notebooks/`, drops stale agent-metadata entries, fills in new pipeline `api/`/`services/` modules and new web `api/`/`lib/` files, bumps the Alembic migration count to 20. ([#658](https://github.com/brlauuu/podlog/issues/658))
 
 ### Major changes
 - Per-active-provider queue ETA in notifications. The "Est. time left" line in episode notifications now uses the rate of episodes processed by whichever inference provider is currently configured, and tags the line with `(local)` or `(remote)` so the basis is visible. ([#595](https://github.com/brlauuu/podlog/pull/595))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,9 @@ podlog/
 ├── .node-version                   # Node version for local dev
 ├── .nvmrc                          # Node version for nvm users
 ├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow)
-├── .agents/                        # Agent configuration
-├── .superpowers/                   # Superpowers metadata (gitignored)
-├── .omx/                           # Oh-my-codex metadata (gitignored)
 ├── issues/                         # Local issue drafts / notes
+├── backups/                        # Daily DB dumps + rsync audio snapshots (gitignored)
+├── notebooks/                      # Jupyter exploration notebooks (gitignored bind mount)
 ├── apps/
 │   ├── pipeline/                   # Python 3.11 — FastAPI + DB-backed job queue
 │   │   ├── app/
@@ -50,22 +49,24 @@ podlog/
 │   │   │   ├── job_queue.py        # PostgreSQL-backed job queue (enqueue, claim, complete)
 │   │   │   ├── task_registry.py    # Maps pipeline stages to task functions + next-stage routing
 │   │   │   ├── worker.py           # Background job worker + feed polling loop
-│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware, meta_analysis)
+│   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware, meta_analysis, backups, explore, prompts)
 │   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, transcribe_helpers, diarize, chunk, embed, infer, archive, cleanup, prewarm, backfill_chunks, helpers)
-│   │   │   └── services/           # Business logic (rss, whisper, pyannote, pyannote_cloud, alignment, chunking, embed, rag, inference, inference_helpers, meta_analysis, notifications, notification_events, notification_runtime, notification_settings, digest, digest_formatters, events, hardware, fireworks_audio, pipeline_commands, timing_labels)
-│   │   ├── alembic/                # Database migrations (17 versions)
+│   │   │   └── services/           # Business logic (rss, whisper, pyannote, pyannote_cloud, alignment, chunking, embed, rag, inference, inference_helpers, inference_classify, inference_db, inference_ner, inference_types, meta_analysis, notifications, notification_events, notification_runtime, notification_settings, digest, digest_formatters, events, hardware, fireworks_audio, pipeline_commands, timing_labels, prompts, backup_files, backup_settings)
+│   │   ├── alembic/                # Database migrations (20 versions)
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 16 (App Router)
 │       ├── Dockerfile              # Production image (standalone output)
 │       ├── Dockerfile.test         # Test image used by docker-compose.test.yml
 │       ├── src/app/                # Pages: /, /about, /podcasts, /podcasts/[id], /episodes/[id], /queue, /feeds, /ask, /search, /search/print, /settings, /docs, /meta-analysis (and /notifications redirects to /settings); DocsClient lives in app/docs/
-│       ├── src/app/api/            # API routes: search (search, grouped, mentions, speakers), feeds (CRUD, preview, poll), queue, audio, ask/coverage, episodes ([id], ingest, upload, retry, speakers, speakers/merge), docs, hardware, notifications (settings, test), meta-analysis (coverage, refresh, snapshot), pipeline (ask, embed, health, queue/retry)
+│       ├── src/app/api/            # API routes: search (search, grouped, mentions, speakers), feeds (CRUD, preview, poll), queue, audio, ask/coverage, episodes ([id], ingest, upload, retry, speakers, speakers/merge), docs, hardware, notifications (settings, test), meta-analysis (coverage, refresh, snapshot), pipeline (ask, embed, health, queue/retry), backups, prompts
 │       ├── src/components/         # Navbar, AudioPlayer, SearchResult, QueueStatus, etc.
-│       └── src/lib/                # db.ts, search.ts, search/ (coverage, embedding, feedFilter, filters, filterOpts, grouped, grouping, mentions, queryParser, segments, speakerTurns, types), searchHybrid.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx, episode-link.ts, filename.ts, metaAnalysisColors.ts, metaAnalysisStale.ts, metaAnalysisTypes.ts, normalizeName.ts, page-state.ts, queueStatus.ts, rag-models.ts
+│       └── src/lib/                # db.ts, search.ts, search/ (coverage, embedding, feedFilter, filters, filterOpts, grouped, grouping, mentions, queryParser, segments, speakerTurns, types), searchHybrid.ts, timestamp.ts, pipeline.ts, types.ts, utils.ts, speakerColors.ts, validateMergeRequest.ts, citations.tsx, episode-link.ts, filename.ts, dateFormat.ts, docs-index.ts, docs-search.ts, docs-slug.ts, formatFileSize.ts, settings-schema.ts, metaAnalysisColors.ts, metaAnalysisStale.ts, metaAnalysisTypes.ts, normalizeName.ts, page-state.ts, queueStatus.ts, rag-models.ts, keyboardShortcuts.ts, useKeyboardShortcut.ts
 ├── docs/                           # User-facing documentation and guides
 ├── scripts/                        # Operational scripts (nightly audit, health check)
 └── prds/                           # Specifications and risk register
 ```
+
+Agent-tool metadata (`.agents/`, `.superpowers/`, `.omx/`, `.claude/`, `.worktrees/`) lives at the repo root but is gitignored — present locally, not part of the project tree.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
Resolves #658.

CLAUDE.md's repo-structure tree drifted across multiple recent PRs. Bringing it back in line with disk reality:

- Top-level: add `backups/` and `notebooks/`. Drop `.agents/`, `.superpowers/`, `.omx/` from the tree (gitignored agent-tool metadata, not project structure) — replaced with a single explanatory line.
- Pipeline `api/`: add `backups`, `explore`, `prompts`.
- Pipeline `services/`: add `inference_classify`, `inference_db`, `inference_ner`, `inference_types`, `prompts`, `backup_files`, `backup_settings`.
- Web `src/app/api/`: add `backups`, `prompts`.
- Web `src/lib/`: add `dateFormat`, `docs-index`, `docs-search`, `docs-slug`, `formatFileSize`, `settings-schema`, `keyboardShortcuts`, `useKeyboardShortcut`.
- Alembic version count: 17 → 20.

Note: audit flagged `/settings` page as missing, but `apps/web/src/app/settings/` does exist — that finding was stale and is left as-is.

## Test plan
- [x] Cross-checked every claimed path with `ls` against the current tree
- [x] `apps/pipeline/alembic/versions/*.py` count = 20