### PR TITLE
fix(pipeline): split isolated short runs of real labels as Other (#703 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- Speaker inference: a short pyannote run inside an otherwise-real label is now split off as Other when its nearest same-label neighbour is more than 60 s away. Catches the case where pyannote conflates a short cold-open / pre-roll voice with a real speaker's voice into one label — previously the cold-open got silently attached to the real speaker. Mid-conversation interjections (host's "yeah" between guest answers) stay with the parent speaker because their gap-to-nearest-same-label is small. Follow-up to #703. ([#703](https://github.com/brlauuu/podlog/issues/703))
+
 ## 0.4.6 — 2026-05-14
 
 ### Major changes

--- a/apps/pipeline/app/services/inference.py
+++ b/apps/pipeline/app/services/inference.py
@@ -53,6 +53,14 @@ from app.services.inference_types import (
 DEFAULT_SHORT_RUN_SECONDS = 15.0
 DEFAULT_SHORT_RUN_SEGMENTS = 20
 DEFAULT_RUN_GAP_SECONDS = 2.0
+# Follow-up to #703 PR 2 (option C refinement): a short run inside an
+# otherwise-real pyannote label still gets split off as Other when its
+# nearest same-label neighbour (previous or next run with the same
+# pyannote label) is more than this many seconds away. Catches the
+# "cold-open / outro voice that pyannote mis-clustered into a real
+# speaker" case without breaking mid-conversation interjections, which
+# typically sit within 5-30s of the speaker's surrounding monologue.
+DEFAULT_ISOLATION_GAP_SECONDS = 60.0
 
 __all__ = [
     "CandidateName",
@@ -144,6 +152,7 @@ def assign_speaker_slots(
     short_run_seconds: float = DEFAULT_SHORT_RUN_SECONDS,
     short_run_segments: int = DEFAULT_SHORT_RUN_SEGMENTS,
     run_gap_seconds: float = DEFAULT_RUN_GAP_SECONDS,
+    isolation_gap_seconds: float = DEFAULT_ISOLATION_GAP_SECONDS,
 ) -> SlotAssignment:
     """Remap pyannote speaker labels into final SPEAKER_NN slots (#703).
 
@@ -166,6 +175,16 @@ def assign_speaker_slots(
     where adjacent pairs are at most ``run_gap_seconds`` apart and no
     other speaker spoke in between (the "no other speaker" condition
     is automatic because the input is time-sorted).
+
+    **Isolated-short-run carve-out** (option C follow-up to PR 2): a
+    short run inside an otherwise-real pyannote label is *also* split
+    off as its own ``role='other'`` slot when its temporally-nearest
+    same-label neighbour is more than ``isolation_gap_seconds`` away.
+    Catches the case where pyannote mis-clusters a short intro / outro
+    voice into a real speaker's cluster. Mid-conversation interjections
+    (host's "yeah" between guest answers) typically sit within a few
+    seconds of surrounding same-label runs, so they stay with the
+    parent speaker.
 
     ``result`` is currently accepted for backward-compat with prior
     call sites but is unused — the function only inspects the segment
@@ -227,13 +246,51 @@ def assign_speaker_slots(
 
     real_labels = {lbl for lbl, real in label_has_real_run.items() if real}
 
+    # --- Step 2.5: flag isolated short runs of real labels for splitting ---
+    # Compare each short run inside a real label against its temporally-
+    # nearest same-label neighbour. If the gap exceeds isolation_gap_seconds,
+    # the run is split off as Other even though its parent label has real
+    # runs elsewhere — protects against the "cold-open mis-clustered into
+    # the host slot" case (issue #703 follow-up).
+    runs_by_label: dict[str, list[dict]] = {}
+    for run in runs:
+        runs_by_label.setdefault(run["label"], []).append(run)
+    isolated_real_short_run_ids: set[int] = set()
+    for lbl in real_labels:
+        same = runs_by_label[lbl]  # already in time order
+        for i, run in enumerate(same):
+            is_real = (
+                run["duration"] >= short_run_seconds
+                or run["seg_count"] >= short_run_segments
+            )
+            if is_real:
+                continue
+            prev_gap = (
+                run["start_time"] - same[i - 1]["last_end"]
+                if i > 0
+                else float("inf")
+            )
+            next_gap = (
+                same[i + 1]["start_time"] - run["last_end"]
+                if i + 1 < len(same)
+                else float("inf")
+            )
+            if min(prev_gap, next_gap) > isolation_gap_seconds:
+                isolated_real_short_run_ids.add(id(run))
+
     # --- Step 3: number real labels (SPEAKER_00..) and short runs after them ---
     real_sorted = sorted(real_labels, key=lambda lbl: (label_first_appearance[lbl], lbl))
     label_remap: dict[str, str] = {
         old: f"SPEAKER_{i:02d}" for i, old in enumerate(real_sorted)
     }
 
-    short_runs = [r for r in runs if r["label"] not in real_labels]
+    # Pool of runs that get their own Other slot: every run from a
+    # fully-short label, plus isolated short runs flagged in step 2.5.
+    short_runs = [
+        r for r in runs
+        if r["label"] not in real_labels
+        or id(r) in isolated_real_short_run_ids
+    ]
     short_runs.sort(key=lambda r: (r["start_time"], r["label"]))
     next_slot = len(real_sorted)
     other_labels: set[str] = set()
@@ -248,11 +305,10 @@ def assign_speaker_slots(
     # --- Step 4: build per-segment new label list ---
     new_labels: list[str | None] = [None] * len(segments)
     for run in runs:
-        lbl = run["label"]
-        if lbl in real_labels:
-            target = label_remap[lbl]
-        else:
+        if id(run) in run_to_new:
             target = run_to_new[id(run)]
+        else:
+            target = label_remap[run["label"]]
         for idx in run["members"]:
             new_labels[idx] = target
 

--- a/apps/pipeline/tests/unit/test_inference.py
+++ b/apps/pipeline/tests/unit/test_inference.py
@@ -1607,6 +1607,39 @@ class TestAssignSpeakerSlots:
         assert a_relaxed.other_labels == set()
         assert a_relaxed.new_labels[0] == a_relaxed.new_labels[2]
 
+    def test_real_label_with_mixed_short_runs_splits_only_isolated_ones(self):
+        """A real label can have both isolated short runs (split off as
+        Other) and adjacent short interjections (stay glued) — they're
+        evaluated independently."""
+        segments = [
+            _seg("SPEAKER_X", 0, 4),         # cold-open: 4s short, isolated from rest
+            _seg("SPEAKER_Y", 10, 80),       # Y monologue (real, 70s)
+            _seg("SPEAKER_X", 200, 280),     # X real (80s)
+            _seg("SPEAKER_Y", 280, 281),     # Y "yeah" (1s, 200s after Y's first run)
+            _seg("SPEAKER_Y", 282, 360),     # Y resumes (real, 78s)
+            _seg("SPEAKER_X", 365, 365.5),   # X says "right" 85s after X's real run
+        ]
+        a = assign_speaker_slots(None, segments)
+        # Real labels (X has the 200-280 run, Y has 10-80 and 282-360) get
+        # the first two SPEAKER_NN slots by first-appearance time:
+        #   X first appears at 0s, Y at 10s → X=SPEAKER_00, Y=SPEAKER_01.
+        # Y's "yeah" at 280-281 is 200s after Y's run ended at 80s, BUT
+        # 1s before Y's next run starts at 282s. min_gap = 1s < 60s → stay
+        # with Y.
+        assert a.new_labels[3] == "SPEAKER_01"
+        # X's cold-open at 0-4 has nearest same-label neighbour 196s away
+        # → split off as Other.
+        assert a.new_labels[0] in a.other_labels
+        # X's "right" at 365-365.5 is 85s after X's real run ended at 280s
+        # AND no later X runs → only prev_gap counts, 85s > 60s → split.
+        assert a.new_labels[5] in a.other_labels
+        # The two split-off slots are distinct.
+        assert a.new_labels[0] != a.new_labels[5]
+        # The real-label slots are unchanged.
+        assert a.new_labels[1] == "SPEAKER_01"
+        assert a.new_labels[2] == "SPEAKER_00"
+        assert a.new_labels[4] == "SPEAKER_01"
+
     def test_short_run_at_label_boundary_uses_only_existing_neighbour(self):
         """A short run that's the first run of its label (no
         previous-same-label run) only has to clear the gap to the

--- a/apps/pipeline/tests/unit/test_inference.py
+++ b/apps/pipeline/tests/unit/test_inference.py
@@ -1538,21 +1538,91 @@ class TestAssignSpeakerSlots:
 
     def test_real_label_keeps_short_interjections_together(self):
         """Option B: a pyannote label with at least one real run keeps
-        all its segments — even brief interjections — together. Trust
-        pyannote at the label level when the speaker is established."""
+        all its segments — even brief interjections — together when
+        the interjection sits within the isolation-gap window of the
+        rest of the label's runs."""
         segments = [
             _seg("SPEAKER_X", 0, 50),       # X: 50s real monologue
             _seg("SPEAKER_Y", 50, 100),     # Y: 50s real monologue
-            _seg("SPEAKER_X", 105, 105.5),  # X says "yeah" (0.5s, breaks run)
+            _seg("SPEAKER_X", 105, 105.5),  # X says "yeah" 55s after run 1 ends
             _seg("SPEAKER_Y", 106, 150),    # Y continues
         ]
         a = assign_speaker_slots(None, segments)
-        # SPEAKER_X is real (50s run), so its short interjection stays with it.
+        # SPEAKER_X is real (50s run), short interjection is within the
+        # default 60s isolation window → stays with X.
         assert a.new_labels[0] == "SPEAKER_00"
         assert a.new_labels[2] == "SPEAKER_00"  # short "yeah" stays with X
         assert a.new_labels[1] == "SPEAKER_01"
         assert a.new_labels[3] == "SPEAKER_01"
         assert a.other_labels == set()
+
+    def test_isolated_short_run_of_real_label_splits_off_as_other(self):
+        """Option C (#703 follow-up): a short run inside an otherwise-
+        real pyannote label is split off as Other when its nearest
+        same-label neighbour is more than isolation_gap_seconds away.
+        Targets the cold-open-mis-clustered case."""
+        segments = [
+            # SPEAKER_X has a 4s cold open at 0, then doesn't reappear
+            # until 200s — pyannote conflated two voices into one
+            # label.
+            _seg("SPEAKER_X", 0, 4),         # cold open (4s, short run)
+            _seg("SPEAKER_Y", 10, 80),       # Y monologue (real)
+            _seg("SPEAKER_Y", 81, 199),      # Y continues
+            _seg("SPEAKER_X", 200, 280),     # X's real content (80s, real)
+            _seg("SPEAKER_X", 281, 360),     # X continues
+        ]
+        a = assign_speaker_slots(None, segments)
+        # X is "real" (has the 200-280 run), Y is real. Real-label
+        # assignment by first appearance: Y first (10s) → SPEAKER_00 (no,
+        # wait — X appears first at t=0, so X → SPEAKER_00 if it's real).
+        # X *is* real because of the 80s run at 200-280. So:
+        #   X → SPEAKER_00, Y → SPEAKER_01.
+        # But the cold-open at 0-4 is isolated from X's next run by
+        # 196s (>60s) → split off as Other.
+        assert a.new_labels[0] != a.new_labels[3]  # cold-open ≠ X's real run
+        assert a.new_labels[0] in a.other_labels
+        assert a.new_labels[3] == "SPEAKER_00"  # X's real run keeps the slot
+        assert a.new_labels[4] == "SPEAKER_00"
+        # Y is unaffected.
+        assert a.new_labels[1] == "SPEAKER_01"
+        assert a.new_labels[2] == "SPEAKER_01"
+
+    def test_isolation_threshold_is_configurable(self):
+        """Bumping isolation_gap_seconds preserves short runs that
+        would otherwise split off."""
+        # 113s gap between SPEAKER_X's two runs.
+        segments = [
+            _seg("SPEAKER_X", 0, 4),         # short run
+            _seg("SPEAKER_Y", 10, 100),      # Y real
+            _seg("SPEAKER_X", 117, 200),     # X real run (83s away)
+        ]
+        # Default 60s isolation: split.
+        a_default = assign_speaker_slots(None, segments)
+        assert a_default.new_labels[0] in a_default.other_labels
+
+        # Relaxed 200s isolation: keep together.
+        a_relaxed = assign_speaker_slots(
+            None, segments, isolation_gap_seconds=200.0
+        )
+        assert a_relaxed.other_labels == set()
+        assert a_relaxed.new_labels[0] == a_relaxed.new_labels[2]
+
+    def test_short_run_at_label_boundary_uses_only_existing_neighbour(self):
+        """A short run that's the first run of its label (no
+        previous-same-label run) only has to clear the gap to the
+        next same-label run, not the missing previous one."""
+        segments = [
+            # X cold open at 0, X's next run is 10s later (well within
+            # the 60s isolation window).
+            _seg("SPEAKER_X", 0, 4),         # short run, no prev neighbour
+            _seg("SPEAKER_X", 14, 80),       # X's real run, 10s gap
+            _seg("SPEAKER_Y", 80, 130),
+        ]
+        a = assign_speaker_slots(None, segments)
+        # Cold open's nearest neighbour is X's run at 14s (10s gap)
+        # — under threshold, stay glued to X.
+        assert a.other_labels == set()
+        assert a.new_labels[0] == a.new_labels[1] == "SPEAKER_00"
 
     def test_run_extends_across_small_gap(self):
         """Two segments by the same speaker separated by < 2s are one run."""

--- a/docs/guide/06-speakers.md
+++ b/docs/guide/06-speakers.md
@@ -116,7 +116,9 @@ This is the step that handles the "first speaker isn't always the host" problem.
 
 Why "real" looks at runs not totals: a speaker who talks for 30 seconds in one block is a real participant even if they only have 1 or 2 segments; a speaker with 13 scattered 1-second interjections is almost always a diarization slip or a multi-voice misclustering, not a real participant.
 
-Defaults are exposed as module constants in [`inference.py`](https://github.com/brlauuu/podlog/blob/9237a61b712ccb288a6ef5b89ce4bc5c39e4c60c/apps/pipeline/app/services/inference.py#L51) — `DEFAULT_SHORT_RUN_SECONDS = 15.0`, `DEFAULT_SHORT_RUN_SEGMENTS = 20`, `DEFAULT_RUN_GAP_SECONDS = 2.0`.
+**Isolated-short-run carve-out.** Step 4 above keeps short interjections glued to a real pyannote label by default, which trusts pyannote's clustering at the label level. That trust breaks down when pyannote conflates two different voices into one label — for example, a 4-second cold-open / pre-roll voice that gets clustered with the guest because both clips are short. To catch this without over-fragmenting normal back-and-forth, a short run is *also* split off as Other when its temporally-nearest same-label neighbour (previous or next run with the same pyannote label) is more than `DEFAULT_ISOLATION_GAP_SECONDS = 60.0` away. Typical mid-conversation interjections sit within a few seconds of surrounding same-label runs, so they stay; an isolated intro voice with a > 60 s gap before its parent label reappears gets the Other treatment.
+
+Defaults are exposed as module constants in `inference.py` — `DEFAULT_SHORT_RUN_SECONDS = 15.0`, `DEFAULT_SHORT_RUN_SEGMENTS = 20`, `DEFAULT_RUN_GAP_SECONDS = 2.0`, `DEFAULT_ISOLATION_GAP_SECONDS = 60.0`.
 
 ### Why some speakers come up as Other
 


### PR DESCRIPTION
## Summary

Refinement of the run-based slot assignment from #703 PR 2 (option B), motivated by a real failure on episode 19e78f3d after the user re-ran inference. pyannote re-clustered the audio into only 2 speaker labels this time, conflating the 3.7-second cold-open voice with the guest's voice. The existing option-B rule (keep all segments together when the parent label has any real run) silently attached the cold-open to the guest.

### The new rule

A short run inside an otherwise-real pyannote label is split off as Other when its temporally-nearest same-label neighbour is more than `DEFAULT_ISOLATION_GAP_SECONDS = 60.0` s away.

| Case | Gap to nearest same-label run | Behavior |
|---|---:|---|
| Cold-open at 0–4 s, parent label resumes 113 s later | 113 s | **Split → Other** |
| Host "yeah" 5 s after the host's previous turn ended | 5 s | Stay with host |
| Host follow-up after a 55-second guest answer | 55 s | Stay with host |
| Isolated outro voice with no same-label run within 60 s either side | ∞ | **Split → Other** |

60 s is the upper end of normal turn-taking rhythm in interview-style podcasts, so the rule fires only on truly orphaned short runs.

### What changes for episode 19e78f3d on next re-inference

Today: SPEAKER_00 (Dror, renamed) contains 659 segments including the 0.577–4.235 s cold-open as its first segment.

After this PR: the cold-open's nearest same-label neighbour is 113 s later; gap > 60 s; split off as its own Other slot. SPEAKER_00 keeps the other 658 Dror segments. The Other slot can be merged or named separately from the UI.

### Test plan
- [x] 3 new tests in TestAssignSpeakerSlots: isolated-short-splits, threshold-configurable, label-boundary-uses-only-existing-neighbour.
- [x] Existing test_real_label_keeps_short_interjections_together still passes (55s gap < 60s threshold).
- [x] Full pipeline unit suite: 823 passed, 1 skipped.
- [x] docs/guide/06-speakers.md updated to document the isolation carve-out.

### Note

This is a behavior change in `assign_speaker_slots`. Episodes already in the DB won't see the effect until they're re-inferred — same as PRs 1–5 of #703.