### PR TITLE
refactor: remove dead buildNormalizedQuery, retain verify_api_key (#913)

### DIFF
--- a/apps/pipeline/app/services/pyannote_cloud.py
+++ b/apps/pipeline/app/services/pyannote_cloud.py
@@ -100,7 +100,16 @@ def _wrap_http_error(action: str, exc: httpx.HTTPStatusError) -> PyannoteCloudEr
 
 
 def verify_api_key(api_key: str, base_url: str) -> bool:
-    """Ping GET /test to verify the API key. Returns True on 2xx, False on 401/403."""
+    """Ping GET /test to verify the API key. Returns True on 2xx, False on 401/403.
+
+    Currently only exercised by tests — deliberately kept, not dead code (#913).
+    It is the missing half of a "Test key" button for the pyannote-cloud API
+    key in Remote Inference settings: the field exists, the check does not, and
+    docs/guide/13-pyannote-cloud.md works around it by telling users to run the
+    equivalent `curl` against `GET /v1/test` by hand. Wiring it up mirrors the
+    existing `POST /notifications/test` pattern. Tracked in #933; do not
+    delete this on a dead-code sweep without closing that issue first.
+    """
     if not api_key:
         return False
     url = f"{_base(base_url)}/test"

--- a/apps/web/src/lib/search/queryParser.ts
+++ b/apps/web/src/lib/search/queryParser.ts
@@ -95,11 +95,3 @@ export function parseSearchQuery(raw: string): ParsedSearchQuery {
     mode,
   };
 }
-
-export function buildNormalizedQuery(parsed: ParsedSearchQuery): string {
-  if (parsed.freeText) return parsed.freeText;
-  const scopedParts = [parsed.titleFilter, parsed.descriptionFilter, parsed.speakerFilter].filter(
-    (part): part is string => Boolean(part)
-  );
-  return scopedParts.join(" ").trim();
-}

--- a/apps/web/tests/unit/search-query-parser.test.ts
+++ b/apps/web/tests/unit/search-query-parser.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { buildNormalizedQuery, parseSearchQuery } from "@/lib/search/queryParser";
+import { parseSearchQuery } from "@/lib/search/queryParser";
 
 describe("parseSearchQuery", () => {
   test("keeps plain query as transcript_hybrid free text", () => {
@@ -69,17 +69,5 @@ describe("parseSearchQuery", () => {
     expect(parsed.speakerFilter).toBeNull();
     expect(parsed.freeText).toBe("title: speaker:");
     expect(parsed.mode).toBe("transcript_hybrid");
-  });
-});
-
-describe("buildNormalizedQuery", () => {
-  test("prefers freeText when present", () => {
-    const parsed = parseSearchQuery("hello speaker:jacob");
-    expect(buildNormalizedQuery(parsed)).toBe("hello");
-  });
-
-  test("falls back to scoped values when freeText is empty", () => {
-    const parsed = parseSearchQuery("title:china description:iran speaker:jacob");
-    expect(buildNormalizedQuery(parsed)).toBe("china iran jacob");
   });
 });


### PR DESCRIPTION
## Summary

Resolves #913. Two exports whose only reference was their own test — and they needed **opposite** treatment, which is why the issue's "check intent before deleting" note mattered.

## `buildNormalizedQuery` — deleted

`apps/web/src/lib/search/queryParser.ts`. No production caller, no intra-file use, no PRD mention. Its sibling `parseSearchQuery` from the same file *is* used in production, so this wasn't a whole-module oversight — just one function that outlived its purpose. Removed with its `describe` block and the now-unused import.

## `verify_api_key` — kept

`apps/pipeline/app/services/pyannote_cloud.py`. **Not dead code.** It's the finished half of an unfinished feature:

- The settings UI has a pyannote API-key input (`RemoteInferencePyannoteParts.tsx:91`) with no way to check the key
- `docs/guide/13-pyannote-cloud.md:89` works around that by telling users to run the check by hand:
  > Verify at `GET /v1/test` via `curl -H 'Authorization: Bearer <key>' https://api.pyannote.ai/v1/test`

That curl is exactly what `verify_api_key` does. Deleting it would have removed working, tested code that closes a real UX gap — and the gap has teeth: an invalid key currently fails silently at save time and only surfaces as a `401` once a diarization job runs, after an episode has already been downloaded and transcribed.

Added a docstring note explaining why it's retained (so a future sweep doesn't delete it) and filed **#933** to wire it up, mirroring the existing `POST /notifications/test` button pattern. #933 asks for that note to be removed once it has a caller.

## Test plan

- [x] Web: **972** tests pass (2 fewer — the deleted block)
- [x] Pipeline: **999** tests pass
- [x] `npm run typecheck` clean; `npm run lint` 0 errors
- [x] `ruff check apps/pipeline/app/services/pyannote_cloud.py` clean
- [x] No remaining `buildNormalizedQuery` references in `src/` or `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)