### PR TITLE
docs: document the 19 missing env vars + gate the list (#899)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,12 @@ cp .env.example .env
 | `FEED_POLL_INTERVAL_HOURS` | `24` | How often the worker checks RSS feeds for new episodes. |
 | `DATA_DIR` | `/data` | Base directory for audio files and transcripts inside the container. Normally no need to change this. |
 
+### CPU threads
+
+| Variable | Default | Description |
+|---|---|---|
+| `WHISPER_CPU_THREADS` | `0` | CPU threads for the WhisperX transcription pass. `0` auto-detects available cores. WhisperX otherwise defaults to 4, which pins transcription to 4 cores regardless of machine size. On hyperthreaded CPUs, set this to the physical-core count. |
+
 ## Retry and Error Handling
 
 | Variable | Default | Description |
@@ -50,6 +56,9 @@ The worker monitors running jobs and marks them as failed if they exceed expecte
 |---|---|---|
 | `INFERENCE_ENABLED` | `true` | Whether to run spaCy NER-based speaker name inference after diarization. |
 | `SPACY_MODEL` | `en_core_web_trf` | spaCy NER model. `en_core_web_trf` (~500 MB, best accuracy) is the default; override to `en_core_web_lg` (~200 MB) on memory-constrained hosts. The worker image ships both and automatically falls back to `en_core_web_lg` at runtime if `trf` is unavailable. |
+| `RECURRING_HOST_WINDOW` | `10` | How many recent episodes of a feed the `recurring_host` heuristic looks back over. |
+| `RECURRING_HOST_THRESHOLD` | `0.8` | Fraction of that window a speaker must appear in to be treated as a recurring host (0.0–1.0). |
+| `FEED_SPEAKER_CACHE_RECENCY_DAYS` | `365` | How long a user-supplied speaker rename stays eligible for reuse across episodes of the same feed. `0` disables the recency cutoff. |
 
 ## Fireworks Provider
 
@@ -142,11 +151,55 @@ The host-level health check script (`scripts/healthcheck.py`) uses these setting
 
 The script uses `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from `.env` if present; otherwise falls back to the values configured in the web UI. Requires `postgresql-client` (`pg_isready`, `psql`) on the host.
 
+## Notifications
+
+Delivery settings for pipeline notifications. Telegram credentials are shared with the health-check script above. Most of these can also be set from the web UI (Settings → Notifications); the `.env` value wins where both are present.
+
+| Variable | Default | Description |
+|---|---|---|
+| `NOTIFICATION_FREQUENCY` | `immediate` | When to deliver. One of `immediate`, `daily`, `weekly`. The digest modes batch events instead of sending per-episode. |
+| `NOTIFICATION_EMAIL_TO` | (unset) | Recipient address for email notifications. Email delivery is off unless this is set. |
+| `NOTIFICATION_EMAIL_FROM` | `podlog@localhost` | From address on outgoing notification email. |
+
+### SMTP
+
+Only used when `NOTIFICATION_EMAIL_TO` is set.
+
+| Variable | Default | Description |
+|---|---|---|
+| `SMTP_HOST` | `host.docker.internal` | SMTP server hostname. The default targets an MTA running on the Docker host. |
+| `SMTP_PORT` | `25` | SMTP port. Use `587` for STARTTLS submission. |
+| `SMTP_USER` | (unset) | SMTP username. Leave unset for an unauthenticated relay. |
+| `SMTP_PASSWORD` | (unset) | SMTP password. |
+| `SMTP_USE_TLS` | `false` | Use STARTTLS. Set alongside `SMTP_PORT=587` for most hosted providers. |
+
+## Backups
+
+The `backup` service runs by default (see [Backups](guide/16-backups.md) for restore procedures). Set all three retention values to `0` to opt out entirely.
+
+| Variable | Default | Description |
+|---|---|---|
+| `BACKUP_RETENTION_DAILY` | `7` | Daily DB dumps to keep. `0` disables the daily bucket. |
+| `BACKUP_RETENTION_WEEKLY` | `4` | Weekly dumps to keep. |
+| `BACKUP_RETENTION_MONTHLY` | `12` | Monthly dumps to keep. |
+| `BACKUP_CHECK_INTERVAL_SECS` | `3600` | How often the backup loop wakes to check whether today's backup has run. |
+
+## Ask AI Prompts
+
+System prompts sent to the LLM at the start of each chat. These are the build-time defaults; overrides saved from Settings → Prompts live in the database and take precedence. "Reset to default" in the UI clears the override and falls back to the value here.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PROMPT_ASK_PAGE_SYSTEM` | (built-in) | System prompt for the cross-episode `/ask` page. |
+| `PROMPT_ASK_EPISODE_SYSTEM` | (built-in) | System prompt for the per-episode Ask popup. |
+| `RAG_LOCAL_MODEL` | `qwen2.5:3b` | Default Ollama model for local RAG generation. The Ask UI can override this per request. |
+
 ## Advanced / Internal
 
 | Variable | Default | Description |
 |---|---|---|
 | `DATABASE_URL` | (auto-generated) | PostgreSQL connection string. Override only if using an external database. |
+| `HARDWARE_PROFILE` | (auto-detected) | Pins the hardware profile used for tuning defaults instead of detecting it at startup. Leave unset unless detection is getting it wrong. |
 
 ## Model Memory Usage
 

--- a/scripts/check_docs_sync.py
+++ b/scripts/check_docs_sync.py
@@ -64,6 +64,35 @@ LISTING_CHECKS: tuple[tuple[str, str, str, frozenset[str]], ...] = (
 # Never treated as part of a listing — package/module scaffolding.
 IGNORED_DIR_ENTRIES = frozenset({"__init__", "__pycache__"})
 
+# Env-var documentation check (#899).
+#
+# README points at docs/configuration.md as "the full list of all environment
+# variables", but 19 real settings were missing — including WHISPER_CPU_THREADS,
+# which shipped as a new feature with no doc entry at all. pydantic-settings
+# maps each Settings field to its upper-cased name, so the field list is the
+# authoritative set.
+CONFIG_MODULE = "apps/pipeline/app/config.py"
+CONFIG_DOC = "docs/configuration.md"
+CONFIG_FIELD_RE = re.compile(r"^    ([a-z][a-z0-9_]*)\s*:", re.M)
+
+# Fields that are deliberately not user-facing configuration.
+UNDOCUMENTED_CONFIG_FIELDS: frozenset[str] = frozenset()
+
+
+def check_config_documented() -> list[str]:
+    """Return Settings fields that docs/configuration.md never mentions."""
+    module = REPO_ROOT / CONFIG_MODULE
+    doc = REPO_ROOT / CONFIG_DOC
+    if not module.exists() or not doc.exists():
+        return [f"cannot check env vars: {CONFIG_MODULE} or {CONFIG_DOC} is missing"]
+    text = doc.read_text(encoding="utf-8")
+    fields = set(CONFIG_FIELD_RE.findall(module.read_text(encoding="utf-8")))
+    return [
+        f"{CONFIG_DOC} does not document {name.upper()} (from {CONFIG_MODULE})"
+        for name in sorted(fields - UNDOCUMENTED_CONFIG_FIELDS)
+        if name.upper() not in text
+    ]
+
 
 def _listed_names(line: str, ignore: frozenset[str]) -> set[str]:
     """Extract bare names from the parenthesized listing on `line`.
@@ -192,17 +221,24 @@ def main(argv: list[str]) -> int:
     # Listing checks are repo-wide rather than per-target, so only run them
     # on a default (whole-repo) invocation.
     listing_problems = [] if args.targets else check_listings()
+    config_problems = [] if args.targets else check_config_documented()
 
-    if not overall_missing and not listing_problems:
+    if not overall_missing and not listing_problems and not config_problems:
         for rel in targets:
             print(f"OK  {rel}")
         if not args.targets:
             print("OK  exhaustive listings")
+            print("OK  env vars documented")
         return 0
 
     if listing_problems:
         print(f"\n[FAIL] {len(listing_problems)} listing problem(s):")
         for p in listing_problems:
+            print(f"  - {p}")
+
+    if config_problems:
+        print(f"\n[FAIL] {len(config_problems)} undocumented env var(s):")
+        for p in config_problems:
             print(f"  - {p}")
 
     for rel, paths in overall_missing:
@@ -223,6 +259,13 @@ def main(argv: list[str]) -> int:
         print(
             "\nThese listings claim to be exhaustive. Update the doc so it names "
             "exactly what is on disk — in both directions.",
+            file=sys.stderr,
+        )
+    if config_problems:
+        print(
+            f"\nREADME points at {CONFIG_DOC} as the full list of environment "
+            "variables. Document the setting there, or add the field to "
+            "UNDOCUMENTED_CONFIG_FIELDS if it is genuinely internal.",
             file=sys.stderr,
         )
     return 1


### PR DESCRIPTION
## Summary

Resolves #899.

`README.md:128` points at `docs/configuration.md` as "the full list of all environment variables". It was missing **19** of them.

The sharpest case: `WHISPER_CPU_THREADS`, whose entire purpose is letting operators tune CPU transcription, shipped as a new Unreleased feature with no entry anywhere under `docs/`.

**New sections:** Notifications (with an SMTP subsection), Backups, Ask AI Prompts.
**Extended:** Pipeline Tuning (`WHISPER_CPU_THREADS`), Speaker Inference (`RECURRING_HOST_WINDOW`, `RECURRING_HOST_THRESHOLD`, `FEED_SPEAKER_CACHE_RECENCY_DAYS`), Advanced (`HARDWARE_PROFILE`).

Every default and type was read out of `apps/pipeline/app/config.py` rather than guessed — including the `Literal` values for `NOTIFICATION_FREQUENCY` and the `host.docker.internal` SMTP default, which is worth a word of explanation for anyone wondering why it isn't `localhost`.

## Correction to the issue

The issue said 16 missing; the real number is **19**. Three that it listed — `OLLAMA_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` — were already documented, in prose rather than table rows, which is what the audit's table-row grep missed.

## Recurrence guard

`scripts/check_docs_sync.py` now diffs the `Settings` fields against the doc. pydantic-settings maps each field to its upper-cased name, so the field list is authoritative. An `UNDOCUMENTED_CONFIG_FIELDS` escape hatch exists for genuinely internal fields; it is **currently empty**, because all 59 fields are documented.

## Test plan

- [x] All 59 `config.py` fields verified present in the doc by set-diff — `still undocumented: NONE`
- [x] Added a throwaway `brand_new_knob: int = 5` to `config.py` → gate fails with
      `docs/configuration.md does not document BRAND_NEW_KNOB (from apps/pipeline/app/config.py)`; reverted
- [x] Clean tree passes all four checks: `OK CLAUDE.md` / `OK docs/development.md` / `OK exhaustive listings` / `OK env vars documented`
- [x] `ruff check scripts/check_docs_sync.py` clean

Builds on the listing gate added in #898 (PR #917).

🤖 Generated with [Claude Code](https://claude.com/claude-code)