### PR TITLE
docs: add the backup service to every service enumeration (#897)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ For a side-by-side comparison of the local and remote options for both transcrip
   Ollama API :11434 ──> │  ollama (local LLM)                          │
                         │    RAG-based Ask AI feature                  │
                         └──────────────────────────────────────────────┘
+
+                        ┌──────────────────────────────────────────────┐
+                        │  backup (cron-style loop)                    │
+                        │    Nightly DB dump + audio archive snapshot  │
+                        │    Writes to ./backups/ on the host          │
+                        └──────────────────────────────────────────────┘
 ```
 
-Default profile: 5 containers (`db`, `pipeline`, `worker`, `ollama`, `web`). Remote-inference profile: 4 containers (Ollama is disabled unless you opt in with the `local-ask` Compose profile). No Redis, no Celery — the job queue is PostgreSQL-backed using `FOR UPDATE SKIP LOCKED`.
+Default profile: 6 containers (`db`, `pipeline`, `worker`, `ollama`, `web`, `backup`). Remote-inference profile: 5 containers (Ollama is disabled unless you opt in with the `local-ask` Compose profile). A seventh service, `explore` (Jupyter), is opt-in via `make explore`. No Redis, no Celery — the job queue is PostgreSQL-backed using `FOR UPDATE SKIP LOCKED`.
 
 ## Configuration
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 ```
 podlog/
-├── docker-compose.yml              # default profile: db, pipeline, worker, ollama, web
+├── docker-compose.yml              # default profile: db, pipeline, worker, ollama, web, backup
 ├── docker-compose.remote.yml       # remote-inference override (no ollama)
 ├── .env.example                    # All config vars documented
 ├── Makefile                        # make up / down / build / test / etc.
@@ -42,7 +42,7 @@ podlog/
 
 - Python 3.11+ with [Poetry](https://python-poetry.org/) — for running the pipeline natively
 - Node.js 20.9.0+ with npm (see `.nvmrc` / `.node-version` for pinned local version) — for running the web app natively
-- Docker and Docker Compose — required for the full stack (db, pipeline, worker, ollama, web) and recommended for everyday development
+- Docker and Docker Compose — required for the full stack (db, pipeline, worker, ollama, web, backup) and recommended for everyday development
 
 ### Pipeline (Python)
 

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -84,8 +84,9 @@ Podlog starts these containers by profile:
 
 | Profile | Services |
 |---|---|
-| **Local-first (`make up`)** | `web`, `pipeline`, `worker`, `db`, `ollama` |
-| **Remote-inference (`make up-remote`)** | `web`, `pipeline`, `worker`, `db` (no `ollama`) |
+| **Local-first (`make up`)** | `web`, `pipeline`, `worker`, `db`, `ollama`, `backup` |
+| **Remote-inference (`make up-remote`)** | `web`, `pipeline`, `worker`, `db`, `backup` (no `ollama`) |
+| **Explore (opt-in, `make explore`)** | adds `explore` (Jupyter) to whichever profile is running |
 
 Service details:
 
@@ -96,6 +97,7 @@ Service details:
 | **worker** | — | Processes episodes: download, transcribe, diarize, chunk, embed, infer, archive |
 | **db** | 5432 | PostgreSQL 15 with pgvector for FTS + semantic search |
 | **ollama** | 11434 | Local Ask AI generation provider (local-first profile) |
+| **backup** | — | Nightly DB dump + audio archive snapshot into `./backups/` (see [Backups](16-backups.md)) |
 
 No Redis, no Celery — the job queue is PostgreSQL-backed.
 

--- a/prds/PRD-03-infrastructure.md
+++ b/prds/PRD-03-infrastructure.md
@@ -251,7 +251,7 @@ volumes:
   ollama_data:
 ```
 
-**5 services:** db, pipeline, worker, ollama, web. No external broker (Redis removed) — the job queue is PostgreSQL-backed. No Celery Beat or Flower.
+**6 default services:** db, pipeline, worker, ollama, web, backup. A seventh, `explore` (Jupyter), is defined behind the `explore` Compose profile and is opt-in via `make explore`. No external broker (Redis removed) — the job queue is PostgreSQL-backed. No Celery Beat or Flower.
 
 **Key design points:**
 - `pipeline` uses `Dockerfile.control` (lightweight FastAPI server); `worker` uses `Dockerfile.worker` (includes ML dependencies).

--- a/prds/PRD-03-infrastructure.md
+++ b/prds/PRD-03-infrastructure.md
@@ -253,6 +253,8 @@ volumes:
 
 **6 default services:** db, pipeline, worker, ollama, web, backup. A seventh, `explore` (Jupyter), is defined behind the `explore` Compose profile and is opt-in via `make explore`. No external broker (Redis removed) — the job queue is PostgreSQL-backed. No Celery Beat or Flower.
 
+> The YAML above is abridged and predates the `backup` (#630) and `explore` (#607) services — it is illustrative, not a mirror of the file. The committed `docker-compose.yml` is the source of truth for the service set.
+
 **Key design points:**
 - `pipeline` uses `Dockerfile.control` (lightweight FastAPI server); `worker` uses `Dockerfile.worker` (includes ML dependencies).
 - `pipeline` healthcheck ensures migrations complete before downstream services start.


### PR DESCRIPTION
## Summary

Resolves #897.

The `backup` service has no `profiles:` key in `docker-compose.yml` (line 139, `restart: unless-stopped`), so it starts with `make up` — but every user-facing service list omitted it. #865 corrected only CLAUDE.md.

- **README.md** — 5 → 6 default containers, 4 → 5 for the remote profile, added a `backup` block to the ASCII architecture diagram, and noted `explore` as the opt-in seventh
- **docs/development.md** — both the tree comment (line 7) and the prerequisites line (line 45)
- **docs/guide/01-installation.md** — both profile rows, a new row for the opt-in `explore` profile, and a `backup` row in the service-details table linking to `16-backups.md`
- **prds/PRD-03-infrastructure.md** — "5 services" → 6 default, plus `explore` behind its profile

## Test plan

- [x] `grep -nE "^  [a-z_]+:" docker-compose.yml` → 7 services; only `explore` has `profiles: [explore]`, confirming `backup` is default-on
- [x] Re-grepped the repo for residual "5 containers" / "5 services" / "worker, ollama, web" claims — all remaining hits are either the corrected lines or the historical `docs/superpowers/` artifacts tracked in #911
- [x] `python3 scripts/check_docs_sync.py` → `OK CLAUDE.md`, `OK docs/development.md`

## Notes

Labeled `no-changelog`: documentation-only, which the workflow's escape hatch explicitly covers ("README-only edits").

Left deliberately unchanged: `CLAUDE.md:116` lists "(db, pipeline, worker, ollama, web)" as an example of the short-name convention rather than as a service enumeration, so it isn't a count claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)