### PR TITLE
docs(development): fix audit report path layout (#821)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -339,7 +339,7 @@ claude -p "/codebase-audit" \
 
 #### Output (Claude)
 
-- Reports are written to `docs/audit/YYYY-MM-DD/claude/` (one file per check plus `summary.md`)
+- Reports are written to `docs/audit/claude/YYYY-MM-DD/` (one file per check plus `summary.md`)
 - No auto-commit or issue creation; reports are left for manual review
 - Completion state is visible in `summary.md` (`COMPLETE 7/7` or `IN PROGRESS N/7`)
 


### PR DESCRIPTION
Resolves #821.

The dev-guide "Audit Workflows → Output (Claude)" section described the report layout as `docs/audit/YYYY-MM-DD/claude/` — actual layout is `docs/audit/claude/YYYY-MM-DD/` (matches the codebase-audit skill spec).

This handles 1 of the 6 INFO items in this bucket. The other 5:
- *Alembic migration count* — already fixed in #789
- *README Tech Stack "blank Layer cell"* — not reproduced; the WhisperX row has `[WhisperX](...)` in column 1
- *RISKS-AND-GAPS.md stale changelog* — leave for the next release-skill run
- *"Not yet done" list accurate* — positive observation, no action
- *PRD-06 marked Shipped consistent* — positive observation, no action

## Test plan
- [x] Path matches the codebase-audit skill spec (`docs/audit/<agent>/<date>/`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)