### PR TITLE
fix(pipeline): bump pytest-asyncio to 1.x to restore CI (#813 #814)

### DIFF
--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -4137,21 +4137,22 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.3"
+version = "1.4.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-asyncio-0.23.3.tar.gz", hash = "sha256:af313ce900a62fbe2b1aed18e37ad757f1ef9940c6b6a88e2954de38d6b1fb9f"},
-    {file = "pytest_asyncio-0.23.3-py3-none-any.whl", hash = "sha256:37a9d912e8338ee7b4a3e917381d1c95bfc8682048cb0fbc35baba316ec1faba"},
+    {file = "pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1"},
+    {file = "pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0"
+pytest = ">=8.4,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)", "sphinx-tabs (>=3.5)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
@@ -5798,11 +5799,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "ml"]
+groups = ["main", "dev", "ml"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {dev = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -6469,4 +6471,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "653bf50b69bea9995e6bcc6892e9e46270a60eaf14d58acdd35b66960775d236"
+content-hash = "df2fe86ae99dad69e98a6f53da0fbdc5146e7e37b580ffbf27b80d34ea36b7ea"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -66,7 +66,7 @@ numpy = ">=1.26,<3.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"
 pytest-cov = "^5.0.0"
-pytest-asyncio = "^0.23.0"
+pytest-asyncio = "^1.0.0"
 ruff = "^0.15.0"
 
 [build-system]


### PR DESCRIPTION
Hotfix for PR #839 (#813).

pytest 9 (bumped in #839) is incompatible with pytest-asyncio 0.23 — `pytest_asyncio.plugin.pytest_collectstart` calls `collector.obj` on `Package` nodes, which raises `AttributeError: 'Package' object has no attribute 'obj'` and breaks test collection. pytest-asyncio 1.x supports pytest 9.

Also resolves #814 (the standalone pytest-asyncio bump request — these had to land together anyway).

## Test plan
- [x] `poetry lock` resolved cleanly to pytest-asyncio 1.4.0
- [x] All 884 pipeline unit tests pass — including the 4 previously-failing host-env-only tests in `test_api_explore.py` (the pytest-asyncio 1.x recognizes `asyncio_mode = "auto"` properly)
- [ ] CI green

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)