### PR TITLE
ci: publish runtime images to GHCR (#937, phase 1 of 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Verify CLAUDE.md / docs/development.md reference real paths
         run: python scripts/check_docs_sync.py
 
+      # #937/#965: a ${{ }} expression inside a `run:` block is substituted as
+      # text before the shell parses it, so backticks in the value execute.
+      # This shipped once and was then written a second time the same day, so
+      # it gets a check rather than a code-review habit.
+      - name: Verify no workflow interpolates into a shell command
+        run: python scripts/check_workflow_injection.py
+
   pipeline-unit-fast:
     name: Pipeline Unit Fast
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,141 @@
+name: Publish Images
+
+# Phase 1 of #937: publish the four runtime images to GHCR so a user can run
+# a released version without building multi-GB ML dependencies locally.
+#
+# WHY ONE JOB PER IMAGE
+#
+# The worker image is 16.9 GB and pipeline is 13.4 GB (measured 2026-08-20,
+# after #939 removed 17 GB of baked poetry cache from each). A GitHub-hosted
+# ubuntu-latest runner has roughly 14 GB free by default, so neither ML image
+# can be built there without first reclaiming space, and the two together
+# cannot coexist on one runner at all.
+#
+# So: a matrix with one image per job, and a reclaim step before the heavy
+# ones. #937 asked for this to be measured before Phase 1 rather than
+# discovered during it.
+#
+# GHCR storage is free here because the repository is public.
+
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One image per job so the two multi-GB ML images never share a runner.
+      # fail-fast off: a failure publishing one image should not cancel the
+      # others, or a release ends up half-published with no way to see how
+      # much of it worked.
+      fail-fast: false
+      matrix:
+        include:
+          - image: podlog-pipeline
+            context: ./apps/pipeline
+            dockerfile: apps/pipeline/Dockerfile.control
+            heavy: true
+          - image: podlog-worker
+            context: ./apps/pipeline
+            dockerfile: apps/pipeline/Dockerfile.worker
+            heavy: true
+          - image: podlog-web
+            context: .
+            dockerfile: apps/web/Dockerfile
+            heavy: false
+          - image: podlog-backup
+            context: ./apps/backup
+            dockerfile: apps/backup/Dockerfile
+            heavy: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Only for the ML images. Stripping the preinstalled Android SDK, .NET
+      # and friends reclaims roughly 30 GB, which is the difference between
+      # "no space left on device" and a working build.
+      - name: Reclaim runner disk
+        if: matrix.heavy
+        run: |
+          echo "Before:"; df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune -af || true
+          echo "After:"; df -h / | tail -1
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # A version tag publishes X.Y.Z, X.Y, X and moves `stable`.
+      # A push to main publishes `edge`.
+      #
+      # `stable` starts from v0.7.0 (decided 2026-08-20). The four earlier
+      # tags were created retroactively and point at commits whose VERSION
+      # file disagrees with the tag, so an image built from them would not
+      # match its own label. v0.7.0 is the first tag cut through the release
+      # workflow with those invariants asserted.
+      - name: Derive tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+
+      # The web image bakes the version at build time (#644) -- without this
+      # the footer falls back to the 0.0.0 sentinel and reports a stale build.
+      - name: Read VERSION
+        id: version
+        run: echo "value=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          # amd64 only, per #937's non-goals: multi-arch would mean emulating
+          # a multi-GB ML install in CI, slow and flaky for no current user.
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Only apps/web/Dockerfile declares ARG APP_VERSION (#644) -- it
+          # bakes the footer version at build time. Passing it to the others
+          # would emit an unused-build-arg warning on every build.
+          build-args: ${{ matrix.image == 'podlog-web' && format('APP_VERSION={0}', steps.version.outputs.value) || '' }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+      # Via env, never interpolated into the script. Same defect that broke
+      # the release workflow on its first run (#965): `${{ }}` is substituted
+      # as text before the shell parses it, so any backtick or $() in the
+      # value gets executed.
+      - name: Report
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          echo "Published:"
+          printf '%s\n' "$TAGS"
+          df -h / | tail -1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- Runtime images are now published to the GitHub container registry on each release, so a future update can pull a known-good version instead of rebuilding several gigabytes of machine-learning dependencies locally. Nothing consumes them yet — wiring them into the compose setup and adding an update command come next. Each image builds in its own CI job, because the two largest are 13 GB and 17 GB and a standard runner has about 14 GB of disk; the heavy jobs reclaim space first. Also adds a check that fails the build if any workflow pastes a value into a shell command, after that mistake shipped once and was very nearly repeated. ([#937](https://github.com/brlauuu/podlog/issues/937))
+
 ## 0.7.0 — 2026-08-20
 
 ### Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ podlog/
 ├── LICENSE
 ├── .node-version                   # Node version for local dev
 ├── .nvmrc                          # Node version for nvm users
-├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow, changelog, release)
+├── .github/                        # GitHub Actions workflows (ci, ci-full-unit, ci-slow, changelog, release, publish-images)
 ├── issues/                         # Local issue drafts / notes
 ├── backups/                        # Daily DB dumps + rsync audio snapshots (gitignored)
 ├── notebooks/                      # Jupyter exploration notebooks (gitignored bind mount)
@@ -74,7 +74,7 @@ podlog/
 │   ├── backup/                     # Nightly backup service (Dockerfile + backup.sh + restore scripts)
 │   └── explore/                    # Jupyter DB-exploration container (Dockerfile + requirements.txt; opt-in via `make explore`)
 ├── docs/                           # User-facing documentation and guides
-├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates, release-notes extractor)
+├── scripts/                        # Operational scripts (health check, docs-sync + npm/node CI gates, release-notes extractor, workflow-injection check)
 └── prds/                           # Specifications and risk register
 ```
 

--- a/scripts/check_workflow_injection.py
+++ b/scripts/check_workflow_injection.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fail if any workflow interpolates ${{ }} inside a `run:` block (#937).
+
+GitHub Actions substitutes ${{ }} into the script as *text*, before the shell
+parses it. Any backtick or $() in the substituted value is then executed.
+
+This is not theoretical here. The release workflow shipped with
+
+    --notes "${{ steps.notes.outputs.body }}"
+
+and its first real run executed the backticks in CHANGELOG.md -- the log shows
+`make up` running on the runner (#965). The same pattern was then written a
+second time, in the image-publish workflow, within the same day.
+
+The safe form is to pass the value through `env:` and reference it as a normal
+shell variable, which is never re-parsed:
+
+    - env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+      run: printf '%s\n' "$TAGS"
+
+Run locally:  python3 scripts/check_workflow_injection.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+# `run:` block, either literal-block or single-line form, up to the next key
+# at the same indentation.
+RUN_BLOCK = re.compile(r"^(\s+)run:\s*[|>]?-?\s*\n((?:\1\s+.*\n|\s*\n)*)", re.M)
+INLINE_RUN = re.compile(r"^\s+run:\s*(?![|>])(.+)$", re.M)
+EXPR = re.compile(r"\$\{\{")
+
+
+def offenders(text: str) -> list[str]:
+    found = []
+    for m in RUN_BLOCK.finditer(text):
+        for line in m.group(2).split("\n"):
+            if EXPR.search(line):
+                found.append(line.strip())
+    for m in INLINE_RUN.finditer(text):
+        if EXPR.search(m.group(1)):
+            found.append(m.group(1).strip())
+    return found
+
+
+def main() -> None:
+    problems: list[tuple[str, str]] = []
+    files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    for path in files:
+        for line in offenders(path.read_text()):
+            problems.append((path.name, line))
+
+    if problems:
+        print(f"[FAIL] {len(problems)} shell-interpolated expression(s):\n", file=sys.stderr)
+        for name, line in problems:
+            print(f"  {name}: {line[:100]}", file=sys.stderr)
+        print(
+            "\nPass the value through `env:` and use \"$VAR\" instead. "
+            "See #965 for what happens otherwise.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"OK  no shell-interpolated expressions in {len(files)} workflow(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope

**Phase 1 only**, per this issue's own instruction to ship as sequential PRs. **Nothing consumes these images yet** — compose `image:` keys and `make up-release` are phase 2, `make update` is phase 3.

## #937's open question, answered

The issue said: *"Image size: the worker image carries the full ML stack. Worth measuring **before** Phase 1 and deciding whether a slimmer runtime layer is warranted."*

Measured, after #939 removed 17 GB of baked poetry cache from each image:

| Image | Size |
|---|---|
| `podlog-worker` | **16.9 GB** |
| `podlog-pipeline` | **13.4 GB** |
| `podlog-web` | 329 MB |
| `podlog-backup` | 207 MB |

**GHCR storage isn't the constraint** — the repo is public, so it's free. **Build capacity is.** A GitHub-hosted `ubuntu-latest` runner has roughly **14 GB free**, so the worker image cannot be built there by default, and the two ML images cannot share a runner.

Hence: **one job per image**, with a disk-reclaim step before the heavy two (stripping preinstalled Android SDK, .NET etc. frees ~30 GB). `fail-fast` is off so one failure doesn't cancel the rest and leave a release half-published with no visibility into how far it got.

## Tagging

A version tag publishes `X.Y.Z`, `X.Y`, `X` and moves `stable`. A push to `main` publishes `edge`. amd64 only, per the issue's non-goals.

**`stable` starts from v0.7.0.** The four earlier tags were retroactive and point at commits whose `VERSION` disagrees with the tag — an image built from one wouldn't match its own label. v0.7.0 is the first tag cut with those invariants asserted by the release workflow.

## I reproduced the bug I'd just fixed

While writing this workflow I wrote `${{ steps.meta.outputs.tags }}` **inside a `run:` block** — the exact defect fixed hours earlier in #965, where the release workflow executed backticks from the changelog and ran `make up` on the runner.

Twice in one day is a pattern, not an accident. So this adds **`scripts/check_workflow_injection.py`**, wired into CI, which fails the build on any `${{ }}` inside a `run:` block and points at the safe `env:` form.

Verified it catches the real thing: reintroducing the original `release.yml` line makes it fail with that exact line quoted; restoring passes.

## Smaller fix

`APP_VERSION` is passed **only** to the web image — the only Dockerfile declaring it (#644). Passing it to the others emitted an unused-build-arg warning on every build.

## Not yet verified

**An actual push to GHCR.** That only happens on a real tag or `main` push. The disk-reclaim assumption in particular is the kind of thing confirmed by running it, not by reading it — merging this to `main` will trigger the `edge` build and prove it or not.

Relates to #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)