### PR TITLE
feat(web): footer flags when running image is stale vs VERSION on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Minor changes
+- Footer shows the version of the running build and warns when a newer one is on disk. The footer reads `process.env.NEXT_PUBLIC_APP_VERSION` (baked into the image at build time) for "what's running," and fetches `/api/version` (which reads the `VERSION` file bind-mounted into the container at `/version`) for "what's on disk." When the on-disk semver is strictly greater than the built-in one, the footer renders `v0.X.Y → 0.X.Z (rebuild available)` in amber as a nudge to rebuild + restart. Silent in matched / downgrade / file-missing / fetch-failed cases.
+
 ### Fixes
 - Speaker inference: a short pyannote run inside an otherwise-real label is now split off as Other when its nearest same-label neighbour is more than 60 s away. Catches the case where pyannote conflates a short cold-open / pre-roll voice with a real speaker's voice into one label — previously the cold-open got silently attached to the real speaker. Mid-conversation interjections (host's "yeah" between guest answers) stay with the parent speaker because their gap-to-nearest-same-label is small. Follow-up to #703. ([#703](https://github.com/brlauuu/podlog/issues/703))
 

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,0 +1,34 @@
+import { promises as fs } from "fs";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * `built_in` — version baked into the running image at `docker build`
+ * time via the APP_VERSION arg → NEXT_PUBLIC_APP_VERSION env var.
+ * Sourced from process.env so server- and client-side stay in sync.
+ *
+ * `on_disk` — current contents of the repo-root VERSION file,
+ * bind-mounted into the container at /version (see docker-compose.yml).
+ * Reading at request time lets the footer detect a bump-since-last-
+ * rebuild without rebuilding to find out.
+ *
+ * Returns 200 on success; 200 with on_disk=null when the file is
+ * missing (development mode, no mount, or the file got deleted).
+ */
+const VERSION_FILE_PATH = process.env.VERSION_FILE_PATH ?? "/version";
+
+export async function GET() {
+  const builtIn = process.env.NEXT_PUBLIC_APP_VERSION ?? null;
+  let onDisk: string | null = null;
+  try {
+    const raw = await fs.readFile(VERSION_FILE_PATH, "utf-8");
+    const trimmed = raw.trim();
+    onDisk = trimmed.length > 0 ? trimmed : null;
+  } catch {
+    // File missing (no bind mount) or unreadable — degrade silently;
+    // the footer will treat this as "can't compare" and stay quiet.
+    onDisk = null;
+  }
+  return NextResponse.json({ built_in: builtIn, on_disk: onDisk });
+}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,6 +1,44 @@
-const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
+"use client";
+
+import { useEffect, useState } from "react";
+import { isOnDiskNewer } from "@/lib/semver";
+
+interface VersionResponse {
+  built_in: string | null;
+  on_disk: string | null;
+}
 
 export default function Footer() {
+  // Read NEXT_PUBLIC_APP_VERSION inside the component so tests can
+  // set it per-test without juggling module-level captures. Next.js
+  // inlines the value at build time in production, so this is
+  // equivalent to a module-level constant for runtime cost.
+  const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0";
+
+  // On-disk VERSION (read from /version inside the container, see
+  // docker-compose.yml). When it's strictly newer than what's baked
+  // into the running image, the footer tags the version with a
+  // rebuild-available hint (#744).
+  const [onDisk, setOnDisk] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/version", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: VersionResponse | null) => {
+        if (cancelled || !data) return;
+        setOnDisk(data.on_disk);
+      })
+      .catch(() => {
+        // Network/parse failures stay silent — equivalent to "can't compare"
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const stale = isOnDiskNewer(onDisk, APP_VERSION);
+
   return (
     <footer className="border-t border-border bg-background text-xs text-muted-foreground mt-auto">
       <div className="max-w-5xl mx-auto px-4 py-4 flex flex-col items-center gap-1">
@@ -24,7 +62,17 @@ export default function Footer() {
             O&apos;Saasy License
           </a>
         </p>
-        <p>v{APP_VERSION}</p>
+        <p>
+          v{APP_VERSION}
+          {stale && onDisk && (
+            <span
+              className="ml-2 text-amber-600 dark:text-amber-400"
+              title="The VERSION file on disk is newer than the version baked into this image. Rebuild + restart to pick up the latest changes."
+            >
+              → {onDisk} (rebuild available)
+            </span>
+          )}
+        </p>
       </div>
     </footer>
   );

--- a/apps/web/src/lib/semver.ts
+++ b/apps/web/src/lib/semver.ts
@@ -1,0 +1,67 @@
+/**
+ * Tiny semver comparator for the footer's stale-build check (#744).
+ *
+ * Avoids pulling in the full `semver` npm dep for a single comparison.
+ * Parses `MAJOR.MINOR.PATCH` triples (extra pre-release / build
+ * metadata after the patch is tolerated but ignored for ordering
+ * — fine for our 0.x.y world; revisit when we hit 1.0.0 and start
+ * caring about pre-release ordering).
+ */
+export interface SemverParts {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * Parse a `MAJOR.MINOR.PATCH...` string. Returns null when the input
+ * isn't shaped like a semver (missing components, non-numeric pieces).
+ * Leading "v" is tolerated.
+ */
+export function parseSemver(text: string): SemverParts | null {
+  if (typeof text !== "string") return null;
+  const trimmed = text.trim().replace(/^v/i, "");
+  // Match a leading MAJOR.MINOR.PATCH; ignore whatever follows (pre-release,
+  // build metadata, trailing whitespace).
+  const m = trimmed.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return {
+    major: Number.parseInt(m[1], 10),
+    minor: Number.parseInt(m[2], 10),
+    patch: Number.parseInt(m[3], 10),
+  };
+}
+
+/**
+ * Numeric three-part compare. Returns:
+ *   -1 if `a < b`
+ *    0 if equal
+ *    1 if `a > b`
+ *
+ * Either side null → 0 (treat as equal so callers don't false-alarm
+ * when the input is malformed). Callers that need to distinguish
+ * "couldn't compare" should check parseSemver explicitly first.
+ */
+export function compareSemver(
+  a: SemverParts | null,
+  b: SemverParts | null,
+): -1 | 0 | 1 {
+  if (!a || !b) return 0;
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Convenience: true when `onDisk` is strictly newer than `builtIn`
+ * (i.e. the running image is stale relative to what's on disk).
+ * False on any parse failure.
+ */
+export function isOnDiskNewer(onDisk: string | null, builtIn: string | null): boolean {
+  if (!onDisk || !builtIn) return false;
+  const a = parseSemver(builtIn);
+  const b = parseSemver(onDisk);
+  if (!a || !b) return false;
+  return compareSemver(b, a) === 1;
+}

--- a/apps/web/tests/unit/footer-links.test.tsx
+++ b/apps/web/tests/unit/footer-links.test.tsx
@@ -10,6 +10,15 @@ const BLOG_URL = "https://brlauuu.github.io";
 
 describe("Footer brlauuu links", () => {
   beforeEach(() => {
+    // Footer fires /api/version on mount (#744). Stub so this suite
+    // stays focused on link wiring.
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ built_in: null, on_disk: null }),
+      } as unknown as Response),
+    ) as unknown as typeof fetch;
     render(<Footer />);
   });
 

--- a/apps/web/tests/unit/footer.test.tsx
+++ b/apps/web/tests/unit/footer.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Tests for the Footer's version + stale-build display (#744).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Footer from "@/components/Footer";
+
+const ORIGINAL_VERSION = process.env.NEXT_PUBLIC_APP_VERSION;
+
+function setBuiltInVersion(v: string | undefined) {
+  if (v === undefined) {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+  } else {
+    process.env.NEXT_PUBLIC_APP_VERSION = v;
+  }
+}
+
+function jsonResp(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+afterAll(() => {
+  setBuiltInVersion(ORIGINAL_VERSION);
+});
+
+describe("Footer", () => {
+  it("renders only v{version} when on-disk matches built-in", async () => {
+    setBuiltInVersion("0.4.6");
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResp({ built_in: "0.4.6", on_disk: "0.4.6" })),
+    ) as unknown as typeof fetch;
+
+    
+    render(<Footer />);
+
+    await waitFor(() => {
+      expect(screen.getByText("v0.4.6")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/rebuild available/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the rebuild hint when on-disk is newer than built-in", async () => {
+    setBuiltInVersion("0.3.0");
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResp({ built_in: "0.3.0", on_disk: "0.4.6" })),
+    ) as unknown as typeof fetch;
+
+    
+    render(<Footer />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/0.4.6 \(rebuild available\)/i)).toBeInTheDocument();
+    });
+    // Original built-in version is still shown so the user can see both.
+    expect(screen.getByText(/v0\.3\.0/i)).toBeInTheDocument();
+  });
+
+  it("stays silent when on-disk is older than built-in (downgrade / branch checkout)", async () => {
+    setBuiltInVersion("0.4.6");
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResp({ built_in: "0.4.6", on_disk: "0.3.0" })),
+    ) as unknown as typeof fetch;
+
+    
+    render(<Footer />);
+
+    await waitFor(() => {
+      expect(screen.getByText("v0.4.6")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/rebuild available/i)).not.toBeInTheDocument();
+  });
+
+  it("stays silent when on-disk is null (file missing, no mount)", async () => {
+    setBuiltInVersion("0.4.6");
+    global.fetch = jest.fn(() =>
+      Promise.resolve(jsonResp({ built_in: "0.4.6", on_disk: null })),
+    ) as unknown as typeof fetch;
+
+    
+    render(<Footer />);
+
+    await waitFor(() => {
+      expect(screen.getByText("v0.4.6")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/rebuild available/i)).not.toBeInTheDocument();
+  });
+
+  it("stays silent when the fetch fails", async () => {
+    setBuiltInVersion("0.4.6");
+    global.fetch = jest.fn(() => Promise.reject(new Error("network"))) as unknown as typeof fetch;
+
+    
+    render(<Footer />);
+
+    expect(await screen.findByText("v0.4.6")).toBeInTheDocument();
+    expect(screen.queryByText(/rebuild available/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/unit/semver.test.ts
+++ b/apps/web/tests/unit/semver.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the tiny semver comparator used by the footer's stale-build
+ * check (#744).
+ */
+import { compareSemver, isOnDiskNewer, parseSemver } from "@/lib/semver";
+
+describe("parseSemver", () => {
+  it("parses MAJOR.MINOR.PATCH", () => {
+    expect(parseSemver("0.4.6")).toEqual({ major: 0, minor: 4, patch: 6 });
+    expect(parseSemver("1.0.0")).toEqual({ major: 1, minor: 0, patch: 0 });
+  });
+
+  it("tolerates leading 'v'", () => {
+    expect(parseSemver("v0.4.6")).toEqual({ major: 0, minor: 4, patch: 6 });
+    expect(parseSemver("V1.2.3")).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it("ignores pre-release / build suffix", () => {
+    expect(parseSemver("0.4.6-pre")).toEqual({ major: 0, minor: 4, patch: 6 });
+    expect(parseSemver("1.0.0+build.5")).toEqual({ major: 1, minor: 0, patch: 0 });
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseSemver("not a version")).toBeNull();
+    expect(parseSemver("1.2")).toBeNull();
+    expect(parseSemver("")).toBeNull();
+    expect(parseSemver(null as unknown as string)).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  it("returns 0 for equal versions", () => {
+    expect(
+      compareSemver(parseSemver("0.4.6"), parseSemver("0.4.6")),
+    ).toBe(0);
+  });
+
+  it("compares major", () => {
+    expect(
+      compareSemver(parseSemver("0.9.9"), parseSemver("1.0.0")),
+    ).toBe(-1);
+    expect(
+      compareSemver(parseSemver("2.0.0"), parseSemver("1.99.99")),
+    ).toBe(1);
+  });
+
+  it("compares minor when major is equal", () => {
+    expect(
+      compareSemver(parseSemver("0.3.9"), parseSemver("0.4.0")),
+    ).toBe(-1);
+    // The 10-vs-9 case that breaks naive string compare.
+    expect(
+      compareSemver(parseSemver("0.9.0"), parseSemver("0.10.0")),
+    ).toBe(-1);
+  });
+
+  it("compares patch when major and minor are equal", () => {
+    expect(
+      compareSemver(parseSemver("0.4.5"), parseSemver("0.4.6")),
+    ).toBe(-1);
+    // Also exercises the patch-level 10-vs-9 case.
+    expect(
+      compareSemver(parseSemver("0.4.9"), parseSemver("0.4.10")),
+    ).toBe(-1);
+  });
+
+  it("returns 0 when either side is null", () => {
+    expect(compareSemver(null, parseSemver("1.0.0"))).toBe(0);
+    expect(compareSemver(parseSemver("1.0.0"), null)).toBe(0);
+    expect(compareSemver(null, null)).toBe(0);
+  });
+});
+
+describe("isOnDiskNewer", () => {
+  it("true when on-disk is strictly newer", () => {
+    expect(isOnDiskNewer("0.4.6", "0.3.0")).toBe(true);
+    expect(isOnDiskNewer("1.0.0", "0.10.5")).toBe(true);
+  });
+
+  it("false when equal", () => {
+    expect(isOnDiskNewer("0.4.6", "0.4.6")).toBe(false);
+  });
+
+  it("false when on-disk is older (downgrade / branch checkout)", () => {
+    expect(isOnDiskNewer("0.3.0", "0.4.6")).toBe(false);
+  });
+
+  it("false on any parse failure (silent)", () => {
+    expect(isOnDiskNewer("not a version", "0.4.6")).toBe(false);
+    expect(isOnDiskNewer("0.4.6", "garbage")).toBe(false);
+    expect(isOnDiskNewer(null, "0.4.6")).toBe(false);
+    expect(isOnDiskNewer("0.4.6", null)).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/version-route.test.ts
+++ b/apps/web/tests/unit/version-route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for GET /api/version (#744). Reads the on-disk VERSION file
+ * (bind-mounted into the container at /version) and pairs it with the
+ * NEXT_PUBLIC_APP_VERSION env var that was baked into the image at
+ * build time.
+ *
+ * @jest-environment node
+ */
+import { promises as fs } from "fs";
+
+const originalReadFile = fs.readFile;
+const readFileMock = jest.fn();
+
+beforeAll(() => {
+  // Patch readFile on the fs.promises object so the route can be
+  // imported lazily inside each test (so env-var changes take effect).
+  (fs as unknown as { readFile: typeof fs.readFile }).readFile =
+    readFileMock as unknown as typeof fs.readFile;
+});
+
+afterAll(() => {
+  (fs as unknown as { readFile: typeof fs.readFile }).readFile = originalReadFile;
+});
+
+beforeEach(() => {
+  readFileMock.mockReset();
+  jest.resetModules();
+  // Default — caller overrides per test.
+  process.env.NEXT_PUBLIC_APP_VERSION = "0.3.0";
+  delete process.env.VERSION_FILE_PATH;
+});
+
+async function callRoute() {
+  // Lazy import so the route picks up the current env vars.
+  const mod: typeof import("@/app/api/version/route") = await import(
+    "@/app/api/version/route"
+  );
+  const resp = await mod.GET();
+  return { status: resp.status, body: await resp.json() };
+}
+
+describe("GET /api/version", () => {
+  it("returns built_in + on_disk when the file is readable", async () => {
+    readFileMock.mockResolvedValueOnce("0.4.6\n");
+
+    const { status, body } = await callRoute();
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ built_in: "0.3.0", on_disk: "0.4.6" });
+    expect(readFileMock).toHaveBeenCalledWith("/version", "utf-8");
+  });
+
+  it("trims surrounding whitespace from the file content", async () => {
+    readFileMock.mockResolvedValueOnce("  0.4.6  \n\n");
+
+    const { body } = await callRoute();
+
+    expect(body.on_disk).toBe("0.4.6");
+  });
+
+  it("returns on_disk=null when the file read fails", async () => {
+    readFileMock.mockRejectedValueOnce(new Error("ENOENT"));
+
+    const { status, body } = await callRoute();
+
+    expect(status).toBe(200);
+    expect(body.built_in).toBe("0.3.0");
+    expect(body.on_disk).toBeNull();
+  });
+
+  it("returns on_disk=null for an empty file", async () => {
+    readFileMock.mockResolvedValueOnce("   \n");
+
+    const { body } = await callRoute();
+
+    expect(body.on_disk).toBeNull();
+  });
+
+  it("returns built_in=null when NEXT_PUBLIC_APP_VERSION is unset", async () => {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+    readFileMock.mockResolvedValueOnce("0.4.6\n");
+
+    const { body } = await callRoute();
+
+    expect(body.built_in).toBeNull();
+    expect(body.on_disk).toBe("0.4.6");
+  });
+
+  it("honors VERSION_FILE_PATH override", async () => {
+    process.env.VERSION_FILE_PATH = "/etc/podlog/version";
+    readFileMock.mockResolvedValueOnce("0.5.0");
+
+    await callRoute();
+
+    expect(readFileMock).toHaveBeenCalledWith("/etc/podlog/version", "utf-8");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,11 @@ services:
       - ./docs/guide:/docs/guide:ro
       - ./docs/about.md:/docs/about.md:ro
       - ./CHANGELOG.md:/docs/CHANGELOG.md:ro
+      # /api/version reads this at request time and compares against
+      # NEXT_PUBLIC_APP_VERSION (baked at build time) so the footer can
+      # signal "your running image is stale, rebuild it" when VERSION
+      # bumps between rebuilds.
+      - ./VERSION:/version:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Closes the missing piece in the version-display story: the footer's `v0.X.Y` line shows whatever the running image was built with, but until now nothing in the UI signaled "the VERSION file on disk has been bumped since you last rebuilt." This adds that signal.

### What the user sees
- **Matched** (running == VERSION on disk): unchanged, just `v0.4.6`.
- **Stale** (VERSION on disk is newer): `v0.4.6 → 0.5.0 (rebuild available)` in amber, with a tooltip saying "Rebuild + restart to pick up the latest changes."
- **Edge cases** (downgrade, file missing, fetch failure): silent, falls back to the matched-style rendering.

### How it works
1. `docker-compose.yml` now bind-mounts `./VERSION:/version:ro` into the web service.
2. New server-side route `GET /api/version` returns `{ built_in: NEXT_PUBLIC_APP_VERSION, on_disk: <file contents or null> }`.
3. New `lib/semver.ts` parses and compares MAJOR.MINOR.PATCH numerically (avoids the `0.10.0 < 0.9.0` string-compare bug, avoids a new dep on the `semver` package).
4. `Footer` fetches `/api/version` on mount, compares via `isOnDiskNewer`, renders the badge when strictly newer.

### Forward-compatibility note
The user mentioned that once they cut 1.0.0 they want to switch to a release-tag-driven staleness check (instead of VERSION-file-driven) and add a "preview" channel. That's deliberately out of scope here — the current design works for the 0.x.y world and the `compareSemver` helper already ignores pre-release suffix, so it'll need a small extension for proper release-channel handling later, not a rewrite.

### Test plan
- [x] 14 cases in `tests/unit/semver.test.ts` (parse / compare / isOnDiskNewer, including the 0.10.0 vs 0.9.0 case).
- [x] 6 cases in `tests/unit/version-route.test.ts` (success, trim whitespace, file missing, empty file, built_in unset, VERSION_FILE_PATH override).
- [x] 5 cases in `tests/unit/footer.test.tsx` (matched / stale / downgrade / file-null / fetch-fail).
- [x] Existing `tests/unit/footer-links.test.tsx` stubs fetch so its 3 link-wiring checks still pass.

### Note about rebuild
The new `NEXT_PUBLIC_APP_VERSION` env var is set at build time, so the first time this PR's image runs it'll already show `v0.4.6` matching VERSION. Confirming staleness in practice will require either bumping VERSION without rebuilding (so the footer flags it) or comparing after the next release bump.