### PR TITLE
fix: stamp correct version on a bare `docker compose build`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# This .dockerignore applies to image builds that use the repository root
+# as their build context. Currently that is only the production `web` image
+# (docker-compose.yml, context: .), which needs the root VERSION file so the
+# Dockerfile can stamp the app version without relying on the caller passing
+# a build arg. Keep the context small — exclude heavy/irrelevant paths.
+# backups/ alone is tens of GB; without this, the web build context explodes.
+
+# Dependencies & build output
+**/node_modules
+**/.next
+
+# Large data / generated dirs
+backups/
+notebooks/
+models/
+.pytest_cache/
+
+# VCS & local agent tooling
+.git/
+.worktrees/
+.agents/
+.superpowers/
+.omx/
+.claude/
+
+# Local secrets / env
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ fresh empty `Unreleased` is left at the top.
 - Footer shows the version of the running build and warns when a newer one is on disk. The footer reads `process.env.NEXT_PUBLIC_APP_VERSION` (baked into the image at build time) for "what's running," and fetches `/api/version` (which reads the `VERSION` file bind-mounted into the container at `/version`) for "what's on disk." When the on-disk semver is strictly greater than the built-in one, the footer renders `v0.X.Y → 0.X.Z (rebuild available)` in amber as a nudge to rebuild + restart. Silent in matched / downgrade / file-missing / fetch-failed cases.
 
 ### Fixes
+- The footer no longer falsely shows "→ x.y.z (rebuild available)" after a plain `docker compose build web`. The web image build now reads the repo-root `VERSION` file directly (build context moved to the repo root, guarded by a new root `.dockerignore` so the context stays small), instead of defaulting to the `0.0.0` sentinel when the caller forgot to pass `--build-arg APP_VERSION`. `make build` is unaffected.
+- The pipeline API no longer reports version `0.0.0` after a plain `docker compose build`. The live `VERSION` file is now bind-mounted into the pipeline container (`./VERSION:/app/VERSION:ro`), so `app.main._read_version()` always reads the current version at runtime instead of relying on a copy that only `make build` staged into the build context.
 - `make ollama-pull` referenced a non-existent Ollama model `gemma4:e4b`; corrected to `gemma3n:e4b` (the Gemma 3n E4B variant) in the Makefile, the Ask page model dropdown (`apps/web/src/lib/rag-models.ts`), and the two doc pages that listed the pullable model set. ([#790](https://github.com/brlauuu/podlog/issues/790))
 
 ### Internal

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,8 @@ down-remote:    ## Stop remote-inference profile stack
 
 build:          ## Rebuild all images (reads version from VERSION file)
 	@cp VERSION apps/pipeline/VERSION
-	@cp VERSION apps/web/VERSION
 	docker compose build --build-arg APP_VERSION=$$(cat VERSION)
-	@rm -f apps/pipeline/VERSION apps/web/VERSION
+	@rm -f apps/pipeline/VERSION
 
 logs:           ## Follow logs for all services
 	docker compose logs -f

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,15 +1,24 @@
+# NOTE: build context is the repo ROOT (see docker-compose.yml `context: .`),
+# not apps/web — so COPY paths are repo-relative. This lets the build read the
+# root VERSION file directly instead of depending on the caller passing
+# --build-arg APP_VERSION. A root .dockerignore keeps the context small.
 FROM node:20-alpine AS deps
 WORKDIR /app
-COPY package.json package-lock.json* ./
+COPY apps/web/package.json apps/web/package-lock.json* ./
 RUN npm ci
 
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
-ARG APP_VERSION=0.0.0
-ENV NEXT_PUBLIC_APP_VERSION=$APP_VERSION
-RUN npm run build
+COPY apps/web/ ./
+# APP_VERSION is optional. `make build` and CI pass it explicitly via
+# --build-arg; a bare `docker compose build web` omits it and we fall back to
+# the repo-root VERSION file. This prevents the image from being stamped with
+# the 0.0.0 sentinel, which made the footer falsely show "rebuild available".
+COPY VERSION /tmp/VERSION
+ARG APP_VERSION=""
+RUN APP_VERSION="${APP_VERSION:-$(cat /tmp/VERSION)}" && \
+    NEXT_PUBLIC_APP_VERSION="$APP_VERSION" npm run build
 
 FROM node:20-alpine AS runner
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
       # filename/date with strict regexes and guard against path traversal —
       # they're the only writes the pipeline ever does under /backups.
       - ./backups:/backups
+      # app.main._read_version() reads /app/VERSION at runtime. Baking it via
+      # `COPY . .` only works when apps/pipeline/VERSION exists at build time
+      # (which only `make build` stages), so a bare `docker compose build`
+      # would otherwise stamp the 0.0.0 fallback. Mounting the live file makes
+      # the reported version correct regardless of how the image was built —
+      # mirrors web's ./VERSION:/version:ro mount.
+      - ./VERSION:/app/VERSION:ro
     depends_on:
       db:
         condition: service_healthy
@@ -94,13 +101,16 @@ services:
 
   web:
     build:
-      context: ./apps/web
+      # Context is the repo root so the Dockerfile can read the VERSION file
+      # directly (a root .dockerignore keeps the context small).
+      context: .
+      dockerfile: apps/web/Dockerfile
       args:
-        # Read APP_VERSION from the env so `docker compose build web`
-        # bakes NEXT_PUBLIC_APP_VERSION correctly. `make build` exports
-        # APP_VERSION from the VERSION file; direct compose builds work
-        # if you `export APP_VERSION=$(cat VERSION)` first.
-        APP_VERSION: ${APP_VERSION:-0.0.0}
+        # APP_VERSION is optional. `make build` and CI pass it explicitly;
+        # when omitted (e.g. a bare `docker compose build web`), the Dockerfile
+        # falls back to the repo-root VERSION file, so the baked-in version is
+        # never the 0.0.0 sentinel that made the footer cry "rebuild available".
+        APP_VERSION: ${APP_VERSION:-}
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Problem

Both the web footer and the pipeline API reported a `0.0.0` version after a plain `docker compose build`. Only `make build` stages the `VERSION` file into the build contexts, so a direct compose build fell back to the `0.0.0` sentinel:

- **web** → footer falsely showed "→ x.y.z (rebuild available)" because the baked-in `NEXT_PUBLIC_APP_VERSION` (`0.0.0`) was compared against the on-disk `VERSION` (`0.5.4`).
- **pipeline** → API reported `0.0.0` (`/app/VERSION` didn't even exist in the image; `app.main._read_version()` fell through to its `0.0.0` fallback).

## Fix

| Service | Approach |
|---|---|
| **web** | Move the image build context to the repo root and read `VERSION` directly in the Dockerfile as a fallback when `--build-arg APP_VERSION` is omitted. A new root `.dockerignore` keeps the context small (`backups/` alone is tens of GB → context stays ~65 kB). |
| **pipeline** | Bind-mount the live `./VERSION` into the container (`./VERSION:/app/VERSION:ro`) so `_read_version()` reads the current version at runtime regardless of how the image was built — mirrors web's existing `./VERSION:/version:ro` mount. The pipeline reads version at runtime by design, so this is the idiomatic equivalent and avoids a 10–20 min ML rebuild + destabilizing the shared test-stack Dockerfile. |

Also drops the now-vestigial `cp VERSION apps/web/VERSION` from `make build`.

`make build` and CI (which pass `--build-arg APP_VERSION`) are unaffected — the arg still takes precedence; the file is only a fallback.

## Verification

- Bare `docker compose build web` with **no** `APP_VERSION` env and no `make` → bakes `0.5.4`; `/api/version` returns `{"built_in":"0.5.4","on_disk":"0.5.4"}` → banner gone. Build context transfer was 65 kB (not 38 GB).
- Recreated pipeline → API reports `0.5.4`.
- `docker compose config` validates for prod, test, and with-arg variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)