### PR TITLE
deps(pipeline): bump pytest-cov ^5.0.0 → ^7.0.0 (#815)

### DIFF
--- a/apps/pipeline/poetry.lock
+++ b/apps/pipeline/poetry.lock
@@ -4157,22 +4157,23 @@ testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
+version = "7.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
-    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+    {file = "pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678"},
+    {file = "pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
-pytest = ">=4.6"
+coverage = {version = ">=7.10.6", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=7"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -6471,4 +6472,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "df2fe86ae99dad69e98a6f53da0fbdc5146e7e37b580ffbf27b80d34ea36b7ea"
+content-hash = "a6b357488abecf05158e597fdc537543d14f855eb0eef3da9b15490ef301efdc"

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -65,7 +65,7 @@ numpy = ">=1.26,<3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"
-pytest-cov = "^5.0.0"
+pytest-cov = "^7.0.0"
 pytest-asyncio = "^1.0.0"
 ruff = "^0.15.0"
 


### PR DESCRIPTION
Resolves #815.

pytest-cov was pinned at `^5.0.0` (resolved to 5.0.0); 7.x is current. Lockfile resolved cleanly to 7.1.0.

## Test plan
- [x] `poetry lock` resolved cleanly to pytest-cov 7.1.0
- [x] `pytest tests/unit --cov=app --cov-fail-under=82` passes — 884 tests, **87.68% coverage** (well above the 82% gate)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)