### PR TITLE
docs: correct PRD-02 queue retry path param to episode_id (#901)

### DIFF
--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -166,7 +166,7 @@ Queue data is fetched by polling `GET /api/queue` every 5 seconds via React Quer
 
 Failed jobs show a collapsible error detail panel with the full traceback (toggled by a chevron in the row).
 
-**Retry action:** A "Retry" button in the Actions column calls `POST /api/queue/{task_id}/retry`. The button is disabled (greyed out with tooltip "Cannot retry — resolve the underlying issue first") for `DISK_FULL` and `OOM` errors since these require manual intervention. A Retry button is shown for `TRANSIENT_NETWORK`, `HTTP_ACCESS`, and `SYSTEM_ERROR` failures.
+**Retry action:** A "Retry" button in the Actions column calls `POST /api/queue/{episode_id}/retry` (via the web proxy at `/api/pipeline/queue/[episodeId]/retry`) — retry is keyed by episode, not by task. The button is disabled (greyed out with tooltip "Cannot retry — resolve the underlying issue first") for `DISK_FULL` and `OOM` errors since these require manual intervention. A Retry button is shown for `TRANSIENT_NETWORK`, `HTTP_ACCESS`, and `SYSTEM_ERROR` failures.
 
 **Done episodes:** Completed episodes are collapsed into an expandable "Done (N)" disclosure section at the bottom of the table. Expanding it reveals the full list sorted by completion time descending.
 


### PR DESCRIPTION
## Summary

Resolves #901.

`prds/PRD-02-search-web-app.md:169` documented the queue dashboard as calling `POST /api/queue/{task_id}/retry`. Retry is keyed by **episode**:

- Pipeline route: `@router.post("/queue/{episode_id}/retry")` — `apps/pipeline/app/api/queue.py:192`
- Web proxy: `apps/web/src/app/api/pipeline/queue/[episodeId]/retry/route.ts`

I also named the proxy path in the PRD, since that is what the dashboard actually calls — the PRD previously pointed only at the pipeline route, which the browser never hits directly.

Same underlying error as the PRD-01 §10 entry corrected in #900.

## Test plan

- [x] Confirmed the pipeline route signature at `queue.py:192`
- [x] Confirmed the proxy route file exists at the `[episodeId]` path
- [x] Grepped `prds/`, `docs/`, `README.md`, `CLAUDE.md` for residual `queue/{task_id}` → none outside the historical `docs/superpowers/` artifacts (tracked in #911)
- [x] `scripts/check_docs_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)