### PR TITLE
docs(changelog): file the workflow fix under 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+## 0.7.0 — 2026-08-20
+
 ### Fixes
 - Fixed the release workflow, which failed on its first real use. Release notes were being pasted into a shell command, so the backticks that appear throughout the changelog were run as commands instead of printed — the failed run went as far as executing a build command on the CI machine. Notes are now handed over as a file, which cannot be interpreted as code. ([#936](https://github.com/brlauuu/podlog/issues/936))
-
-## 0.7.0 — 2026-08-20
 
 ### Major changes
 


### PR DESCRIPTION
## Why

The release workflow's own fix (#965) landed as an `Unreleased` entry. Tagging v0.7.0 at HEAD then tripped the guard that workflow enforces:

```
[FAIL] ## Unreleased still has 1 entry. Graduate them into the version
section before tagging, or the release notes will be missing them.
```

That guard was the **open question** in #936 — whether to assert `Unreleased` is empty at tag time. It earned its place on its second run by catching a real omission before anything was published.

It also **confirmed #936's stated worry** about it: the remedy is deleting and re-pushing a tag, which is awkward after the fact. Both halves of that trade-off are now observed rather than theoretical.

## What

The workflow fix ships *in* 0.7.0, so it belongs in that section rather than waiting for the next release. Moved, nothing else touched — 362 entries before and after.

`scripts/release_notes.py 0.7.0` now exits 0: VERSION agrees, `Unreleased` is empty, the section extracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)