### PR TITLE
build: collapse the version to one source, add release automation (#936)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+# Publishes a GitHub Release when a vX.Y.Z tag is pushed (#936).
+#
+# The tag is the trigger, not the source of truth. After #936 exactly two
+# things carry a version -- the repo-root VERSION file and the git tag -- and
+# scripts/release_notes.py asserts they agree before anything is published.
+# It also refuses to publish when `## Unreleased` still holds entries, which
+# would otherwise produce a release whose notes belong to the previous
+# version.
+#
+# #937 later hangs image publishing off this same trigger.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@v4
+        with:
+          # The tag, not the branch head -- VERSION is asserted against the
+          # tagged commit's contents, which is the whole point of the check.
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate and extract release notes
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Releasing $VERSION (tag $GITHUB_REF_NAME)"
+          {
+            echo "body<<RELEASE_NOTES_EOF"
+            python3 scripts/release_notes.py "$VERSION"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "${{ steps.notes.outputs.body }}" \
+            --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,10 @@ next-env.d.ts
 apps/web/.next/
 apps/web/node_modules/
 
-# Build artifacts — VERSION copies placed by `make build`
+# Build artifact — the VERSION copy `make build` used to place here.
+# apps/web/VERSION was dropped in #936: nothing has written it since the web
+# Dockerfile moved to a repo-root build context reading /VERSION directly.
 apps/pipeline/VERSION
-apps/web/VERSION
 
 # Docker volumes (local bind mounts during dev)
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- The version number now lives in exactly one file. `apps/pipeline/pyproject.toml` and `apps/web/package.json` used to carry their own copies that had to be updated by hand, which is how the web one drifted five minor versions behind without anything noticing — nothing reads either at runtime. Both are now pinned to a `0.0.0` placeholder, leaving `/VERSION` and the git tag as the only two places a version appears. A new release workflow publishes the GitHub release automatically when a version tag is pushed, and refuses to do so if the tag disagrees with `/VERSION` or if the changelog still has unreleased entries that were never filed under the version being released. ([#936](https://github.com/brlauuu/podlog/issues/936))
+
 ### Major changes
 - The database, pipeline API and Ollama are no longer reachable from your local network. They were published on all interfaces, so any device that could route to the machine running Podlog could connect to PostgreSQL directly, or call the pipeline API — which has no authentication and whose settings endpoint holds your Fireworks and pyannote keys. All three are now bound to the machine itself, matching how the optional Jupyter service was already configured. The web interface is deliberately left reachable, so you can still open Podlog from a phone or another computer. Nothing else changes: the containers talk to each other over their private network, and the health check, `make` targets and documented `curl` commands all run on the same machine. ([#952](https://github.com/brlauuu/podlog/issues/952))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ podlog/
 ├── LICENSE
 ├── .node-version                   # Node version for local dev
 ├── .nvmrc                          # Node version for nvm users
-├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow, changelog)
+├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow, changelog, release)
 ├── issues/                         # Local issue drafts / notes
 ├── backups/                        # Daily DB dumps + rsync audio snapshots (gitignored)
 ├── notebooks/                      # Jupyter exploration notebooks (gitignored bind mount)
@@ -74,7 +74,7 @@ podlog/
 │   ├── backup/                     # Nightly backup service (Dockerfile + backup.sh + restore scripts)
 │   └── explore/                    # Jupyter DB-exploration container (Dockerfile + requirements.txt; opt-in via `make explore`)
 ├── docs/                           # User-facing documentation and guides
-├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates)
+├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates, release-notes extractor)
 └── prds/                           # Specifications and risk register
 ```
 
@@ -126,6 +126,9 @@ make shell-db          # Open psql shell
   - Pipeline: `pytest` — unit tests mock DB/models, integration tests use a real test DB.
   - Web: `jest` + `@testing-library/react` for unit, `playwright` for e2e.
 - **PRD references:** When implementing a feature, cite the PRD section (e.g. "per PRD-02 §5.6") in code comments only where the requirement is non-obvious.
+- **Versioning (#936):** `/VERSION` at the repo root is the **only file containing a version**. The git tag is the only other place a version appears, and `scripts/release_notes.py` asserts the two agree before a release publishes. `apps/pipeline/pyproject.toml` and `apps/web/package.json` are both pinned to the `0.0.0` sentinel on purpose — neither is read at runtime, and keeping them "in sync by hand" is exactly how `package.json` drifted five minor versions behind without anything noticing. Do not reintroduce a version number anywhere else.
+- **Semver policy:** **Major** — a change the operator must act on: a removed or renamed env var, a migration that cannot be rolled back by restoring the previous dump, a new external service requirement (e.g. a newly mandatory API key), or a breaking change to the pipeline API the web app consumes. **Minor** — new user-visible capability, additive env vars with working defaults, additive migrations. **Patch** — fixes, dependency refreshes, docs, internal work.
+- **Releasing:** bump `/VERSION`, graduate `## Unreleased` into a dated section, merge, then push a `vX.Y.Z` annotated tag. `.github/workflows/release.yml` validates and publishes. It refuses to publish if the tag disagrees with `VERSION`, or if `## Unreleased` still holds entries. No fixed calendar — cut a release when `Unreleased` has accumulated user-visible entries and CI is green.
 - **When modifying the design:** Update the relevant PRD and RISKS-AND-GAPS.md. Bump the version number.
 - **Changelog:** PRs that ship user-visible behavior add a one-line entry to `CHANGELOG.md` under `## Unreleased`, grouped as Major / Minor / Fixes (or Internal where appropriate). Version headings are bare semver (`## 0.3.0 — 2026-04-24`), not the keepachangelog reference-link form (`## [0.3.0]`) — the latter breaks the About-page anchor lookup (#644). The same file is rendered at the bottom of `/about` in the web app, so write entries for a human reading them there.
 

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,12 @@ down:           ## Stop all services
 down-remote:    ## Stop remote-inference profile stack
 	docker compose -f docker-compose.yml -f docker-compose.remote.yml down
 
+# Does not copy VERSION into apps/pipeline/ any more (#936): the pipeline gets
+# it at runtime from the ./VERSION:/app/VERSION:ro bind mount, web bakes it
+# from the repo-root build context, and the worker never reads it. The old
+# cp/rm dance also left a stray file behind whenever a build failed.
 build:          ## Rebuild all images (reads version from VERSION file)
-	@cp VERSION apps/pipeline/VERSION
 	docker compose build --build-arg APP_VERSION=$$(cat VERSION)
-	@rm -f apps/pipeline/VERSION
 
 logs:           ## Follow logs for all services
 	docker compose logs -f

--- a/apps/pipeline/pyproject.toml
+++ b/apps/pipeline/pyproject.toml
@@ -1,8 +1,14 @@
 [tool.poetry]
 name = "podlog-pipeline"
-# Kept in sync with the repo-root VERSION file. The runtime version is read
-# from that file by app.main._read_version(); this is packaging metadata only.
-version = "0.6.0"
+# Deliberately pinned to the 0.0.0 sentinel (#936). The single source of
+# truth for the version is the repo-root /VERSION file, read at runtime by
+# app.main._read_version(). Poetry requires this key and accepts 0.0.0.
+#
+# It used to mirror /VERSION and had to be bumped by hand, which is exactly
+# how apps/web/package.json drifted five minor versions behind without
+# anything noticing. Verified before changing: nothing reads this value at
+# runtime -- _read_version() reads the file, not the package metadata.
+version = "0.0.0"
 description = "Podlog ingestion pipeline — RSS fetch, Whisper transcription, pyannote diarization"
 authors = []
 license = "O'Saasy"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podlog-web",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "license": "O'Saasy",
   "engines": {

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Extract one version's section from CHANGELOG.md, and validate the release (#936).
+
+Used by .github/workflows/release.yml on a `v*` tag push. Kept as a script
+rather than inline YAML so it can be run and tested locally:
+
+    python3 scripts/release_notes.py 1.0.0
+
+Three checks, all of which must pass before a release is published:
+
+1. The tag version matches the VERSION file at that commit. VERSION and the
+   git tag are the only two places a version appears after #936, so this is
+   the guard that keeps them honest.
+2. `## Unreleased` carries no entries. A tag cut from a commit where the
+   changelog was never rolled over would otherwise publish a release whose
+   notes belong to the *previous* version.
+3. A section exists for this version. The heading form is bare semver
+   (`## 1.0.0 — YYYY-MM-DD`), not the keepachangelog reference-link form --
+   #644 established that, and the About page's anchor lookup depends on it.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HEADING = re.compile(r"^## (\d+\.\d+\.\d+) — (\d{4}-\d{2}-\d{2})\s*$", re.M)
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def extract(changelog: str, version: str) -> str:
+    """Return the body of the section for `version`, without its heading."""
+    matches = list(HEADING.finditer(changelog))
+    for i, m in enumerate(matches):
+        if m.group(1) != version:
+            continue
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(changelog)
+        return changelog[start:end].strip()
+    return ""
+
+
+def unreleased_entries(changelog: str) -> list[str]:
+    """Entry lines sitting under `## Unreleased`, if any."""
+    m = re.search(r"^## Unreleased\s*$", changelog, re.M)
+    if not m:
+        return []
+    nxt = HEADING.search(changelog, m.end())
+    body = changelog[m.end(): nxt.start() if nxt else len(changelog)]
+    return [ln for ln in body.split("\n") if ln.startswith("- ")]
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail("usage: release_notes.py <version>   (no leading 'v')")
+    version = sys.argv[1].lstrip("v")
+
+    on_disk = (ROOT / "VERSION").read_text().strip()
+    if on_disk != version:
+        fail(
+            f"tag says {version} but VERSION says {on_disk}. "
+            "The tag must be cut from a commit whose VERSION file matches it."
+        )
+
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+
+    stray = unreleased_entries(changelog)
+    if stray:
+        fail(
+            f"## Unreleased still has {len(stray)} entr{'y' if len(stray) == 1 else 'ies'}. "
+            "Graduate them into the version section before tagging, or the release "
+            f"notes will be missing them. First: {stray[0][:70]}"
+        )
+
+    body = extract(changelog, version)
+    if not body:
+        fail(
+            f"no '## {version} — YYYY-MM-DD' section in CHANGELOG.md. "
+            "Headings must be bare semver with an em dash (#644)."
+        )
+
+    print(body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope

**Part A of #936 only** — the version-source cleanup and the tag-triggered release workflow.

The **1.0.0 cut is deliberately not here.** Whether this is 1.0 is a product judgement, not an engineering task. #937 (prebuilt images) gates its own work on that decision — its text says *"Nothing here should be built before the 1.0 cut."*

## The problem

Three files carried a version and had to be kept in sync by hand. That's how `apps/web/package.json` ended up **five minor versions behind** without anything noticing. Both package versions are now the `0.0.0` sentinel, leaving `/VERSION` and the git tag as the only two places a version appears.

## #936 said to verify rather than trust its own comments — so I did

| Claim | Verified |
|---|---|
| Nothing in `apps/web/src` reads `package.json`'s version | Confirmed |
| Nothing reads `pyproject`'s version at runtime | Confirmed — `_read_version()` reads the VERSION **file**, not package metadata |
| The `cp VERSION apps/pipeline/VERSION` dance is removable | Confirmed — pipeline gets it from the bind mount, web bakes it from the repo-root context, **the worker never reads it at all** |

That last check found the artifact #936 predicted: a stray untracked `apps/pipeline/VERSION` sitting in the tree containing **`0.5.4`** — stale by a full minor. `COPY . .` would have baked it into the image, masked only by the bind mount. Removed.

## Release automation

`scripts/release_notes.py`, called by `.github/workflows/release.yml` on a `v*` tag push. It refuses to publish when:

1. **The tag disagrees with `VERSION`** at that commit — the guard keeping the two remaining sources honest
2. **`## Unreleased` still holds entries** — which would publish a release whose notes belong to the previous version *(the open question in #936; included)*
3. No section exists for that version

Kept as a script rather than inline YAML so it can be run locally.

**Verified against all 25 existing sections**, including `0.2.0` (2 lines) and `0.3.0` (29 lines) which #936 named specifically. All extract, none empty, and a nonexistent version returns empty rather than the wrong section. Both refusal guards were confirmed to actually fire.

## One thing worth knowing

The three retroactive tags from #958 **would fail guard 1** — `v0.5.5` points at a commit where `VERSION` reads `0.5.4`. The workflow triggers on tag *push*, so already-pushed tags never run it. The assertion holds from here forward.

## Verification

After the Makefile change, both build paths still stamp the version correctly:

- `make build`'s explicit `--build-arg` → **0.6.0**
- a bare `docker compose build web` relying on the #644 repo-root fallback → **0.6.0**

1052 pipeline tests, 1036 web tests, docs-sync green.

## Not closing #936

This leaves the 1.0.0 cut, the changelog preamble swap, and the post-1.0 tagging cadence. Those belong to the release decision.

Relates to #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)