### PR TITLE
chore(explore): bump pandas 2->3, plotly 5->6 and the rest (#908)

### DIFF
--- a/apps/explore/requirements.txt
+++ b/apps/explore/requirements.txt
@@ -1,9 +1,21 @@
 # Issue #607: explore service dependencies.
 # Pinned to known-working versions; bump in lockstep when upgrading.
-jupyterlab==4.3.5
-ipywidgets==8.1.5
-pandas==2.2.3
-numpy==2.2.2
-plotly==5.24.1
-sqlalchemy==2.0.36
-psycopg2-binary==2.9.10
+#
+# Bumped 2026-08-09 (#908). pandas 2->3 and plotly 5->6 are major bumps:
+# - pandas 3 makes copy-on-write the only behaviour and removes the
+#   silent-downcasting fallbacks, so notebooks that mutated a slice in place
+#   may now need .loc / .copy().
+# - plotly 6 aligns this container with the web app, which moved to
+#   plotly.js 3.x / react-plotly.js 4.x in #867. Figures authored here and
+#   rendered in the app now come from the same major.
+#
+# numpy is held at 2.4.x deliberately: the image is python:3.11-slim and
+# numpy 2.5+ publishes no wheel for 3.11. Raising it means bumping the base
+# image first. pandas 3.0.5 does support 3.11, so both major bumps still land.
+jupyterlab==4.6.2
+ipywidgets==8.1.8
+pandas==3.0.5
+numpy==2.4.6
+plotly==6.9.0
+sqlalchemy==2.0.51
+psycopg2-binary==2.9.12


### PR DESCRIPTION
## Summary

Resolves #908. The explore container hadn't been bumped since #607.

| Package | Before | After |
|---|---|---|
| jupyterlab | 4.3.5 | 4.6.2 |
| ipywidgets | 8.1.5 | 8.1.8 |
| **pandas** | 2.2.3 | **3.0.5** |
| numpy | 2.2.2 | 2.4.6 |
| **plotly** | 5.24.1 | **6.9.0** |
| sqlalchemy | 2.0.36 | 2.0.51 |
| psycopg2-binary | 2.9.10 | 2.9.12 |

`plotly` mattered most: the web app moved to `plotly.js` 3.x / `react-plotly.js` 4.x in #867, so figures authored in this container and figures rendered in the app were coming from different majors.

## The numpy constraint

My first attempt pinned `numpy==2.5.1` and **the build failed**: `No matching distribution found`. The image is `python:3.11-slim`, and numpy 2.5+ publishes no wheel for 3.11 — the ceiling there is 2.4.6.

Rather than quietly bump the base image inside a dependency PR, I held numpy at 2.4.6 and recorded why in the file. `pandas` 3.0.5 *does* support 3.11, so both major bumps still land. Raising numpy further is a base-image decision and should be its own change.

## Verification — real rebuild, not a resolver check

- [x] `docker compose build explore` succeeds
- [x] Versions **inside the image** match the pins exactly (python 3.11.15, pandas 3.0.5, numpy 2.4.6, plotly 6.9.0, sqlalchemy 2.0.51, psycopg2 2.9.12)
- [x] End-to-end against the **live** database: `pandas.read_sql` over `episodes` returned real rows (958 done) with correct `int64` dtypes — this is the pandas 3 path that actually carries risk, not the import
- [x] `plotly.express` built a figure from that DataFrame (1 trace) under plotly 6
- [x] Started `db` for the test and stopped it afterwards; stack left exactly as found (only `backup` running, as before)

## Note for whoever uses this next

pandas 3 makes copy-on-write the only behaviour and drops the silent-downcasting fallbacks. Existing notebooks under `notebooks/` (gitignored, not visible to CI) that mutate a slice in place may need `.loc` or `.copy()`. I didn't run user notebooks — that's the one thing this PR can't verify for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)