### PR TITLE
test(web): lift QueueStatus.tsx coverage 67.85% → 79.76% (#822 large 2/4)

### DIFF
--- a/apps/web/tests/unit/queue-status.test.tsx
+++ b/apps/web/tests/unit/queue-status.test.tsx
@@ -73,4 +73,129 @@ describe("QueueStatus", () => {
       );
     });
   });
+
+  test("renders empty state when no jobs", async () => {
+    const empty = {
+      active_count: 0, pending_count: 0, failed_count: 0,
+      done_count: 0, stuck_count: 0,
+      active_jobs: [], pending_jobs: [], failed_jobs: [],
+      done_jobs: [], stuck_jobs: [],
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => empty } as Response)
+    ) as jest.Mock;
+
+    render(<QueueStatus />);
+    expect(await screen.findByText(/no episodes in the queue/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /add a feed/i })).toHaveAttribute("href", "/feeds");
+  });
+
+  test("StageBar filter buttons toggle the active filter", async () => {
+    const payload = {
+      active_count: 1, pending_count: 0, failed_count: 1,
+      done_count: 0, stuck_count: 0,
+      active_jobs: [
+        {
+          episode_id: "ep-active", title: "Streaming",
+          status: "transcribing",
+          retry_count: 0, retry_max: 3, feed_mode: "full",
+          feed_title: "Show A", updated_at: new Date().toISOString(),
+        },
+      ],
+      pending_jobs: [],
+      failed_jobs: [
+        {
+          episode_id: "ep-broken", title: "Broken One",
+          status: "failed", error_class: "TRANSIENT_NETWORK",
+          retry_count: 1, retry_max: 3, feed_mode: "full",
+          feed_title: "Show B", updated_at: new Date().toISOString(),
+        },
+      ],
+      done_jobs: [], stuck_jobs: [],
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => payload } as Response)
+    ) as jest.Mock;
+
+    render(<QueueStatus />);
+    await screen.findByText("Streaming");
+
+    // Both rows should be visible initially.
+    expect(screen.getByText("Broken One")).toBeInTheDocument();
+
+    // Click the StatusBadge on the failed row → applies stage=failed filter.
+    // The row has [feed_title button, status badge button] in order.
+    const failedRow = screen.getByText("Broken One").closest("tr")!;
+    const buttons = failedRow.querySelectorAll("button");
+    // Status badge is the last button in the row's pre-retry section
+    const failedStatus = buttons[buttons.length - 1];
+    fireEvent.click(failedStatus);
+
+    // "Filtering by" indicator appears.
+    await waitFor(() => {
+      expect(screen.getByText(/filtering by/i)).toBeInTheDocument();
+    });
+
+    // Clear-filter button removes the indicator.
+    fireEvent.click(screen.getByRole("button", { name: /clear filter/i }));
+    await waitFor(() => {
+      expect(screen.queryByText(/filtering by/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test("podcast-title click sets the search field to that title", async () => {
+    const payload = {
+      active_count: 1, pending_count: 0, failed_count: 0,
+      done_count: 0, stuck_count: 0,
+      active_jobs: [
+        {
+          episode_id: "ep-1", title: "Ep One", status: "transcribing",
+          retry_count: 0, retry_max: 3, feed_mode: "full",
+          feed_title: "Show Alpha", updated_at: new Date().toISOString(),
+        },
+      ],
+      pending_jobs: [], failed_jobs: [], done_jobs: [], stuck_jobs: [],
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => payload } as Response)
+    ) as jest.Mock;
+
+    render(<QueueStatus />);
+    await screen.findByText("Ep One");
+    fireEvent.click(screen.getByRole("button", { name: "Show Alpha" }));
+    expect((screen.getByPlaceholderText(/search episodes/i) as HTMLInputElement).value)
+      .toBe("Show Alpha");
+  });
+
+  test("show/hide completed-episodes toggle reveals the done table", async () => {
+    const payload = {
+      active_count: 0, pending_count: 0, failed_count: 0,
+      done_count: 1, stuck_count: 0,
+      active_jobs: [], pending_jobs: [], failed_jobs: [],
+      done_jobs: [
+        {
+          episode_id: "ep-done", title: "Finished Ep", status: "done",
+          retry_count: 0, retry_max: 3, feed_mode: "full",
+          feed_title: "Show D", updated_at: new Date().toISOString(),
+        },
+      ],
+      stuck_jobs: [],
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => payload } as Response)
+    ) as jest.Mock;
+
+    render(<QueueStatus />);
+    // Initially the done section is hidden ("Show 1 completed episode").
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /show 1 completed/i }))
+        .toBeInTheDocument()
+    );
+    expect(screen.queryByText("Finished Ep")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show 1 completed/i }));
+    await waitFor(() =>
+      expect(screen.getByText("Finished Ep")).toBeInTheDocument()
+    );
+  });
 });


### PR DESCRIPTION
Part of #822 (tests INFO bucket).

Adds 4 tests for previously-uncovered UI branches:

- **Empty state**: "No episodes in the queue." with link to /feeds
- **StageBar filter**: clicking a row's status badge applies the stage filter; "Clear filter" removes it
- **Podcast click**: clicking a feed title sets the search input to that title
- **Show/hide done**: "Show N completed episodes" toggle reveals the done table

Coverage: 67.85% → **79.76%** (cleared the 60-80% INFO range and now hits the top of it).

## Test plan
- [x] 5 queue-status tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)