### PR TITLE
docs: describe scripts/ by what it actually contains (#903)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ podlog/
 │   ├── backup/                     # Nightly backup service (Dockerfile + backup.sh + restore scripts)
 │   └── explore/                    # Jupyter DB-exploration container (Dockerfile + requirements.txt; opt-in via `make explore`)
 ├── docs/                           # User-facing documentation and guides
-├── scripts/                        # Operational scripts (nightly audit, health check)
+├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates)
 └── prds/                           # Specifications and risk register
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ podlog/
 │   │   └── src/lib/                # Utilities (db, search, search/* (coverage, embedding, feedFilter, filters, filterOpts, grouped, grouping, mentions, queryParser, segments, speakerTurns, types), searchHybrid, timestamp, pipeline, types, utils, speakerColors, validateMergeRequest, citations, normalizeName, filename, dateFormat, docs-index, docs-search, docs-slug, formatFileSize, settings-schema, metaAnalysisStale, metaAnalysisTypes, page-state, queueStatus, rag-models, semver, episode-link, keyboardShortcuts, useKeyboardShortcut, useChordShortcut)
 │   ├── backup/                     # Nightly backup service (Dockerfile + backup.sh + restore scripts)
 │   └── explore/                    # Jupyter DB-exploration container (opt-in via `make explore`)
-├── scripts/                        # Operational scripts (nightly audit, health check)
+├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates)
 ├── backups/                        # Daily DB dumps + audio snapshots (gitignored)
 ├── notebooks/                      # Jupyter notebooks (gitignored bind mount for the explore service)
 ├── docs/                           # User-facing documentation


### PR DESCRIPTION
## Summary

Resolves #903.

`CLAUDE.md:69` and `docs/development.md:32` both described `scripts/` as "Operational scripts (nightly audit, health check)". There is no nightly-audit script — `grep -rn nightly scripts/` returns nothing. It is an **agent skill** at `.agents/skills/nightly-audit/SKILL.md` (gitignored per CLAUDE.md:73), which `docs/development.md:250` already cites correctly. The two halves of that same file disagreed with each other.

Replaced with the real contents: the health-check pair plus the three CI gates.

`check_docs_sync.py` was the notable omission — it is the gate that guards exactly this class of drift, and after #898 and #899 it now enforces considerably more of it, so leaving it undocumented was the worst of the five.

## Test plan

- [x] `ls scripts/` → `check_docs_sync.py`, `check-npm-outdated.sh`, `check-web-node-version.sh`, `healthcheck-install.sh`, `healthcheck.py`
- [x] `grep -rn "nightly audit"` across CLAUDE.md, docs/, README.md → no remaining claims that it is a script
- [x] Left the legitimate skill references intact (AGENTS.md:3 and the `docs/development.md` audit-workflow section, which correctly describe it as a skill)
- [x] `scripts/check_docs_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)