### PR TITLE
test(pipeline): lift services/embed.py coverage 63% → 100% (#822 medium 1/7)

### DIFF
--- a/apps/pipeline/tests/unit/test_embed_service.py
+++ b/apps/pipeline/tests/unit/test_embed_service.py
@@ -124,3 +124,141 @@ class TestEmbedQuery:
         mock_model.encode.assert_called_once_with(
             ["search query"], show_progress_bar=False, normalize_embeddings=True
         )
+
+
+class TestNormalize:
+    """Cover _normalize (#822)."""
+
+    def test_unit_vector_passes_through(self):
+        # Unit vector — norm = 1 — should round-trip.
+        result = embed_mod._normalize([1.0, 0.0, 0.0])
+        assert pytest.approx(result, abs=1e-6) == [1.0, 0.0, 0.0]
+
+    def test_scales_to_unit_norm(self):
+        result = embed_mod._normalize([3.0, 4.0])  # norm = 5
+        import math
+        assert math.isclose(result[0], 0.6, abs_tol=1e-6)
+        assert math.isclose(result[1], 0.8, abs_tol=1e-6)
+
+    def test_zero_vector_returns_unchanged(self):
+        # Division-by-zero guard: zero vector returns itself.
+        assert embed_mod._normalize([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+
+class TestValidateVectorsDim:
+    """Cover _validate_vectors_dim count mismatch (#822)."""
+
+    def test_count_mismatch_raises(self):
+        with pytest.raises(RuntimeError, match="size mismatch"):
+            embed_mod._validate_vectors_dim([[0.0] * 384], expected_count=2)
+
+
+class TestEmbedTextsFireworks:
+    """Cover the Fireworks embedding provider (#822)."""
+
+    def _ok_response(self, vectors):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(
+            return_value={"data": [{"embedding": v} for v in vectors]}
+        )
+        return resp
+
+    def _client_cm(self, post_return):
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        client_cm.post = MagicMock(return_value=post_return)
+        return client_cm
+
+    def test_raises_when_api_key_missing(self):
+        with patch.object(embed_mod.settings, "fireworks_api_key", None):
+            with pytest.raises(RuntimeError, match="FIREWORKS_API_KEY is missing"):
+                embed_mod._embed_texts_fireworks(["hello"])
+
+    def test_happy_path_returns_normalized_vectors(self):
+        # Use 3-4 raw vector, gets normalized to length 384 in the test
+        # via the validation step? No — validation hard-coded to 384.
+        # Build full 384-dim vectors to clear validation.
+        v1 = [0.1] * 384
+        v2 = [0.2] * 384
+        resp = self._ok_response([v1, v2])
+        client_cm = self._client_cm(resp)
+        with (
+            patch.object(embed_mod.settings, "fireworks_api_key", "fk_test"),
+            patch.object(embed_mod.settings, "fireworks_embedding_base_url",
+                          "https://embed-prod.fireworks.ai/v1"),
+            patch.object(embed_mod.settings, "fireworks_embedding_model",
+                          "accounts/fireworks/models/embedding"),
+            patch.object(embed_mod.httpx, "Client", return_value=client_cm),
+        ):
+            result = embed_mod._embed_texts_fireworks(["a", "b"])
+        assert len(result) == 2
+        # Vectors normalized to unit length
+        import math
+        for vec in result:
+            assert math.isclose(sum(x * x for x in vec) ** 0.5, 1.0, abs_tol=1e-5)
+        # Endpoint URL strips trailing slash and appends /embeddings
+        called_url = client_cm.post.call_args[0][0]
+        assert called_url == "https://embed-prod.fireworks.ai/v1/embeddings"
+
+    def test_uses_runtime_override_when_provided(self):
+        v1 = [0.1] * 384
+        resp = self._ok_response([v1])
+        client_cm = self._client_cm(resp)
+        with (
+            patch.object(embed_mod.settings, "fireworks_api_key", "env-key"),
+            patch.object(embed_mod.settings, "fireworks_embedding_base_url", "https://env/v1"),
+            patch.object(embed_mod.settings, "fireworks_embedding_model", "env-model"),
+            patch.object(embed_mod.httpx, "Client", return_value=client_cm),
+        ):
+            embed_mod._embed_texts_fireworks(
+                ["hello"],
+                runtime={
+                    "fireworks_api_key": "runtime-key",
+                    "fireworks_embedding_base_url": "https://runtime/v1",
+                    "fireworks_embedding_model": "runtime-model",
+                },
+            )
+        called_args, called_kwargs = client_cm.post.call_args
+        assert called_args[0] == "https://runtime/v1/embeddings"
+        assert called_kwargs["headers"]["Authorization"] == "Bearer runtime-key"
+        assert called_kwargs["json"]["model"] == "runtime-model"
+
+    def test_raises_when_embedding_is_not_list(self):
+        # Malformed response — embedding is a string instead of a list.
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(
+            return_value={"data": [{"embedding": "not-a-list"}]}
+        )
+        client_cm = self._client_cm(resp)
+        with (
+            patch.object(embed_mod.settings, "fireworks_api_key", "fk_test"),
+            patch.object(embed_mod.settings, "fireworks_embedding_base_url", "https://x/v1"),
+            patch.object(embed_mod.settings, "fireworks_embedding_model", "m"),
+            patch.object(embed_mod.httpx, "Client", return_value=client_cm),
+        ):
+            with pytest.raises(RuntimeError, match="missing embedding vector"):
+                embed_mod._embed_texts_fireworks(["a"])
+
+    def test_batches_requests_over_256_inputs(self):
+        # Two batches: 256 + 1
+        v = [0.0] * 384
+        v[0] = 1.0  # non-zero so normalize doesn't div-by-zero
+        # First call returns 256 items, second returns 1
+        resp1 = self._ok_response([v] * 256)
+        resp2 = self._ok_response([v])
+        client_cm = MagicMock()
+        client_cm.__enter__ = MagicMock(return_value=client_cm)
+        client_cm.__exit__ = MagicMock(return_value=False)
+        client_cm.post = MagicMock(side_effect=[resp1, resp2])
+        with (
+            patch.object(embed_mod.settings, "fireworks_api_key", "fk_test"),
+            patch.object(embed_mod.settings, "fireworks_embedding_base_url", "https://x/v1"),
+            patch.object(embed_mod.settings, "fireworks_embedding_model", "m"),
+            patch.object(embed_mod.httpx, "Client", return_value=client_cm),
+        ):
+            result = embed_mod._embed_texts_fireworks(["t"] * 257)
+        assert len(result) == 257
+        assert client_cm.post.call_count == 2


### PR DESCRIPTION
Part of #822 (tests INFO bucket).

Adds 8 tests for previously-uncovered pure helpers and the Fireworks provider branch:

- `_normalize`: unit vector passthrough, 3-4-5 triangle scaling, zero-vector guard
- `_validate_vectors_dim`: count mismatch raises
- `_embed_texts_fireworks`: missing API key raises; happy path returns normalized vectors with correct endpoint URL; runtime override beats env settings; malformed embedding response raises; batches over 256 inputs

Coverage: 63% → **100%**.

## Test plan
- [x] 18 embed-service tests pass
- [x] embed.py at 100% (75/75 stmts)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)