### PR TITLE
chore(notebooks): gitignore rendered HTML artifacts (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ fresh empty `Unreleased` is left at the top.
 - Footer shows the version of the running build and warns when a newer one is on disk. The footer reads `process.env.NEXT_PUBLIC_APP_VERSION` (baked into the image at build time) for "what's running," and fetches `/api/version` (which reads the `VERSION` file bind-mounted into the container at `/version`) for "what's on disk." When the on-disk semver is strictly greater than the built-in one, the footer renders `v0.X.Y → 0.X.Z (rebuild available)` in amber as a nudge to rebuild + restart. Silent in matched / downgrade / file-missing / fetch-failed cases.
 
 ### Internal
+- `notebooks/.gitignore` now excludes rendered HTML artifacts (`examples/*.html`, `examples/_*.html`) so `jupyter nbconvert --to html` output stays out of `git status`. ([#748](https://github.com/brlauuu/podlog/issues/748))
 - Jest now ignores `apps/web/.next/standalone/` so a local `npm run build` doesn't trip jest-haste-map with `duplicate manual mock found: react-markdown`. The standalone output contains copies of `__mocks__/` and `node_modules/react/` that collided with the canonical ones; six suites previously failed at collection on a freshly-built local tree. CI was unaffected because it builds fresh, but the fix is harmless there. ([#750](https://github.com/brlauuu/podlog/issues/750))
 
 ### Fixes

--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -7,3 +7,9 @@
 !lib/
 !lib/**
 .ipynb_checkpoints/
+
+# Issue #748: `jupyter nbconvert --to html` writes alongside the .ipynb
+# source. Keep those build artifacts out of git status.
+examples/*.html
+examples/_*.html
+


### PR DESCRIPTION
## Summary
\`jupyter nbconvert --to html\` writes \`<name>.html\` (plus any sub-figure HTMLs prefixed with \`_\`) into the same directory as the \`.ipynb\` source. Until now those build artifacts cluttered \`git status\` because the existing \`notebooks/.gitignore\` allowlist re-included everything under \`examples/\`.

## Changes
Appends to \`notebooks/.gitignore\` (after the \`!examples/**\` re-include so order is correct):

\`\`\`
examples/*.html
examples/_*.html
\`\`\`

## Verification
\`git check-ignore -v\` confirms:
- \`notebooks/examples/01_explore_db.html\` → ignored
- \`notebooks/examples/_episode_duration_over_time.html\` → ignored
- \`notebooks/examples/01_explore_db.ipynb\` → still tracked

\`git status\` is now clean of those leftover artifacts.

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)