### PR TITLE
docs: regenerate PRD-01 §10 from the actual routers (#900)

### DIFF
--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -340,19 +340,63 @@ CREATE TABLE speaker_names (
 
 ## 10. Internal API Endpoints
 
+All routers are mounted under the `/api` prefix (`apps/pipeline/app/main.py:57-69`).
+
+Note the web app does **not** proxy every one of these — it reads PostgreSQL directly for search and episode detail, which is why there is no `GET /api/episodes` here.
+
 ```
-POST   /api/feeds                    Add a new RSS feed
-GET    /api/feeds                    List all feeds
-DELETE /api/feeds/{id}               Remove a feed (and optionally its episodes)
+Feeds
+POST   /api/feeds                          Add a new RSS feed
+GET    /api/feeds                          List all feeds
+PATCH  /api/feeds/{feed_id}                Update a feed (e.g. pause/resume polling)
+DELETE /api/feeds/{feed_id}                Remove a feed (and optionally its episodes)
+GET    /api/feeds/preview                  Preview an RSS URL before adding it
+POST   /api/feeds/{feed_id}/poll           Force a poll now (rejected if the feed is paused)
+POST   /api/feeds/{feed_id}/episodes       Enqueue specific episodes from a feed
+GET    /api/feeds/{feed_id}/episodes/guids Known episode GUIDs, for dedupe
 
-POST   /api/episodes/ingest          Manually ingest a single audio URL
-GET    /api/episodes                 List episodes (filterable by feed, status)
-GET    /api/episodes/{id}            Get episode detail + segments
+Episodes
+POST   /api/episodes/ingest                Manually ingest a single audio URL
+POST   /api/episodes/upload                Upload a local audio file
+DELETE /api/episodes/{episode_id}          Delete an episode and its artifacts
 
-GET    /api/queue                    Get current queue state (pending/active/failed counts, worker status)
-POST   /api/queue/{task_id}/retry    Retry a failed job (only valid for non-system failures)
+Queue and health
+GET    /api/queue                          Queue state (pending/active/failed counts, worker status)
+POST   /api/queue/{episode_id}/retry       Retry a failed episode (keyed by episode, not task)
+GET    /api/health                         Health check — includes worker warm-up state
+GET    /api/hardware                       Detected hardware profile and tuning defaults
 
-GET    /api/health                   Health check — includes worker warm-up state
+Ask AI and embeddings
+POST   /api/ask                            RAG query (SSE stream)
+POST   /api/embed                          Embed a query string for vector search
+POST   /api/backfill/chunks                Backfill chunks/embeddings for existing episodes
+GET    /api/backfill/status                Backfill progress
+
+Prompts
+GET    /api/prompts                        List system prompts and their overrides
+PUT    /api/prompts/{key}                  Save a prompt override
+POST   /api/prompts/{key}/reset            Clear an override, fall back to the env default
+
+Notifications
+GET    /api/notifications/settings         Read notification settings
+PUT    /api/notifications/settings         Update notification settings
+POST   /api/notifications/test             Send a test notification
+
+Meta-analysis
+GET    /api/meta-analysis/snapshot         Cached cross-feed metrics
+POST   /api/meta-analysis/refresh          Recompute the snapshot
+GET    /api/meta-analysis/coverage/missing-speakers
+                                           Episodes still missing speaker names
+
+Backups
+GET    /api/backups                        List DB dumps and audio snapshots
+GET    /api/backups/retention              Read retention policy
+PUT    /api/backups/retention              Update retention policy
+DELETE /api/backups/db/{tier}/{filename}   Delete a specific DB dump
+DELETE /api/backups/audio/{date}           Delete an audio snapshot
+
+Explore
+GET    /api/explore/status                 Jupyter explore container status (opt-in profile)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Resolves #900.

PRD-01 §10 was wrong in both directions. CLAUDE.md declares the PRDs "the source of truth for requirements", so an agent or contributor citing this section was working from a list that both invented endpoints and omitted most real ones.

- Documented `GET /api/episodes` and `GET /api/episodes/{id}` — **neither exists**
- Gave the retry route as `POST /api/queue/{task_id}/retry` — it is `{episode_id}` (`apps/pipeline/app/api/queue.py:192`)
- Omitted **24** shipped endpoints

Rewritten directly from the `@router` decorators, grouped by area (Feeds / Episodes / Queue and health / Ask AI / Prompts / Notifications / Meta-analysis / Backups / Explore).

I also added a line explaining *why* there is no `GET /api/episodes`: the web app reads PostgreSQL directly for search and episode detail and only proxies to the pipeline API for management operations. Without that, the absence looks like a gap rather than the architecture.

## Test plan

- [x] Set-diff of documented routes against the `@router` decorators across `apps/pipeline/app/api/*.py`:
      `documented=34  actual=34`, `documented but NOT in code: NONE`, `in code but NOT documented: NONE`
- [x] Confirmed all routers mount under `/api` (`main.py:57-69`), so the PRD's `/api/...` convention is accurate
- [x] `scripts/check_docs_sync.py` passes

The `{task_id}` → `{episode_id}` error also appears in PRD-02:169 and is handled separately in #901, per one-issue-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)