### PR TITLE
refactor(rag-models): un-export formatContext (#823)

### DIFF
--- a/apps/web/src/lib/rag-models.ts
+++ b/apps/web/src/lib/rag-models.ts
@@ -79,7 +79,7 @@ export const FIREWORKS_CHAT_MODELS: RagModel[] = [
 
 export const DEFAULT_FIREWORKS_CHAT_MODEL = FIREWORKS_CHAT_MODELS[0].value;
 
-export function formatContext(tokens: number): string {
+function formatContext(tokens: number): string {
   if (tokens >= 1024) {
     const k = tokens / 1024;
     return Number.isInteger(k) ? `${k}K` : `${k.toFixed(1)}K`;


### PR DESCRIPTION
Resolves #823.

`formatContext` is exported but the only call site is line 91 of the same file. Demoted to a module-private helper.

## Test plan
- [x] Grep across `apps/web/src` and `apps/web/tests` for `formatContext` — only references are within the file itself
- [x] 3 RAG test suites pass (10 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)