### PR TITLE
fix(ollama): catch remaining gemma4:e4b refs missed in #790

### DIFF
--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -27,7 +27,7 @@ DEFAULT_MODEL = "qwen2.5:3b"
 MODEL_NUM_CTX = {
     "qwen2.5:3b": 8192,
     "phi3:mini": 16384,
-    "gemma4:e4b": 16384,
+    "gemma3n:e4b": 16384,
 }
 DEFAULT_NUM_CTX = 8192
 

--- a/apps/pipeline/tests/unit/test_rag_streaming.py
+++ b/apps/pipeline/tests/unit/test_rag_streaming.py
@@ -186,11 +186,11 @@ class TestOllamaStreaming:
                     pass
 
         asyncio.run(run("qwen2.5:3b"))
-        asyncio.run(run("gemma4:e4b"))
+        asyncio.run(run("gemma3n:e4b"))
         asyncio.run(run("unknown-model:foo"))
 
         assert captured_payloads[0]["options"]["num_ctx"] == MODEL_NUM_CTX["qwen2.5:3b"]
-        assert captured_payloads[1]["options"]["num_ctx"] == MODEL_NUM_CTX["gemma4:e4b"]
+        assert captured_payloads[1]["options"]["num_ctx"] == MODEL_NUM_CTX["gemma3n:e4b"]
         assert captured_payloads[2]["options"]["num_ctx"] == DEFAULT_NUM_CTX
 
     def test_stream_ollama_response_non_200_raises(self):

--- a/apps/web/tests/unit/episode-chat.test.tsx
+++ b/apps/web/tests/unit/episode-chat.test.tsx
@@ -104,9 +104,9 @@ describe("EpisodeChat — model selector", () => {
     );
 
     const select = screen.getByLabelText(/^model:/i) as HTMLSelectElement;
-    await user.selectOptions(select, "gemma4:e4b");
+    await user.selectOptions(select, "gemma3n:e4b");
 
-    expect(localStorage.getItem("podlog-ask-model")).toBe("gemma4:e4b");
+    expect(localStorage.getItem("podlog-ask-model")).toBe("gemma3n:e4b");
   });
 });
 


### PR DESCRIPTION
Follow-up to PR #827 (#790).

The audit found 4 occurrences but missed:
- `apps/pipeline/app/services/rag.py` — `MODEL_NUM_CTX` map (would have fallen back to `DEFAULT_NUM_CTX = 8192` instead of the configured 16384)
- `apps/web/tests/unit/episode-chat.test.tsx` — 2 hardcoded strings
- `apps/pipeline/tests/unit/test_rag_streaming.py` — 2 hardcoded strings

CI's Web Unit Full job caught one of the test refs after merge — this PR cleans up all five.

## Test plan
- [x] Web jest `episode-chat` — 37 passed
- [x] Pipeline pytest `test_rag_streaming` — 17 passed
- [x] `grep -rn 'gemma4'` across all source dirs — 0 hits
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)