### PR TITLE
docs(claude-md): bump migration count 20 → 21 (#789)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ podlog/
 │   │   │   ├── api/                # FastAPI routers (feeds, episodes, queue, health, ask, embed, backfill, notifications, hardware, meta_analysis, backups, explore, prompts)
 │   │   │   ├── tasks/              # Pipeline tasks (ingest, download, transcribe, transcribe_helpers, diarize, chunk, embed, infer, archive, cleanup, prewarm, backfill_chunks, helpers)
 │   │   │   └── services/           # Business logic (rss, whisper, pyannote, pyannote_cloud, alignment, chunking, embed, rag, inference, inference_helpers, inference_classify, inference_db, inference_ner, inference_types, meta_analysis, meta_analysis_aggregations, notifications, notification_events, notification_runtime, notification_settings, digest, digest_formatters, events, hardware, fireworks_audio, pipeline_commands, timing_labels, prompts, backup_files, backup_settings)
-│   │   ├── alembic/                # Database migrations (20 versions)
+│   │   ├── alembic/                # Database migrations (21 versions)
 │   │   └── tests/                  # unit, integration, e2e
 │   └── web/                        # Next.js 16 (App Router)
 │       ├── Dockerfile              # Production image (standalone output)


### PR DESCRIPTION
Resolves #789.

- CLAUDE.md said "Database migrations (20 versions)"; `apps/pipeline/alembic/versions/` has 21 files.

## Test plan
- [x] `ls apps/pipeline/alembic/versions/*.py | wc -l` = 21
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)