### PR TITLE
security: bind db, pipeline and ollama to loopback (#952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Major changes
+- The database, pipeline API and Ollama are no longer reachable from your local network. They were published on all interfaces, so any device that could route to the machine running Podlog could connect to PostgreSQL directly, or call the pipeline API — which has no authentication and whose settings endpoint holds your Fireworks and pyannote keys. All three are now bound to the machine itself, matching how the optional Jupyter service was already configured. The web interface is deliberately left reachable, so you can still open Podlog from a phone or another computer. Nothing else changes: the containers talk to each other over their private network, and the health check, `make` targets and documented `curl` commands all run on the same machine. ([#952](https://github.com/brlauuu/podlog/issues/952))
+
 ## 0.6.0 — 2026-08-19
 
 ### Major changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ make test-unit         # Run pipeline unit tests + host healthcheck test (no web
 make shell-db          # Open psql shell
 ```
 
-`make up` starts db, pipeline, worker, ollama, web, and backup (6 services); `explore` is opt-in via the `explore` compose profile (`make explore`). Exposed ports: web (:3000), pipeline API (:8000), ollama (:11434).
+`make up` starts db, pipeline, worker, ollama, web, and backup (6 services); `explore` is opt-in via the `explore` compose profile (`make explore`). Exposed ports: web on `0.0.0.0:3000` (reachable from the LAN, deliberately); db (:5432), pipeline API (:8000) and ollama (:11434) are bound to `127.0.0.1` only (#952), as `explore` (:8888) already was. Host tooling keeps working — `scripts/healthcheck.py`, `make backfill` and the guides all use `localhost` — and containers reach each other by service name over the compose network, not through these mappings.
 
 ## Conventions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,13 @@ services:
       POSTGRES_DB: podlog
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    # Bound to loopback (#952). Postgres holds everything and was reachable
+    # from the whole LAN; password auth is the only thing that stood between
+    # the network and the data. Host tooling is unaffected -- `make shell-db`
+    # goes through `docker compose exec`, and every container reaches the DB
+    # as `db:5432` over the compose network, not via this mapping.
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -30,8 +35,15 @@ services:
       BACKUP_RETENTION_DAILY: ${BACKUP_RETENTION_DAILY:-7}
       BACKUP_RETENTION_WEEKLY: ${BACKUP_RETENTION_WEEKLY:-4}
       BACKUP_RETENTION_MONTHLY: ${BACKUP_RETENTION_MONTHLY:-12}
+    # Bound to loopback (#952). The pipeline API has no authentication, and
+    # every write endpoint -- settings (which holds the Fireworks and pyannote
+    # keys), backfill, retry, upload, feed CRUD -- was open to anything that
+    # could route here. Removing the mapping entirely was considered and
+    # rejected: scripts/healthcheck.py, `make backfill` and two user guides all
+    # call http://localhost:8000. Loopback keeps those working while dropping
+    # LAN reachability. The web container uses http://pipeline:8000.
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -84,8 +96,10 @@ services:
 
   ollama:
     image: ollama/ollama:latest
+    # Bound to loopback (#952). Ollama's API is unauthenticated and will run
+    # arbitrary prompts against local models for anyone who can reach it.
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama_data:/root/.ollama
     healthcheck:
@@ -111,6 +125,11 @@ services:
         # falls back to the repo-root VERSION file, so the baked-in version is
         # never the 0.0.0 sentinel that made the footer cry "rebuild available".
         APP_VERSION: ${APP_VERSION:-}
+    # Deliberately NOT loopback-bound (#952), unlike db/pipeline/ollama above.
+    # This is the user-facing UI and being able to open Podlog from a phone or
+    # another machine on the LAN is a reasonable thing to want. It is read-
+    # mostly and does not expose the API keys the settings endpoint holds.
+    # Change this to 127.0.0.1:3000:3000 if you only ever browse from this host.
     ports:
       - "3000:3000"
     environment:

--- a/docs/guide/17-troubleshooting.md
+++ b/docs/guide/17-troubleshooting.md
@@ -96,6 +96,14 @@ make logs                         # tail logs for all services
 curl -s http://localhost:8000/api/health | python3 -m json.tool
 ```
 
+> **This only works from the machine running Podlog.** The database, pipeline
+> API and Ollama are bound to `127.0.0.1` so they are not reachable from other
+> devices on your network — the pipeline API has no authentication and its
+> settings endpoint holds your Fireworks and pyannote keys. The web UI on port
+> 3000 *is* reachable from the LAN, so you can still browse Podlog from a phone
+> or another computer. To change either, edit the `ports:` entries in
+> `docker-compose.yml`.
+
 The host-level health check (`make health-install`) runs the same probes every 15 minutes and can send Telegram alerts on state transitions — see [Notifications](09-notifications.md#health-monitoring).
 
 ## Stuck or zombie episodes


### PR DESCRIPTION
## Measured, before and after

From the host's own LAN address (`192.168.1.190`):

| Port | Service | Before | After |
|---|---|---|---|
| 5432 | **PostgreSQL** | REACHABLE | refused |
| 8000 | pipeline API (no auth) | REACHABLE | refused |
| 11434 | Ollama (no auth) | REACHABLE | refused |
| 3000 | web UI | REACHABLE | REACHABLE *(deliberate)* |

## Two corrections to the issue, which I filed

**1. My recommended fix was wrong.** The issue said removing the `ports:` mapping "is probably the single highest-value change here and costs nothing except direct curl access from the host for debugging — which `docker compose exec` covers."

It would actually break:
- `scripts/healthcheck.py` — a **host cron** whose default is `http://localhost:8000`
- the Makefile's backfill target
- the `curl` commands in `docs/guide/02-first-run.md` and `17-troubleshooting.md`

Loopback binding achieves the same security outcome while leaving all of those working.

**2. The issue scoped the problem too narrowly.** It covered only the pipeline API. Checking every published port found **PostgreSQL on `0.0.0.0:5432`** — arguably worse, since it holds everything and password auth was the only thing between the LAN and the data. Ollama was open too.

Notably, `explore` was **already** bound to `127.0.0.1:8888` — the pattern existed in this very file, just not applied to the services that needed it most.

## Why web stays public

`web` remains on `0.0.0.0:3000` on purpose: it's the user-facing UI, browsing Podlog from a phone is reasonable, and it doesn't expose the API keys the settings endpoint holds. The compose file now states this explicitly, so it reads as a decision rather than an oversight.

## Why no authentication

After loopback binding, an attacker needs a shell on the host — at which point `.env` is readable anyway. The marginal value is small against managing a shared secret across two containers plus `healthcheck.py` and the Makefile. Recorded as an explicit decision, not an omission, and left as a 1.0 consideration.

## Verification

Everything I claimed would keep working, checked after applying:

| Check | Result |
|---|---|
| `scripts/healthcheck.py` | runs clean — "No state transitions" |
| Makefile backfill URL | 200 |
| Documented first-run `curl` | `OK` |
| `make shell-db` path | works |
| web → pipeline | 200 |
| web → db (search) | 200 |
| pipeline → db (queue) | 200 |

Containers reach each other by service name over the compose network, so inter-container traffic never used these mappings.

## Docs

`CLAUDE.md`'s exposed-ports line updated, plus a note in the troubleshooting guide explaining that the `curl` commands only work from the Podlog host and how to change it.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)