### PR TITLE
docs: fix the ESLint gotcha's verification command (#904)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,17 @@ Lessons from active development. Short rules; rationale linked to the incident o
 
 - **Split large issues into sequential PRs, not one bundle.** Issue #523 was shipped as 5 PRs (#525, #526, #527, #529, #531 + hotfix #532). Each PR had its own review / merge / prod-smoke loop. The hotfix pattern (#532 as a 2-line follow-up to #531) is cheaper than reverting or force-pushing over a merged PR.
 
-- **ESLint 9 → 10 is blocked upstream — verify readiness before re-attempting.** Codebase audits keep surfacing this as a major-version bump available (#494, #551, #676 are all the same finding). The block is in `eslint-config-next`'s bundled `eslint-plugin-react@7.37.5`, which uses the `context.getFilename()` method removed in ESLint 10 and crashes on every file with `TypeError: contextOrFilename.getFilename is not a function`. Before opening a new bump issue, check `apps/web/node_modules/eslint-config-next/node_modules/eslint-plugin-react/package.json` — if the bundled plugin version is still ≤ 7.37.x, the block stands and the audit finding should be treated as a known-blocked duplicate of #494. When the bundled version is ≥ 7.38, attempt the bump fresh. (Remove this note once the bump lands.)
+- **ESLint 9 → 10 is blocked upstream — verify readiness before re-attempting.** Codebase audits keep surfacing this as a major-version bump available (#494, #551, #676 are all the same finding). The block is in `eslint-config-next`'s bundled `eslint-plugin-react@7.37.5`, which uses the `context.getFilename()` method removed in ESLint 10 and crashes on every file with `TypeError: contextOrFilename.getFilename is not a function`. Before opening a new bump issue, check the resolved plugin version:
+
+```bash
+# Run from the repo root. npm hoists the plugin — there is normally NO
+# nested copy under eslint-config-next/node_modules (it holds only globals/).
+node -p "require('./apps/web/node_modules/eslint-plugin-react/package.json').version"
+# and confirm what eslint-config-next asks for
+node -p "require('./apps/web/node_modules/eslint-config-next/package.json').dependencies['eslint-plugin-react']"
+```
+
+If the resolved version is still ≤ 7.37.x, the block stands and the audit finding should be treated as a known-blocked duplicate of #494. When it is ≥ 7.38, attempt the bump fresh. (Remove this note once the bump lands.) As of 2026-08-08: resolved `7.37.5`, declared `^7.37.0` by `eslint-config-next@16.2.6` — still blocked.
 
 ## Current State & What's Next
 


### PR DESCRIPTION
## Summary

Resolves #904.

`CLAUDE.md:144` instructed the reader to check `apps/web/node_modules/eslint-config-next/node_modules/eslint-plugin-react/package.json` before re-attempting the ESLint 9→10 bump. **That path does not exist** — npm hoists the plugin, and that nested directory contains only `globals/`.

So the documented verification step always failed. The failure mode matters: someone checking a path that isn't there could reasonably conclude the bundled plugin was gone and the block had lifted, then burn time on a bump that still crashes on every file.

**The substantive claim is correct** and I re-verified it: resolved `eslint-plugin-react` is **7.37.5**, declared `^7.37.0` by `eslint-config-next@16.2.6`. Still ≤ 7.37.x, so the block genuinely stands and #494 remains the tracking issue.

Replaced with two runnable commands against the hoisted path, a note that the nested copy normally doesn't exist, and today's observed values so the next reader can tell at a glance whether anything has moved.

## A defect in my own first draft

My initial replacement used `require('apps/web/node_modules/...')`. Run from the repo root that throws `MODULE_NOT_FOUND` — Node treats a bare path as a module name, not a relative file. I only caught it because I ran the commands verbatim instead of eyeballing them, which is precisely the failure this issue is about: a documented check that nobody ever executed.

## Test plan

- [x] Confirmed `apps/web/node_modules/eslint-config-next/node_modules/` contains only `globals` — the old path is genuinely absent
- [x] Ran both new commands from the repo root exactly as documented → `7.37.5` and `^7.37.0`
- [x] Confirmed the first draft failed, and that the `./` prefix fixes it
- [x] `scripts/check_docs_sync.py` passes

No new bump issue opened — per the gotcha, this stays a known-blocked duplicate of #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)