### PR TITLE
fix(pipeline): skip phantom speaker_names rows in write_speaker_names (#703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ fresh empty `Unreleased` is left at the top.
 - **Daily backups of the database and audio archive.** New `backup` Docker service runs as part of the standard stack, writes `pg_dump --format=custom` files and incremental `rsync --link-dest` audio snapshots to `./backups/` on the host. Retention is 7 daily / 4 weekly / 12 monthly (configurable, set any to 0 to disable). Restore via `make restore-db DATE=...` and `make restore-audio DATE=...` with confirmation prompts. Idempotent across container restarts. See `docs/guide/16-backups.md`. ([#630](https://github.com/brlauuu/podlog/issues/630))
 
 ### Fixes
+- Speaker inference no longer writes phantom `speaker_names` rows. When the classifier produced more guest candidates than the episode had real speakers — common on feeds with many recurring guests in the per-feed cache — the surplus candidates were written as SPEAKER_NN rows with no matching segments, surfacing people who weren't in the audio at all. The writer now consults the segments table and skips slots that aren't actually present in this episode. Issue #703 (PR 1 of 5). ([#703](https://github.com/brlauuu/podlog/issues/703))
 - Docs page section anchors no longer hide their heading behind the sticky navbar after a TOC click or `scrollIntoView` jump. Headings now have a `scroll-margin-top` so they land below the navbar with breathing room. ([#729](https://github.com/brlauuu/podlog/issues/729))
 
 ### Minor changes

--- a/apps/pipeline/app/services/inference_db.py
+++ b/apps/pipeline/app/services/inference_db.py
@@ -204,8 +204,16 @@ def write_speaker_names(
     result: InferenceResult,
     db,
 ) -> None:
-    """Write inferred display names to the speaker_names table."""
-    from app.models import SpeakerName
+    """Write inferred display names to the speaker_names table.
+
+    Only writes a row when the candidate's SPEAKER_NN slot actually exists
+    in this episode's segments (#703). The classifier produces a guest
+    list that includes every recurring-guest name from the feed cache,
+    which is typically much larger than the number of distinct speakers
+    in any single episode; writing the surplus produced phantom rows
+    that listed people who were not in the audio at all.
+    """
+    from app.models import Segment, SpeakerName
 
     # Build a map of new_label → candidate name
     name_assignments: dict[str, CandidateName] = {}
@@ -218,7 +226,23 @@ def write_speaker_names(
         slot = f"SPEAKER_{i + 1:02d}"
         name_assignments[slot] = guest
 
+    # The set of speaker_labels that actually appear in this episode's
+    # segments. Computed once instead of per-candidate.
+    existing_labels = {
+        row[0]
+        for row in db.query(Segment.speaker_label)
+        .filter(Segment.episode_id == episode_id)
+        .filter(Segment.speaker_label.isnot(None))
+        .distinct()
+        .all()
+    }
+
     for new_label, candidate in name_assignments.items():
+        if new_label not in existing_labels:
+            # No segment carries this label — writing a row would create
+            # a phantom speaker entry. Skip silently; the classifier had
+            # more candidates than the episode has speakers.
+            continue
         existing = (
             db.query(SpeakerName)
             .filter(

--- a/apps/pipeline/tests/unit/test_inference.py
+++ b/apps/pipeline/tests/unit/test_inference.py
@@ -1291,10 +1291,42 @@ class TestAssignSpeakerSlots:
 
 # --- write_speaker_names ---
 
+
+def _mock_db_with_segments(existing_labels: list[str], existing_speaker_name=None) -> MagicMock:
+    """Build a MagicMock db that returns `existing_labels` for the
+    segments-query in write_speaker_names and `existing_speaker_name`
+    (which may be None) for the speaker_names lookups.
+
+    The two queries are dispatched off the SQLAlchemy model class passed
+    to `db.query(...)` — Segment for the bound-labels query, SpeakerName
+    for the per-slot upsert lookup.
+    """
+    from app.models import Segment, SpeakerName
+
+    db = MagicMock()
+
+    segments_q = MagicMock()
+    segments_q.filter.return_value.filter.return_value.distinct.return_value.all.return_value = [
+        (label,) for label in existing_labels
+    ]
+
+    speaker_names_q = MagicMock()
+    speaker_names_q.filter.return_value.first.return_value = existing_speaker_name
+
+    def _route_query(model):
+        if model is SpeakerName:
+            return speaker_names_q
+        # Otherwise treat as the segments scalar select (Segment.speaker_label).
+        return segments_q
+
+    db.query.side_effect = _route_query
+    return db
+
+
 class TestWriteSpeakerNames:
     def test_writes_inferred_host_and_guest(self):
-        db = MagicMock()
-        db.query.return_value.filter.return_value.first.return_value = None
+        # Both SPEAKER_00 and SPEAKER_01 exist in the episode's segments.
+        db = _mock_db_with_segments(["SPEAKER_00", "SPEAKER_01"])
 
         host = CandidateName(name="Tim Ferriss", source="feed_title", role="host", confidence="HIGH")
         guest = CandidateName(name="Jane Smith", source="episode_description", role="guest", confidence="MEDIUM")
@@ -1311,8 +1343,7 @@ class TestWriteSpeakerNames:
         existing = MagicMock()
         existing.confirmed_by_user = True
 
-        db = MagicMock()
-        db.query.return_value.filter.return_value.first.return_value = existing
+        db = _mock_db_with_segments(["SPEAKER_00"], existing_speaker_name=existing)
 
         host = CandidateName(name="Tim Ferriss", source="feed_title", role="host", confidence="HIGH")
         result = InferenceResult(host=host, guests=[])
@@ -1323,6 +1354,43 @@ class TestWriteSpeakerNames:
         # Should NOT have been modified
         assert db.add.call_count == 0
         assert existing.display_name != "Tim Ferriss"  # unchanged (still mock default)
+
+    def test_skips_slots_with_no_segments(self):
+        """#703: the classifier can produce far more guest candidates than
+        the episode has real speakers. write_speaker_names must not write
+        phantom rows for SPEAKER_NN slots that no segment carries."""
+        # Episode has only two actual speakers; classifier produced four
+        # guest candidates so it tried to fill SPEAKER_01..SPEAKER_04.
+        db = _mock_db_with_segments(["SPEAKER_00", "SPEAKER_01"])
+
+        host = CandidateName(name="Tim Ferriss", source="feed_title", role="host", confidence="HIGH")
+        guests = [
+            CandidateName(name="Jane Smith", source="ner", role="guest", confidence="HIGH"),
+            CandidateName(name="Carlos Garcia", source="feed_speaker_cache", role="guest", confidence="HIGH"),
+            CandidateName(name="Marie Curie", source="feed_speaker_cache", role="guest", confidence="HIGH"),
+            CandidateName(name="Ada Lovelace", source="feed_speaker_cache", role="guest", confidence="HIGH"),
+        ]
+        result = InferenceResult(host=host, guests=guests)
+        label_map = {}
+
+        write_speaker_names("ep-1", label_map, result, db)
+
+        # Only SPEAKER_00 (host) and SPEAKER_01 (first guest) should be
+        # written; SPEAKER_02..04 had no segments so they're skipped.
+        assert db.add.call_count == 2
+
+    def test_skips_host_slot_when_no_segments_match(self):
+        """If even SPEAKER_00 has no segments — e.g., diarization failed
+        and the table is empty — the host row is also skipped."""
+        db = _mock_db_with_segments([])
+
+        host = CandidateName(name="Solo Speaker", source="feed_title", role="host", confidence="HIGH")
+        result = InferenceResult(host=host, guests=[])
+        label_map = {}
+
+        write_speaker_names("ep-1", label_map, result, db)
+
+        assert db.add.call_count == 0
 
 
 # --- Soft failure in task ---


### PR DESCRIPTION
## Summary

First of five PRs for #703 (speaker-inference tuning). This one is the safest, smallest change in the set: stop writing \`speaker_names\` rows for SPEAKER_NN slots that don't actually exist in the episode's segments.

### Why this matters
On feeds with many recurring guests cached in \`feed_speaker_cache\`, the inference classifier produces a guest list far longer than the number of distinct speakers in any given episode. \`write_speaker_names\` was zipping that list onto SPEAKER_01, SPEAKER_02, … mechanically, producing rows for speakers that don't appear in the audio. Episode \`19e78f3d-a7e5-427a-b8be-45b23737c120\` (3 real voices) had 31 \`speaker_names\` rows including 28 with zero matching segments.

### Fix
Inside \`write_speaker_names\`, query the segments table once for the set of distinct \`speaker_label\` values that actually appear, then skip any candidate whose slot is not in that set.

### Behavior delta
- Episodes whose classifier candidate count already matched the real speaker count: no change.
- Episodes that previously produced phantom rows: future inference runs no longer produce them.
- Existing phantom rows from past inference runs: untouched (per the discussion, the user prefers to clean those up manually on a per-episode basis, not via a one-shot script).

### Test plan
- [x] Updated TestWriteSpeakerNames to mock the new segments query (helper function \`_mock_db_with_segments\`).
- [x] Two new test cases: \`test_skips_slots_with_no_segments\` (4 guest candidates, episode has 2 speakers; only 2 rows written) and \`test_skips_host_slot_when_no_segments_match\` (segments empty; nothing written).
- [x] \`pytest -k "infer or speaker"\` — 183 passed, 1 skipped (existing).

### Follow-up PRs in this series
- PR 2: short-speaker → role='other' with run-based logic
- PR 3: cache prior gating (recurring guests need this-episode corroboration)
- PR 4: transcript as 4th NER source
- PR 5: under-the-hood documentation in \`docs/guide/06-speakers.md\`