### PR TITLE
deps(pipeline): bump pgvector ^0.3.0 → ^0.4.0 (#817)

### DIFF
--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -3287,14 +3287,14 @@ xml = ["lxml (>=5.3.0)"]
 
 [[package]]
 name = "pgvector"
-version = "0.3.6"
+version = "0.4.2"
 description = "pgvector support for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pgvector-0.3.6-py3-none-any.whl", hash = "sha256:f6c269b3c110ccb7496bac87202148ed18f34b390a0189c783e351062400a75a"},
-    {file = "pgvector-0.3.6.tar.gz", hash = "sha256:31d01690e6ea26cea8a633cde5f0f55f5b246d9c8292d68efdef8c22ec994ade"},
+    {file = "pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08"},
+    {file = "pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a"},
 ]
 
 [package.dependencies]
@@ -6468,4 +6468,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "fa56468e994d64f5fc16e1be5024aa8c4d06dd6671796c87a67ff20d3cb0333d"
+content-hash = "e5a3209837ca118f9cae3d8e7b178f2a8d21252cc61f248940ea648af3feacaa"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -22,7 +22,7 @@ pydantic-settings = "^2.2.0"
 sqlalchemy = "^2.0.0"
 alembic = "^1.13.0"
 psycopg2-binary = "^2.9.9"
-pgvector = "^0.3.0"
+pgvector = "^0.4.0"
 
 # RSS parsing
 feedparser = "^6.0.11"


### PR DESCRIPTION
Resolves #817.

pgvector was pinned at `^0.3.0` (resolved to 0.3.6); 0.4.x is current. Only direct usage is `from pgvector.sqlalchemy import Vector` in `models.py` — the `Vector(384)` SQLAlchemy column type, which is API-stable across the bump. HNSW index migrations are raw SQL (not affected).

## Test plan
- [x] `poetry lock` resolved cleanly to pgvector 0.4.2
- [x] `Vector(384)` constructs as expected
- [x] All 108 embed/chunk/rag/vector unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)