### PR TITLE
chore(deps): record the deliberate fastapi pin rationale (#906)

### DIFF
--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -12,6 +12,21 @@ readme = "README.md"
 python = ">=3.11,<3.14"
 
 # Web / API
+#
+# fastapi is deliberately held on the 0.111 line (#906, previously #770).
+# A caret on a 0.x pins >=0.111.0,<0.112.0, so this is effectively a pin —
+# `poetry update` cannot move it, only editing this constraint can.
+#
+# Why not bump: the work is not fastapi, it is starlette 0.37 -> 1.6, a real
+# major with breaking changes in middleware and background tasks. We are not
+# hitting any bug fixed upstream, so the bump is cost without benefit today.
+#
+# When to revisit: if a CVE lands in fastapi/starlette (they sit directly in
+# the request path), or when something else forces the upgrade. Adding
+# pip-audit to CI (#915) is the higher-value move — it makes that risk
+# visible, which is the actual gap here rather than the version number.
+#
+# Audits keep re-filing this; please update this note rather than deleting it.
 fastapi = "^0.111.0"
 uvicorn = {extras = ["standard"], version = "^0.48.0"}
 httpx = "^0.28.0"


### PR DESCRIPTION
## Summary

Resolves #906. **No dependency change** — this records a decision.

This is the third time the finding has been filed (#770, then #906). #770 was closed without either bumping *or* writing down why not, so the next audit found it again. This PR breaks that loop.

## The decision: don't bump

The headline number is misleading. `fastapi = "^0.111.0"` looks ~30 minors behind, but the actual work isn't fastapi — it's **`starlette` 0.37 → 1.6**, a genuine major with breaking changes across middleware and background tasks. We aren't hitting anything it fixes, so today the bump is cost without benefit.

What I documented in `pyproject.toml`, next to the constraint:

- A caret on a `0.x` pins `>=0.111.0,<0.112.0` — this is **effectively a pin**, and `poetry update` cannot move it. That mechanic is the reason this keeps reading as accidental drift when it isn't.
- Why we're holding.
- What should trigger a revisit: a CVE in fastapi/starlette (both sit directly in the request path), or something else forcing the upgrade.
- That **`pip-audit` in CI (#915) is the higher-value move** — the real gap is that a Python-side CVE would currently be invisible, not the version number.
- A request to update the note rather than delete it.

Same pattern as #773, which closed `@types/node` as an intentional pin explicitly so future audits would stop re-filing it.

## Test plan

- [x] `poetry check` exits 0
- [x] `poetry check --lock` — no manifest/lock desync
- [x] 999 pipeline unit tests pass
- [x] No version constraint changed — comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)