### PR TITLE
docs: fix PRD-03 config filenames, migration count, Makefile block (#902)

### DIFF
--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -190,7 +190,7 @@ A global audio player bar is rendered in the root layout, fixed to the bottom of
 - The user's preference is stored in `localStorage` under the key `podlog-theme`.
 - On first load, the app checks `localStorage` first; if absent, it respects the OS-level `prefers-color-scheme` media query.
 - A toggle button (sun/moon icon) in the top navigation bar switches modes.
-- shadcn/ui components support dark mode natively via CSS variables — no additional configuration required beyond enabling the `class` strategy in `tailwind.config.ts`.
+- shadcn/ui components support dark mode natively via CSS variables — no additional configuration required beyond enabling the `class` strategy — under Tailwind 4 this is the `@custom-variant dark` declaration in `src/app/globals.css`, not a `tailwind.config.*` file.
 
 ### 5.9 Navigation
 
@@ -230,7 +230,7 @@ The Ask page lets users ask natural-language questions about their podcast trans
 |---|---|---|---|
 | `qwen2.5:3b` | Default | 8K | 32K |
 | `phi3:mini` | Quality | 16K | 128K |
-| `gemma4:e4b` | Modern (Gemma 4) | 16K | 128K |
+| `gemma3n:e4b` | Modern (Gemma 3n E4B) | 16K | 128K |
 
 Configured context (`num_ctx`) is kept well below each model's maximum to keep prefill fast on CPU. The dropdown surfaces both numbers so users see the ceiling and the value actually sent to Ollama.
 

--- a/prds/PRD-03-infrastructure.md
+++ b/prds/PRD-03-infrastructure.md
@@ -41,7 +41,7 @@ podlog/
 │   │   ├── poetry.lock
 │   │   ├── alembic/
 │   │   │   ├── env.py
-│   │   │   └── versions/           # 12 migrations
+│   │   │   └── versions/           # 21 migrations
 │   │   ├── app/
 │   │   │   ├── main.py
 │   │   │   ├── config.py
@@ -89,8 +89,9 @@ podlog/
 │       ├── Dockerfile.test         # Built by docker-compose.test.yml for the web_test runner
 │       ├── package.json
 │       ├── package-lock.json
-│       ├── next.config.ts
-│       ├── tailwind.config.ts      # dark mode: 'class' strategy
+│       ├── next.config.mjs
+│       ├── postcss.config.js       # Tailwind 4 (no tailwind.config.*; dark mode
+│       │                           # via @custom-variant in src/app/globals.css)
 │       ├── src/
 │       │   ├── app/
 │       │   │   ├── layout.tsx      # Root layout with AudioPlayerContext + global player
@@ -466,7 +467,36 @@ web:              ## Open web app in browser
 ollama-pull:      ## Pull Ollama models used by the Ask feature
 	docker compose exec ollama ollama pull qwen2.5:3b
 	docker compose exec ollama ollama pull phi3:mini
-	docker compose exec ollama ollama pull gemma4:e4b
+	docker compose exec ollama ollama pull gemma3n:e4b
+
+test-integration: ## Run integration tests (requires HF_TOKEN for pyannote)
+	docker compose -f docker-compose.test.yml run --rm test pytest tests/integration/ -v
+
+explore:          ## Start the Jupyter DB-exploration service (#607). URL+token printed in logs.
+	docker compose --profile explore up -d explore
+	# ...then prints where to find the access token
+
+explore-down:     ## Stop the explore service
+	docker compose --profile explore down explore
+
+explore-logs:     ## Follow the explore service logs (look for the token URL)
+	docker compose --profile explore logs -f explore
+
+backup-now:       ## Force a backup run right now (bypasses the daily flag).
+	docker compose exec backup rm -f /backups/.last_run
+	docker compose restart backup
+
+backup-list:      ## List available DB dumps and audio snapshots.
+	# lists /backups/db/{daily,weekly,monthly} and /backups/audio via the backup container
+
+restore-db:       ## DESTRUCTIVE: restore the DB from a dated dump. Usage: make restore-db DATE=YYYY-MM-DD
+	# prompts for a typed 'yes', stops pipeline/worker/web, then:
+	docker compose exec backup /usr/local/bin/restore-db.sh $(DATE)
+	# ...and always restarts the stack, preserving the script's exit status
+
+restore-audio:    ## DESTRUCTIVE: restore audio archive from a dated snapshot. Usage: make restore-audio DATE=YYYY-MM-DD
+	# prompts for a typed 'yes', then:
+	docker compose exec backup /usr/local/bin/restore-audio.sh $(DATE)
 
 health-check:     ## Run health check once (requires python3, pg_isready, docker)
 	python3 scripts/healthcheck.py

--- a/prds/RISKS-AND-GAPS.md
+++ b/prds/RISKS-AND-GAPS.md
@@ -301,7 +301,7 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 | GAP-02 | No RSS feed validation on add | `validate_and_parse_feed()` in `rss.py` fetches + parses before persisting; 422 on failure | v1.2 |
 | GAP-06 | No disk space pre-check before download | `shutil.disk_usage()` check against `DISK_HEADROOM_BYTES` (default 2 GB) before download | v1.2 |
 | GAP-N/A | `updated_at` missing from episodes table | Added `updated_at` to episodes model (prerequisite for GAP-01 zombie detection) | v1.2 |
-| GAP-N/A | Next.js standalone output missing | Added `output: 'standalone'` to `next.config.ts` (required for Docker build) | v1.2 |
+| GAP-N/A | Next.js standalone output missing | Added `output: 'standalone'` to `next.config.mjs` (required for Docker build) | v1.2 |
 | GAP-01 | Zombie job cleanup | Periodic task every 30 min — queries episodes stuck in non-terminal status for >2 h and marks them `failed` with `error_class=SYSTEM_ERROR` (`app/tasks/cleanup.py`) | v1.3 |
 | GAP-03 | No episode re-processing | Episode reprocessing implemented — resets status to `pending`, clears segments, re-enqueues through the pipeline | v1.3 |
 | RISK-07 | Celery Beat single point of failure | No longer applicable — Celery/Redis replaced by PostgreSQL-backed job queue with polling loop in `worker.py` | v1.3 |


### PR DESCRIPTION
## Summary

Resolves #902. Three defects in PRD-03, plus two cross-file residuals of the same errors.

**1. Config files that don't exist.** `next.config.ts` → `next.config.mjs`. `tailwind.config.ts` removed entirely — this project is Tailwind 4 via `@tailwindcss/postcss` and has **no** `tailwind.config.*` at all; dark mode comes from `@custom-variant dark` in `src/app/globals.css`. The tree now shows `postcss.config.js` with a note explaining where the dark-mode strategy actually lives, so nobody goes hunting for a file that cannot exist. Same correction applied to `prds/PRD-02-search-web-app.md:193` and `prds/RISKS-AND-GAPS.md:304`.

**2. Migration count.** "12 migrations" → 21.

**3. Makefile block.** Still pulled the non-existent `gemma4:e4b`. #790 fixed the Makefile, `rag-models.ts` and two doc pages but missed **both** PRDs — so the bogus model name also survived in PRD-02's model table (line 233), which I fixed too. Both now `gemma3n:e4b`, matching `apps/web/src/lib/rag-models.ts:28`. Added the 8 missing targets.

## A correction I had to make mid-work

My first pass at the 8 missing targets **invented the recipe bodies from the target names**, and five of eight were wrong: `restore-db`/`restore-audio` actually run `/usr/local/bin/*.sh` inside the backup container rather than `bash apps/backup/*.sh`; `backup-now` removes `/backups/.last_run` and restarts rather than calling a `--force` flag; `explore-down` uses `down`, not `stop`; `test-integration` has a `/ -v` suffix.

Writing invented commands into a doc that CLAUDE.md calls the source of truth would have been worse than the omission it was fixing. Every recipe is now transcribed from the real Makefile, with long ones abridged and the elisions marked — including the typed-`yes` confirmation on both destructive restore targets, which is the detail most worth not losing.

## Test plan

- [x] Set-diff of Makefile targets: PRD block and real Makefile name the same **32** targets; `in PRD but not Makefile: NONE`, `in Makefile but not PRD: NONE`
- [x] Confirmed `apps/web/` contains `next.config.mjs`, `postcss.config.js`, and no `tailwind.config.*`
- [x] Migration count checked: `ls apps/pipeline/alembic/versions/*.py | wc -l` → 21
- [x] `gemma3n:e4b` matches `rag-models.ts:28` and `Makefile:62`
- [x] Repo-wide grep for `gemma4` / `next.config.ts` / `tailwind.config.ts` / `12 migrations` → none outside historical `docs/superpowers/` artifacts (#911)
- [x] `scripts/check_docs_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)