### PR TITLE
docs: fix five informational doc-accuracy findings (#911)

### DIFF
--- a/docs/episode-lifecycle.md
+++ b/docs/episode-lifecycle.md
@@ -34,7 +34,7 @@ pending → download → transcribe → diarize → chunk → embed → infer �
 
 **What it does:**
 - Converts audio to 16kHz mono WAV via ffmpeg
-- Runs Whisper large-v3 (or configured model)
+- Runs Whisper `large-v3-turbo` (the `WHISPER_MODEL` default, or the configured model)
 - Writes segments to database
 - Saves word-level alignment data to `{episode_id}.whisperx.json` if available
 - **Explicitly unloads Whisper from memory** (mandatory — Whisper + pyannote must never coexist)

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,19 @@
+# Historical execution artifacts — not current documentation
+
+The files under `plans/` and `specs/` are **point-in-time working documents**: implementation plans and design specs written while a feature was being built. They are kept for provenance — why a design went the way it did — not as a description of how the system works now.
+
+**They are stale by design and will not be updated.** Between them they reference roughly 30 files that no longer exist, including chart components deleted during PRD-06, `apps/web/src/lib/metaAnalysisColors.ts` (removed in #870), `apps/pipeline/requirements.txt` (the pipeline uses Poetry and `pyproject.toml`), and `tests/unit/test_worker_idle_hook.py`.
+
+Do not treat anything here as a source of truth, and do not "fix" the stale references — that would defeat the point of keeping a historical record.
+
+## Where to look instead
+
+| For | See |
+|---|---|
+| Current requirements and design | [`prds/`](../../prds) |
+| How the system is structured today | [`CLAUDE.md`](../../CLAUDE.md) |
+| Development setup and workflows | [`docs/development.md`](../development.md) |
+| Configuration reference | [`docs/configuration.md`](../configuration.md) |
+| What changed and when | [`CHANGELOG.md`](../../CHANGELOG.md) |
+
+Flagged by the 2026-08-08 codebase audit (#911): these live under `docs/` and are otherwise indistinguishable from living documentation to someone browsing the tree.

--- a/prds/PRD-01-ingestion-pipeline.md
+++ b/prds/PRD-01-ingestion-pipeline.md
@@ -426,11 +426,11 @@ GET    /api/explore/status                 Jupyter explore container status (opt
 - Zombie job detection
 - pyannote.ai Precision-2 cloud diarization as an alternative to local pyannote, selected via `DIARIZATION_PROVIDER=precision2` (Issue #516; see RISKS-AND-GAPS RISK-11)
 - Fireworks AI remote-inference profile (`make up-remote`) for users who prefer remote Whisper/LLM over a local Ollama container
+- Feed pause/resume — stop polling without deleting, via `PATCH /api/feeds/{feed_id}` with `paused` (migration `020_add_feed_paused_column.py`); paused feeds also reject manual polls (Issue #743)
 
 ### Future
 - GPU support via Docker NVIDIA runtime flag
 - Episode chapter detection
-- Feed pause/resume (stop polling without deleting)
 
 ---
 

--- a/prds/PRD-02-search-web-app.md
+++ b/prds/PRD-02-search-web-app.md
@@ -546,7 +546,7 @@ const { playEpisode } = useAudioPlayer();
 ### V1 (Phase 2)
 - Search result grouping by episode (top N segments per episode, avoid one long episode dominating)
 - Keyboard navigation of search results
-- Export transcript as `.txt` or `.srt` from episode page
+- Export transcript as `.txt` from episode page (`.srt` is **not** implemented — exports are Markdown/plain text only)
 - "Copy timestamp link" button
 - Meta-Analysis dashboard (`/meta-analysis`) aggregating cross-feed metrics — coverage, episode length, WPM, turn density, host/guest share, tokens, processing time, and cost per feed (Issue #521; see §5.11)
 

--- a/prds/RISKS-AND-GAPS.md
+++ b/prds/RISKS-AND-GAPS.md
@@ -165,7 +165,7 @@ For a typical podcast library of 1,000 episodes (1 hour average, audio archived)
 **Severity:** High  
 **Component:** PRD-02 — `/api/audio` route  
 **Description:** The original PRD-02 v1.0 audio serving route constructed a file path from user-supplied URL parameters without validation. A crafted request like `/api/audio/fake-id/../../../../etc/passwd` could potentially read arbitrary files from the container filesystem.  
-**Mitigation:** Resolved in PRD-02 v1.1 (§5.2, §11). The route now treats the filename parameter as a basename only (path separators stripped), resolves the full path, and verifies it starts with `/data/audio/archive/` before serving.  
+**Mitigation:** Resolved in PRD-02 v1.1 (§5.2, §11). The route now treats the filename parameter as a basename only (path separators stripped), resolves the full path, and verifies it stays within the allowed audio directories before serving. Those are both `/data/audio/archive/` and `/data/audio/raw/` (`AUDIO_DIRS` in the route), not archive alone — raw is needed to serve episodes that have not been archived yet.  
 **Status:** Mitigated in v1.1.
 
 ---


### PR DESCRIPTION
## Summary

Resolves #911.

**1. RISKS-AND-GAPS understated the audio guard.** RISK-05 said the route "verifies it starts with `/data/audio/archive/`". `AUDIO_DIRS` is *both* `/data/audio/archive` and `/data/audio/raw` — raw is needed to serve episodes not yet archived. The traversal protection was always correct; only the description was narrow. Worth fixing precisely because it documents a security control, and an inaccurate description of one invites the wrong conclusion in a future review.

**2. PRD-01 listed feed pause/resume under "Future" — it shipped.** Moved to the Done list *with* the mechanism (`PATCH /api/feeds/{feed_id}` with `paused`, migration `020_add_feed_paused_column.py`, #743) rather than just deleting the line, so the record shows it landed.

**3. PRD-02 listed `.srt` transcript export, which doesn't exist.** Zero `srt` references in `apps/web/src`; exports are Markdown/plain text only. Marked explicitly as not implemented rather than removed — everything else in that V1 block shipped, so a silent deletion would leave no trace it was dropped.

**4. `docs/episode-lifecycle.md` named the model as `large-v3`.** The `WHISPER_MODEL` default is `large-v3-turbo`.

**5. `docs/superpowers/` now has a README** marking `plans/` and `specs/` as historical execution artifacts — stale by design, not to be updated, with a table pointing at the live docs.

That last one is the judgement call. Those files reference ~30 paths that no longer exist, but they're *working documents from when features were built* — provenance, not documentation. "Fixing" the references would destroy what makes them useful. The real problem was that they sit under `docs/` and look identical to current documentation. A banner solves that; rewriting them would not.

## Test plan

- [x] `AUDIO_DIRS` confirmed at `route.ts:6` as `["/data/audio/archive", "/data/audio/raw"]`
- [x] `020_add_feed_paused_column.py` exists
- [x] `grep -rn "srt" apps/web/src --include='*.ts*'` → **0** matches
- [x] `whisper_model` default confirmed as `large-v3-turbo` at `config.py:42`
- [x] All five relative links in the new README resolve
- [x] `scripts/check_docs_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)