### PR TITLE
docs: add apps/pipeline/README.md so poetry check passes (#907)

### DIFF
--- a/apps/pipeline/README.md
+++ b/apps/pipeline/README.md
@@ -1,0 +1,65 @@
+# podlog-pipeline
+
+The Podlog ingestion pipeline: RSS fetch, audio download, Whisper transcription, pyannote diarization, chunking, embedding, speaker inference, and archival.
+
+This package is one half of the [Podlog](../../README.md) monorepo — the other is the Next.js web app in [`apps/web`](../web). It runs as two containers built from the same source: a lightweight FastAPI control plane (`Dockerfile.control`) and a worker that carries the ML dependencies (`Dockerfile.worker`).
+
+## Layout
+
+```
+app/
+├── main.py              # FastAPI entry point; mounts every router under /api
+├── config.py            # pydantic-settings — all env vars live here
+├── models.py            # SQLAlchemy ORM (feeds, episodes, segments, speaker_names)
+├── database.py          # Engine + session factory
+├── job_queue.py         # PostgreSQL-backed job queue (enqueue, claim, complete)
+├── task_registry.py     # Maps pipeline stages to task functions + next-stage routing
+├── worker.py            # Background job worker + feed polling loop
+├── api/                 # FastAPI routers
+├── tasks/               # Pipeline stages (ingest → … → archive)
+└── services/            # Business logic (rss, whisper, pyannote, rag, …)
+alembic/versions/        # Migrations — auto-applied on pipeline startup
+tests/{unit,integration,e2e}
+```
+
+## Running
+
+The pipeline is normally run through Docker Compose from the repo root rather than directly:
+
+```bash
+make up            # starts db, pipeline, worker, ollama, web, backup
+make logs          # follow logs
+make shell-pipeline
+```
+
+For native development (Python 3.11–3.13 + [Poetry](https://python-poetry.org/)), see [`docs/development.md`](../../docs/development.md).
+
+```bash
+poetry install                 # add --with ml for the transcription/diarization stack
+poetry run uvicorn app.main:app --reload
+poetry run python -m app.worker
+```
+
+The `ml` dependency group (WhisperX, torch, pyannote-audio, spaCy, sentence-transformers) is **optional** and not installed by default — the API server does not need it, only the worker does.
+
+## Tests
+
+```bash
+poetry run pytest tests/unit                    # fast, mocks the DB
+poetry run pytest tests/unit --cov=app          # with coverage (CI gate: 82%)
+poetry run pytest tests/integration             # needs a real test DB
+```
+
+Integration and e2e tests require Docker and, for diarization, an `HF_TOKEN`. From the repo root, `make test-unit` and `make test-integration` wrap these.
+
+## Configuration
+
+Every setting is a field on `Settings` in [`app/config.py`](app/config.py), read from the environment. The full reference is [`docs/configuration.md`](../../docs/configuration.md), and `scripts/check_docs_sync.py` fails CI if a setting is added without a doc entry.
+
+## Notes
+
+- **Whisper and pyannote are never in memory at the same time.** Whisper is explicitly unloaded (plus `gc.collect()`) before pyannote loads. This is mandatory on CPU-only hosts — see PRD-01 §5.4.
+- **Diarization failure is non-fatal.** The transcript is still written with `speaker_label = NULL` and `has_diarization = false`.
+- **The version here is packaging metadata.** The runtime version is read from the repo-root `VERSION` file by `app.main._read_version()`.
+
+Design docs live in [`prds/`](../../prds); PRD-01 covers this app.


### PR DESCRIPTION
## Summary

Resolves #907.

`apps/pipeline/pyproject.toml:9` declared `readme = "README.md"` but the file did not exist:

```
$ poetry check
Error: Declared README file does not exist: README.md
```

That made `poetry check` exit non-zero — so it could not be adopted as a CI gate — and `poetry build` would have failed outright.

Per your call, created the README rather than dropping the key.

## What's in it

Written for someone landing in `apps/pipeline/` without the repo-root context: what the package is, how it splits across the control-plane and worker images, the module layout, how to run it under Compose and natively, the test commands and their prerequisites, and where configuration lives.

It also records the three invariants that aren't obvious from the code:

- Whisper and pyannote never coexist in memory (mandatory on CPU-only hosts, PRD-01 §5.4)
- Diarization failure is non-fatal — transcript still written with `speaker_label = NULL`
- The version in `pyproject.toml` is packaging metadata; the runtime reads the repo-root `VERSION`

The `ml` group being optional is called out, since `poetry install` without `--with ml` is the common source of confusion when the worker won't start.

## Test plan

- [x] `poetry check` now **exits 0** (was: `Error: Declared README file does not exist`)
- [x] Every factual claim verified against source rather than summarised: `_read_version` in `app/main.py`, `gc.collect` in the transcribe path, `has_diarization` on the model, `--cov-fail-under=82` at `ci-full-unit.yml:41`, `Dockerfile.control`/`Dockerfile.worker` present
- [x] All six relative links resolve (`../../README.md`, `../web`, `../../docs/development.md`, `../../docs/configuration.md`, `../../prds`, `app/config.py`)
- [x] `scripts/check_docs_sync.py` passes

## Deliberately not included

`poetry check` still prints `[tool.poetry] → [project]` deprecation warnings. They do **not** fail the command, and moving those tables changes packaging metadata that the image build reads — not something to slip into a README PR. Worth its own issue if you want Poetry 2.x readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)