### PR TITLE
feat: scope Ask retrieval to a speaker across feeds (#696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Major changes
+- Ask can now be scoped to a single speaker across every podcast and episode. Asking "what did X say about Y" used to retrieve whatever was most similar to Y regardless of who said it, because the stored embeddings carry no speaker information — the answer would then attribute those words to the person you asked about. A speaker dropdown on the Ask page, populated from the names you have confirmed, restricts retrieval to passages that person actually spoke. It works across episodes and feeds: diarization labels a given person differently in every episode, and the filter resolves through your renames rather than those raw labels. Verified on a real library — the same question returned passages from seven different people unscoped, and only the chosen speaker's, spanning four episodes, when scoped. ([#696](https://github.com/brlauuu/podlog/issues/696))
+
 ### Internal
 - The version number now lives in exactly one file. `apps/pipeline/pyproject.toml` and `apps/web/package.json` used to carry their own copies that had to be updated by hand, which is how the web one drifted five minor versions behind without anything noticing — nothing reads either at runtime. Both are now pinned to a `0.0.0` placeholder, leaving `/VERSION` and the git tag as the only two places a version appears. A new release workflow publishes the GitHub release automatically when a version tag is pushed, and refuses to do so if the tag disagrees with `/VERSION` or if the changelog still has unreleased entries that were never filed under the version being released. ([#936](https://github.com/brlauuu/podlog/issues/936))
 

--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -51,7 +51,10 @@ class AskRequest(BaseModel):
     feed_id: str | None = None
     feed_ids: list[str] | None = None
     episode_id: str | None = None
-    speaker_label: str | None = None
+    # #696: a resolved display name ("Jacob Shapiro"), not a raw SPEAKER_00
+    # label. Scopes retrieval to chunks that speaker actually spoke, across
+    # every feed and episode.
+    speaker_display: str | None = None
     # Issue #699: prior turns of the conversation for follow-up awareness.
     history: list[ChatMessage] | None = None
 
@@ -66,7 +69,7 @@ async def _stream_ask(
     model: str | None,
     feed_ids: list[str] | None,
     episode_id: str | None = None,
-    speaker_label: str | None = None,
+    speaker_display: str | None = None,
     history: list[dict] | None = None,
 ):
     db = SessionLocal()
@@ -107,7 +110,10 @@ async def _stream_ask(
             return
 
         # 1. Retrieve relevant chunks
-        chunks = retrieve_chunks(db, question, feed_ids=feed_ids, episode_id=episode_id, speaker_label=speaker_label)
+        chunks = retrieve_chunks(
+            db, question, feed_ids=feed_ids, episode_id=episode_id,
+            speaker_display=speaker_display,
+        )
 
         if not chunks:
             yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
@@ -167,7 +173,7 @@ async def ask_endpoint(req: AskRequest):
             req.model,
             feed_ids,
             episode_id=req.episode_id,
-            speaker_label=req.speaker_label,
+            speaker_display=req.speaker_display,
             history=history,
         ),
         media_type="text/event-stream",

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -69,7 +69,7 @@ def retrieve_chunks(
     top_k: int = TOP_K,
     feed_ids: list[str] | None = None,
     episode_id: str | None = None,
-    speaker_label: str | None = None,
+    speaker_display: str | None = None,
 ) -> list[ChunkResult]:
     """Retrieve top-K chunks by cosine similarity to the question embedding."""
     runtime = get_runtime_embedding_settings(db)
@@ -83,9 +83,25 @@ def retrieve_chunks(
     if episode_id:
         episode_filter = "AND c.episode_id = :episode_id"
         params["episode_id"] = episode_id
-    if speaker_label:
-        speaker_filter = "AND c.speaker_label = :speaker_label"
-        params["speaker_label"] = speaker_label
+    if speaker_display:
+        # #696: match the *resolved* speaker, not the raw diarization label.
+        #
+        # The old filter compared c.speaker_label, which is SPEAKER_00 and only
+        # means anything within one episode -- the same person is SPEAKER_00 in
+        # one episode and SPEAKER_03 in the next. So "what did Jacob say about
+        # pricing across my feeds" could not be expressed at all.
+        #
+        # This reuses the exact three-level fallback the SELECT already applies
+        # (speaker_names -> feed_speaker_cache -> raw label, added in #695), so
+        # the filter can never disagree with the name shown to the user. #696
+        # proposed materializing the (episode_id, speaker_label) pairs in
+        # Python instead; doing it declaratively avoids that set going stale
+        # against the display expression.
+        speaker_filter = (
+            "AND COALESCE(sn.display_name, fsc.display_name, c.speaker_label) "
+            "= :speaker_display"
+        )
+        params["speaker_display"] = speaker_display
     if feed_ids:
         # Build feed filter supporting both feed IDs and "uploads" (feed_id IS NULL)
         has_uploads = "__uploads__" in feed_ids

--- a/apps/pipeline/tests/unit/test_rag_endpoint.py
+++ b/apps/pipeline/tests/unit/test_rag_endpoint.py
@@ -198,3 +198,37 @@ class TestAskHistory:
             },
         )
         assert resp.status_code == 422
+
+
+
+class TestAskSpeakerScope:
+    """#696: the /ask endpoint passes the chosen speaker through to retrieval."""
+
+    def _run(self, payload):
+        """Drive the endpoint with everything downstream of retrieval stubbed."""
+        with (
+            patch("app.api.ask.check_model_available", new_callable=AsyncMock, return_value=True),
+            patch("app.api.ask.get_runtime_inference_settings", return_value={"inference_provider": "local"}),
+            patch("app.api.ask.retrieve_chunks", return_value=[]) as mock_retrieve,
+            patch("app.api.ask.get_prompt", return_value="SYSTEM"),
+            patch("app.api.ask.build_prompt", return_value=[{"role": "user", "content": "t"}]),
+            patch("app.api.ask.chunks_to_sources", return_value=[]),
+            patch("app.api.ask.stream_response") as mock_stream,
+        ):
+            async def fake_stream(*args, **kwargs):
+                yield "ok"
+
+            mock_stream.side_effect = fake_stream
+            resp = client.post("/api/ask", json=payload)
+            resp.read()  # drain, so the generator body actually executes
+        return mock_retrieve
+
+    def test_speaker_display_reaches_retrieve_chunks(self):
+        mock_retrieve = self._run(
+            {"question": "what about pricing?", "speaker_display": "Jacob Shapiro"}
+        )
+        assert mock_retrieve.call_args.kwargs["speaker_display"] == "Jacob Shapiro"
+
+    def test_omitting_it_leaves_retrieval_unscoped(self):
+        mock_retrieve = self._run({"question": "what about pricing?"})
+        assert mock_retrieve.call_args.kwargs["speaker_display"] is None

--- a/apps/pipeline/tests/unit/test_rag_retrieval.py
+++ b/apps/pipeline/tests/unit/test_rag_retrieval.py
@@ -140,3 +140,72 @@ class TestRetrieveChunks:
         results = retrieve_chunks(mock_db, "what is this about?", episode_id="ep-42")
         assert len(results) == 1
         assert results[0].similarity == 0.1
+
+
+class TestSpeakerAwareRetrieval:
+    """#696: scope retrieval to a speaker across every feed and episode.
+
+    Chunk embeddings carry no speaker signal (chunking.py builds them from
+    segment text alone), so "what did X say about Y" previously retrieved
+    whatever was most similar to Y regardless of who said it. The LLM then
+    labelled those chunks with the right speaker while potentially
+    attributing the wrong words.
+    """
+
+    @patch("app.services.rag.embed_query", return_value=[0.1, 0.2, 0.3])
+    def test_filters_on_the_resolved_name_not_the_raw_label(self, mock_embed):
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        from app.services.rag import retrieve_chunks
+        retrieve_chunks(mock_db, "q", speaker_display="Jacob Shapiro")
+
+        query_str = str(mock_db.execute.call_args[0][0])
+        params = mock_db.execute.call_args[0][1]
+
+        # The filter must use the same three-level fallback as the SELECT, or
+        # it can disagree with the name shown to the user.
+        assert "COALESCE(sn.display_name, fsc.display_name, c.speaker_label)" in query_str
+        assert params["speaker_display"] == "Jacob Shapiro"
+
+    @patch("app.services.rag.embed_query", return_value=[0.1, 0.2, 0.3])
+    def test_does_not_compare_the_raw_diarization_label(self, mock_embed):
+        # The old filter was `c.speaker_label = :speaker_label`, which only
+        # means anything inside one episode -- the same person is SPEAKER_00
+        # in one and SPEAKER_03 in the next. Guard against a revert.
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        from app.services.rag import retrieve_chunks
+        retrieve_chunks(mock_db, "q", speaker_display="Jacob Shapiro")
+
+        query_str = str(mock_db.execute.call_args[0][0])
+        assert "AND c.speaker_label = :" not in query_str
+
+    @patch("app.services.rag.embed_query", return_value=[0.1, 0.2, 0.3])
+    def test_no_speaker_filter_when_none_given(self, mock_embed):
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        from app.services.rag import retrieve_chunks
+        retrieve_chunks(mock_db, "q")
+
+        params = mock_db.execute.call_args[0][1]
+        assert "speaker_display" not in params
+
+    @patch("app.services.rag.embed_query", return_value=[0.1, 0.2, 0.3])
+    def test_combines_with_feed_scope(self, mock_embed):
+        # Speaker and feed filters are independent; asking about one person
+        # within a subset of feeds must apply both.
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        from app.services.rag import retrieve_chunks
+        retrieve_chunks(mock_db, "q", feed_ids=["feed-1"], speaker_display="Marko Papic")
+
+        query_str = str(mock_db.execute.call_args[0][0])
+        params = mock_db.execute.call_args[0][1]
+        assert "e.feed_id IN" in query_str
+        assert "COALESCE(sn.display_name" in query_str
+        assert params["fid_0"] == "feed-1"
+        assert params["speaker_display"] == "Marko Papic"

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -12,6 +12,7 @@ import SearchInput from "@/components/SearchInput";
 import HelpPopover from "@/components/HelpPopover";
 import SearchSpinner from "@/components/SearchSpinner";
 import PodcastFilter from "@/components/PodcastFilter";
+import SpeakerFilter from "@/components/SpeakerFilter";
 import {
   RAG_MODELS,
   DEFAULT_RAG_MODEL,
@@ -72,6 +73,13 @@ export default function AskPage() {
   );
   const [feeds, setFeeds] = useState<Feed[]>([]);
   const [feedsLoading, setFeedsLoading] = useState(true);
+  // #696: scope retrieval to one speaker across every feed and episode.
+  // Before this, asking "what did X say about Y" retrieved whatever was most
+  // similar to Y regardless of who said it -- chunk embeddings carry no
+  // speaker signal.
+  const [selectedSpeaker, setSelectedSpeaker] = useState<string | null>(
+    initialSnapshot?.selectedSpeaker ?? null
+  );
   const [selectedFeedIds, setSelectedFeedIds] = useState<Set<string>>(
     new Set(initialSnapshot?.selectedFeedIds || [])
   );
@@ -161,9 +169,10 @@ export default function AskPage() {
       errorMsg,
       model,
       selectedFeedIds: Array.from(selectedFeedIds),
+      selectedSpeaker,
       helpCoverageSnapshot,
     });
-  }, [question, answer, sources, status, errorMsg, model, selectedFeedIds, helpCoverageSnapshot]);
+  }, [question, answer, sources, status, errorMsg, model, selectedFeedIds, selectedSpeaker, helpCoverageSnapshot]);
 
   // Fetch feeds and coverage stats
   useEffect(() => {
@@ -207,6 +216,7 @@ export default function AskPage() {
         const body: Record<string, unknown> = { question: q, model };
         if (selectedFeedIds.size > 0)
           body.feed_ids = Array.from(selectedFeedIds);
+        if (selectedSpeaker) body.speaker_display = selectedSpeaker;
 
         const resp = await fetch("/api/pipeline/ask", {
           method: "POST",
@@ -270,7 +280,7 @@ export default function AskPage() {
         );
       }
     },
-    [question, model, selectedFeedIds]
+    [question, model, selectedFeedIds, selectedSpeaker]
   );
 
   function handleClear() {
@@ -383,6 +393,15 @@ export default function AskPage() {
               onSelectionChange={setSelectedFeedIds}
               hasManualUploads={hasManualUploads}
               loading={feedsLoading && feeds.length === 0 && !hasManualUploads}
+            />
+
+            {/* Speaker filter (#696) — same component the search page uses,
+                populated from confirmed renames across the selected feeds. */}
+            <SpeakerFilter
+              feedIds={Array.from(selectedFeedIds)}
+              includeManualUploads={selectedFeedIds.has("__uploads__")}
+              selectedSpeaker={selectedSpeaker}
+              onSelectionChange={setSelectedSpeaker}
             />
           </div>
 

--- a/apps/web/src/lib/page-state.ts
+++ b/apps/web/src/lib/page-state.ts
@@ -24,6 +24,10 @@ interface AskPageSnapshot {
   errorMsg: string;
   model: string;
   selectedFeedIds: string[];
+  // #696. Optional so snapshots written before the speaker filter existed
+  // still parse -- a returning user's restored session simply has no
+  // speaker scope rather than failing to restore at all.
+  selectedSpeaker?: string | null;
   helpCoverageSnapshot?: { processed: number; total: number } | null;
 }
 

--- a/apps/web/tests/unit/ask-page-play.test.tsx
+++ b/apps/web/tests/unit/ask-page-play.test.tsx
@@ -95,7 +95,17 @@ describe("Ask page source card actions", () => {
       "Episode 42"
     );
     expect(openSpy).not.toHaveBeenCalled();
-    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    // The point of this assertion is that playback is embedded -- it must not
+    // navigate or re-ask. Asserting an exact total fetch count made it a
+    // tripwire for any unrelated mount-time request (it broke when the
+    // speaker picker was added in #696), so assert the thing it cares about.
+    await waitFor(() =>
+      expect(
+        (global.fetch as jest.Mock).mock.calls.filter(
+          ([url]) => url === "/api/pipeline/ask"
+        )
+      ).toHaveLength(0)
+    );
 
     openSpy.mockRestore();
   });

--- a/apps/web/tests/unit/ask-page-streaming.test.tsx
+++ b/apps/web/tests/unit/ask-page-streaming.test.tsx
@@ -77,6 +77,10 @@ function mockRoutes(ask: () => unknown) {
       } as Response);
     if (url === "/api/notifications/settings")
       return Promise.resolve({ json: async () => ({ rag_provider: "local" }) } as Response);
+    // #696: the page now renders a speaker picker, which fetches the
+    // confirmed-rename list on mount.
+    if (url.startsWith("/api/search/speakers"))
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
     if (url === "/api/pipeline/ask") return ask();
     throw new Error(`unmocked fetch in ask-page test: ${url}`);
   });
@@ -93,6 +97,52 @@ beforeEach(() => {
   mockFetch.mockReset();
   sessionStorage.clear();
   localStorage.clear();
+});
+
+describe("/ask — speaker scoping (#696)", () => {
+  test("asks unscoped when no speaker is picked", async () => {
+    mockRoutes(() => Promise.resolve(streamResponse(HAPPY_SSE)));
+
+    await askQuestion("what about pricing?");
+
+    const askCall = mockFetch.mock.calls.find(
+      ([url]) => url === "/api/pipeline/ask"
+    );
+    const body = JSON.parse(askCall![1].body);
+    expect(body.question).toBe("what about pricing?");
+    // Absent, not null -- the pipeline treats a missing key as "no scope".
+    expect("speaker_display" in body).toBe(false);
+  });
+
+  test("never sends the pre-#696 speaker_label key", async () => {
+    // The pipeline renamed the field. Sending the old one would be dropped
+    // silently by pydantic and scope nothing, which looks like the filter
+    // simply not working.
+    mockRoutes(() => Promise.resolve(streamResponse(HAPPY_SSE)));
+
+    await askQuestion("what about pricing?");
+
+    const askCall = mockFetch.mock.calls.find(
+      ([url]) => url === "/api/pipeline/ask"
+    );
+    expect("speaker_label" in JSON.parse(askCall![1].body)).toBe(false);
+  });
+
+  test("renders the speaker picker", async () => {
+    mockRoutes(() => Promise.resolve(streamResponse(HAPPY_SSE)));
+
+    render(<AskPage />);
+
+    // Populated from /api/search/speakers -- the same endpoint the search
+    // page uses, so confirmed renames across feeds show up here too.
+    await waitFor(() =>
+      expect(
+        mockFetch.mock.calls.some(([url]) =>
+          String(url).startsWith("/api/search/speakers")
+        )
+      ).toBe(true)
+    );
+  });
 });
 
 describe("/ask — SSE streaming", () => {


### PR DESCRIPTION
## Summary

Chunk embeddings carry **no speaker signal** — `chunking.py` builds them from segment text alone. So "what did Jacob say about pricing" retrieved whatever was most similar to *pricing*, regardless of who said it. #695 had already made the *display* of names consistent, which made this worse in a subtle way: the answer confidently attributed those chunks to the right speaker while potentially quoting the wrong person's words.

## Path A, implemented more simply than the issue sketched

#696 proposed resolving a display name to a set of `(episode_id, speaker_label)` pairs in Python, then passing that list into a generalised SQL filter.

But `retrieve_chunks` **already computes the resolved name in its SELECT** — the three-level fallback #695 added (`speaker_names` → `feed_speaker_cache` → raw label). Filtering on that same expression gives the same result declaratively, and **cannot drift from the value shown to the user** the way a materialized Python-side set could.

The old filter compared `c.speaker_label` — the raw `SPEAKER_00`, which only means anything *inside one episode*. The same person is `SPEAKER_00` in one episode and `SPEAKER_03` in the next.

Measured on the live corpus, filtering "Jacob Shapiro" through the resolved expression:

```
 chunks | episodes | feeds | distinct_raw_labels
--------+----------+-------+---------------------
  13730 |      419 |     2 |                   4
```

**419 episodes, 2 feeds, 4 distinct raw labels unified.** The old filter could not express that.

## No new endpoint, no new component

`/api/search/speakers` already lists confirmed display names across feeds, and `SpeakerFilter` already renders exactly this picker for the search page. Both reused as-is.

## Field rename

`speaker_label` → `speaker_display` on the request, since "label" means `SPEAKER_00` and this now takes a human name. Safe to rename: **no client sent it, no test covered it, no doc specified it** — unused wire surface.

## Verified end to end against the real library

Same question, three ways:

| Scope | Sources |
|---|---|
| Unscoped | **7 different speakers** |
| `Marko Papic` | 4 sources, **all his**, across **4 distinct episodes** |
| `Kamran Bokhari` | 3 sources, all his |

That cross-episode reach is precisely what raw labels could not do.

## Two things found on the way

**Adding the picker broke the ask-page suite** — its fetch mock throws on unmocked URLs, and the picker fetches the speaker list. The guard did its job and named the URL; mocks updated.

**`ask-page-play` asserted an exact global fetch count of 3**, making it a tripwire for any unrelated mount-time request. Rewritten to assert what it actually cares about: that embedded playback issues no `/api/pipeline/ask` call.

## Known, unchanged

Scoping to a speaker with no matching chunks yields the existing *"No relevant transcript excerpts found"* error event. That's the pre-existing zero-result path, and the picker only offers real speakers, so it's hard to reach from the UI. Flagging rather than widening scope.

## Testing

1058 pipeline tests (6 new), 1039 web tests (3 new). Includes a guard against reintroducing the raw-label comparison.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)