### PR TITLE
fix(pipeline): use all available CPU cores for Whisper transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxx
 WHISPER_MODEL=large-v3-turbo  # tiny|base|small|medium|large-v3|large-v3-turbo
 WHISPER_COMPUTE_TYPE=int8     # int8 (fast, recommended for CPU) | float32 (accurate)
 WHISPER_BATCH_SIZE=16         # WhisperX batched inference batch size
+WHISPER_CPU_THREADS=0         # CTranslate2 ASR threads; 0 = auto-detect cores (WhisperX default of 4 caps CPU transcription). Set to physical-core count on hyperthreaded CPUs.
 PYANNOTE_MODEL=pyannote/speaker-diarization-community-1  # HuggingFace ID of the diarization model
 # Build-time default for the local pyannote model. Editable at runtime via
 # Settings → Remote Inference (#681). Curated values:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Minor changes
+- CPU transcription now uses all available cores instead of 4. WhisperX defaults its CTranslate2 ASR pass to `threads=4`, which pinned Whisper to 4 cores regardless of machine size (a 99-minute episode was taking 8+ hours on an 8-core host). A new `WHISPER_CPU_THREADS` setting is passed through to `load_model` (`0` = auto-detect available cores; set to the physical-core count on hyperthreaded CPUs), roughly halving per-episode transcription time on multi-core hosts.
+
 ### Fixes
 - The footer no longer falsely shows "→ x.y.z (rebuild available)" after a plain `docker compose build web`. The web image build now reads the repo-root `VERSION` file directly (build context moved to the repo root, guarded by a new root `.dockerignore` so the context stays small), instead of defaulting to the `0.0.0` sentinel when the caller forgot to pass `--build-arg APP_VERSION`. `make build` is unaffected.
 - The pipeline API no longer reports version `0.0.0` after a plain `docker compose build`. The live `VERSION` file is now bind-mounted into the pipeline container (`./VERSION:/app/VERSION:ro`), so `app.main._read_version()` always reads the current version at runtime instead of relying on a copy that only `make build` staged into the build context.

--- a/apps/pipeline/app/config.py
+++ b/apps/pipeline/app/config.py
@@ -42,6 +42,11 @@ class Settings(BaseSettings):
     whisper_model: str = "large-v3-turbo"
     whisper_compute_type: str = "int8"
     whisper_batch_size: int = 16
+    # CPU threads for the CTranslate2 ASR pass. WhisperX defaults this to 4,
+    # which pins transcription to 4 cores regardless of machine size (the cause
+    # of the ~4-core / 8h-per-episode slowdown). 0 = auto-detect available cores.
+    # On hyperthreaded CPUs, setting this to the physical-core count is optimal.
+    whisper_cpu_threads: int = 0
 
     # Storage
     data_dir: str = "/data"

--- a/apps/pipeline/app/services/whisper.py
+++ b/apps/pipeline/app/services/whisper.py
@@ -9,11 +9,27 @@ after transcription. Whisper and pyannote must never be in memory simultaneously
 """
 import gc
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 # Module-level model cache — explicitly set to None by unload_model()
 _model = None
+
+
+def _resolve_cpu_threads(configured: int) -> int:
+    """Resolve the CTranslate2 CPU thread count for the ASR pass.
+
+    WhisperX defaults ``threads`` to 4, which caps transcription at 4 cores
+    no matter how large the host is. We instead pass an explicit value:
+    a positive ``configured`` wins; 0 means auto-detect available cores.
+    """
+    if configured > 0:
+        return configured
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:  # not available on all platforms
+        return os.cpu_count() or 4
 
 
 def load_model(model_name: str = "large-v3-turbo") -> None:
@@ -28,21 +44,25 @@ def load_model(model_name: str = "large-v3-turbo") -> None:
 
     device = "cuda" if _cuda_available() else "cpu"
     compute_type = settings.whisper_compute_type
+    cpu_threads = _resolve_cpu_threads(settings.whisper_cpu_threads)
 
     logger.info(
-        '"action": "whisper_load_start", "model": "%s", "backend": "whisperx"',
-        model_name,
+        '"action": "whisper_load_start", "model": "%s", "backend": "whisperx", '
+        '"cpu_threads": %d',
+        model_name, cpu_threads,
     )
 
     _model = whisperx.load_model(
         model_name,
         device=device,
         compute_type=compute_type,
+        threads=cpu_threads,
     )
 
     logger.info(
-        '"action": "whisper_load_complete", "model": "%s", "device": "%s"',
-        model_name, device,
+        '"action": "whisper_load_complete", "model": "%s", "device": "%s", '
+        '"cpu_threads": %d',
+        model_name, device, cpu_threads,
     )
 
 

--- a/apps/pipeline/tests/unit/test_whisper_service.py
+++ b/apps/pipeline/tests/unit/test_whisper_service.py
@@ -14,11 +14,12 @@ class TestLoadModel:
         """load_model() creates a WhisperX model with correct args."""
         mock_model = MagicMock()
         with patch("app.services.whisper._cuda_available", return_value=False), \
+             patch("app.services.whisper._resolve_cpu_threads", return_value=8), \
              patch("whisperx.load_model", return_value=mock_model) as mock_load:
             import app.services.whisper as ws
             ws.load_model("large-v3-turbo")
             mock_load.assert_called_once_with(
-                "large-v3-turbo", device="cpu", compute_type="int8",
+                "large-v3-turbo", device="cpu", compute_type="int8", threads=8,
             )
             assert ws._model is mock_model
 
@@ -29,6 +30,26 @@ class TestLoadModel:
             ws._model = MagicMock()  # already loaded
             ws.load_model("large-v3-turbo")
             mock_load.assert_not_called()
+
+
+class TestResolveCpuThreads:
+    def test_positive_configured_value_wins(self):
+        """A positive configured value is used verbatim."""
+        import app.services.whisper as ws
+        assert ws._resolve_cpu_threads(8) == 8
+
+    def test_zero_auto_detects_available_cores(self):
+        """0 auto-detects via sched_getaffinity."""
+        import app.services.whisper as ws
+        with patch("os.sched_getaffinity", return_value={0, 1, 2, 3}):
+            assert ws._resolve_cpu_threads(0) == 4
+
+    def test_zero_falls_back_to_cpu_count_without_affinity(self):
+        """Falls back to os.cpu_count() when sched_getaffinity is absent."""
+        import app.services.whisper as ws
+        with patch("os.sched_getaffinity", side_effect=AttributeError), \
+             patch("os.cpu_count", return_value=6):
+            assert ws._resolve_cpu_threads(0) == 6
 
 
 class TestUnloadModel:


### PR DESCRIPTION
## Problem

A transcribe job sat in `picked` state for **8+ hours** on a 99-minute episode. Investigation showed the worker was not hung — it was genuinely transcribing, but pinned to only **4 of 8 CPU cores** (worker CPU capped at ~400%).

**Root cause:** WhisperX defaults its CTranslate2 ASR pass to `threads=4` (`whisperx/asr.py`), which becomes faster-whisper's `cpu_threads=4`. `app/services/whisper.py::load_model()` never passed a thread count, so every transcription ran on 4 cores regardless of host size.

## Fix

- **`config.py`** — new `whisper_cpu_threads` setting (`0` = auto-detect available cores via `os.sched_getaffinity`)
- **`whisper.py`** — `_resolve_cpu_threads()` helper + passes `threads=` into `whisperx.load_model()`; thread count is logged on model load
- **`.env.example`** — documents `WHISPER_CPU_THREADS` (default `0`; set to physical-core count on hyperthreaded CPUs)
- **Tests** — updated `load_model` assertion + 3 new resolver tests
- **CHANGELOG** — Unreleased → Minor changes entry

## Verification

Rebuilt + restarted the worker on the host. Model-load logs now show `"cpu_threads": 8`, and worker CPU rose from **400% → ~780%** (4 → 8 cores) during the ASR pass — roughly **2× throughput**.

Note: this does not make CPU transcription *fast* (a 99-min episode still takes ~1–3h on CPU); the order-of-magnitude win would be GPU or remote Fireworks transcription. This is the free, safe multi-core win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)