### PR TITLE
fix(ci): stop interpolating release notes into a shell command (#936)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,16 +37,21 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Notes go to a FILE, never through a step output into a shell string.
+      # The first run of this workflow (v0.7.0) failed because the previous
+      # version interpolated `${{ steps.notes.outputs.body }}` straight into
+      # the `gh release create` command line: the changelog contains backticks
+      # (`make up`, `0.0.0`), and the shell executed them as command
+      # substitution. It actually ran `make up` on the runner. Any workflow
+      # that interpolates repository content into a `run:` block has the same
+      # defect -- the content is attacker-controllable in a fork PR.
       - name: Validate and extract release notes
-        id: notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Releasing $VERSION (tag $GITHUB_REF_NAME)"
-          {
-            echo "body<<RELEASE_NOTES_EOF"
-            python3 scripts/release_notes.py "$VERSION"
-            echo "RELEASE_NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
+          python3 scripts/release_notes.py "$VERSION" > "$RUNNER_TEMP/notes.md"
+          echo "--- notes ($(wc -l < "$RUNNER_TEMP/notes.md") lines) ---"
+          cat "$RUNNER_TEMP/notes.md"
 
       - name: Create the release
         env:
@@ -54,5 +59,5 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes "${{ steps.notes.outputs.body }}" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
             --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- Fixed the release workflow, which failed on its first real use. Release notes were being pasted into a shell command, so the backticks that appear throughout the changelog were run as commands instead of printed — the failed run went as far as executing a build command on the CI machine. Notes are now handed over as a file, which cannot be interpreted as code. ([#936](https://github.com/brlauuu/podlog/issues/936))
+
 ## 0.7.0 — 2026-08-20
 
 ### Major changes


### PR DESCRIPTION
## What happened

The release workflow added in #961 **failed on its first real use**, cutting v0.7.0. The cause is a defect I introduced:

```yaml
--notes "${{ steps.notes.outputs.body }}"
```

GitHub Actions substitutes that into the `run:` script **as text, before the shell parses it**. The changelog is full of backticks — `` `make up` ``, `` `0.0.0` ``, `` `apps/pipeline/pyproject.toml` `` — so the shell treated them as command substitution and executed them.

From the failed run's log:

```
make: *** [Makefile:4: up] Error 1
apps/pipeline/pyproject.toml: Permission denied
0.0.0: command not found
/VERSION: No such file or directory
```

It genuinely ran `make up` on the CI runner.

## Why this is worth naming as more than a quoting bug

This is the standard **GitHub Actions script-injection** shape. Any workflow that interpolates repository content into a `run:` block has it, and in a workflow triggered by fork PRs that content is attacker-controlled.

Here the trigger is a tag push, so exposure was limited to whatever the changelog happened to contain — but the mechanism is identical, and the failure mode was arbitrary command execution rather than a mangled string.

## The fix

Notes go to a **file**, passed with `--notes-file`. Nothing reaches a shell command line. Also asserted: **zero `${{ }}` expressions remain inside any `run:` block** in this workflow.

The validate step now also prints the extracted notes to the log, so a future failure shows what it was working with.

## Why local testing missed it

I verified `scripts/release_notes.py` directly against all 25 changelog sections — that's the part I wrote, and it was correct. The bug was in the **YAML gluing that script to `gh`**, which only executes on a real tag push.

Testing the component did not test the seam. Worth remembering for the next piece of CI automation.

## State of v0.7.0

**No release was created** — the failure came before `gh release create` took effect, verified with `gh release view v0.7.0` returning "release not found". The tag exists and is correct. Once this merges, re-pushing the tag republishes cleanly.

Relates to #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)