### PR TITLE
test(pipeline): lift job_queue.py coverage 69% → 100% (#822 medium 3/7)

### DIFF
--- a/apps/pipeline/tests/unit/test_job_queue.py
+++ b/apps/pipeline/tests/unit/test_job_queue.py
@@ -61,3 +61,61 @@ class TestJobQueue:
         assert job.status == "failed"
         assert job.error == "something went wrong"
         db.commit.assert_called_once()
+
+
+class TestClaim:
+    """Cover the FOR UPDATE SKIP LOCKED claim path (#822)."""
+
+    def _query_chain(self, db, returns):
+        """Wire up the chained query() chain to return `returns` from .first()."""
+        chain = db.query.return_value
+        chain.filter.return_value = chain
+        chain.order_by.return_value = chain
+        chain.with_for_update.return_value = chain
+        chain.first.return_value = returns
+
+    def test_returns_none_when_no_pending_job(self):
+        db = MagicMock()
+        self._query_chain(db, None)
+        from app.job_queue import poll
+        assert poll(db) is None
+        # commit/refresh should NOT be called when no job is found
+        db.commit.assert_not_called()
+        db.refresh.assert_not_called()
+
+    def test_returns_job_and_marks_picked(self):
+        db = MagicMock()
+        job = MagicMock(spec=Job)
+        job.status = "pending"
+        job.attempt = 0
+        self._query_chain(db, job)
+        from app.job_queue import poll
+        result = poll(db)
+        assert result is job
+        assert job.status == "picked"
+        assert job.attempt == 1
+        # picked_at is set to current UTC time
+        assert job.picked_at is not None
+        # Single commit + refresh from this path
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(job)
+
+    def test_increments_attempt_counter(self):
+        db = MagicMock()
+        job = MagicMock(spec=Job)
+        job.status = "pending"
+        job.attempt = 3
+        self._query_chain(db, job)
+        from app.job_queue import poll
+        poll(db)
+        assert job.attempt == 4
+
+    def test_uses_skip_locked_on_with_for_update(self):
+        # The claim should call with_for_update(skip_locked=True) so multiple
+        # workers don't fight for the same row.
+        db = MagicMock()
+        self._query_chain(db, None)
+        from app.job_queue import poll
+        poll(db)
+        chain = db.query.return_value.filter.return_value.order_by.return_value
+        chain.with_for_update.assert_called_once_with(skip_locked=True)


### PR DESCRIPTION
Part of #822 (tests INFO bucket).

Adds 4 tests for the previously-uncovered `poll()` (claim) path:

- Returns None when no pending job is available (no commit/refresh)
- Returns the row and marks it picked + sets `picked_at` + commits + refreshes
- Increments `attempt` counter from N → N+1
- Calls `with_for_update(skip_locked=True)` so multiple workers don't fight for the same row

Coverage: 69% → **100%**.

## Test plan
- [x] All 8 job_queue tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)