### PR TITLE
docs: rewrite the Meta-Analysis page against the real dashboard (#412, 1 of 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- The Meta-Analysis guide page described a dashboard that does not exist. It listed nine charts — release timeline, turn density, tokens and cost per feed, and six others — none of which are on the page; the real page has three speaker charts. It also promised a click-to-expand modal with a raw data table (there is none), and a filter bar with date and episode-length filters (it filters by podcast only). The page has been rewritten against the actual dashboard, and the matching feature bullet in the README corrected. Also fixes the "learn more" links in the Jupyter panel on that page, which pointed at a guide page number that does not exist and silently redirected to the guide index. ([#412](https://github.com/brlauuu/podlog/issues/412))
+
 ### Internal
 - Runtime images are now published to the GitHub container registry on each release, so a future update can pull a known-good version instead of rebuilding several gigabytes of machine-learning dependencies locally. Nothing consumes them yet — wiring them into the compose setup and adding an update command come next. Each image builds in its own CI job, because the two largest are 13 GB and 17 GB and a standard runner has about 14 GB of disk; the heavy jobs reclaim space first. Also adds a check that fails the build if any workflow pastes a value into a shell command, after that mistake shipped once and was very nearly repeated. ([#937](https://github.com/brlauuu/podlog/issues/937))
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **Ask AI (RAG)** — ask natural-language questions and get streamed, citation-backed answers drawn from your transcript library (local Ollama by default, Fireworks optional).
 - **Export** — download search results or full transcripts as Markdown or plain text, or open a print-friendly view (`/search/print`) for the browser's print-to-PDF flow.
 - **Queue dashboard** — per-stage status, error classification, auto-retry for transient failures, manual retry for the rest.
-- **Meta-Analysis dashboard** — cross-feed metrics (episode counts, durations, WPM, turn density, host/guest share, processing time, token and cost totals) with drill-down charts at `/meta-analysis`.
+- **Meta-Analysis dashboard** — speaker analytics across every feed at `/meta-analysis`: per-speaker minutes and word counts episode by episode, and a host-vs-guest talking-time delta, drawn from either confirmed names or high-confidence inferred ones.
 - **Notifications** — Telegram and email alerts when episodes finish or fail, with optional daily/weekly digest.
 - **Local-first** — no accounts, no cloud, no telemetry; optional Fireworks AI profile for users who prefer remote inference.
 

--- a/apps/web/src/app/meta-analysis/ExploreStatusPanel.tsx
+++ b/apps/web/src/app/meta-analysis/ExploreStatusPanel.tsx
@@ -87,7 +87,7 @@ export default function ExploreStatusPanel() {
         </button>
         {!isRunning && (
           <Link
-            href="/docs?page=16-explore"
+            href="/docs?page=15-explore"
             className="text-link hover:underline"
           >
             Docs →
@@ -123,7 +123,7 @@ make explore-logs`}
             Once it&apos;s running, this panel will show a green dot and an
             &ldquo;Open Jupyter&rdquo; link. See the{" "}
             <Link
-              href="/docs?page=16-explore"
+              href="/docs?page=15-explore"
               className="text-link hover:underline"
             >
               explore guide

--- a/apps/web/tests/unit/docs-deep-links.test.ts
+++ b/apps/web/tests/unit/docs-deep-links.test.ts
@@ -1,0 +1,74 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+/**
+ * Guard for #412: every in-app `/docs?page=<slug>` deep link must name a real
+ * page under `docs/guide/`.
+ *
+ * DocsClient silently falls back to the guide index when `page` matches no
+ * document, so a wrong slug produces no error, no 404, and no broken-link
+ * warning — it just quietly lands the user on the wrong page. That is how
+ * ExploreStatusPanel shipped pointing at `16-explore` (the Backups page
+ * number) instead of `15-explore`, with a unit test asserting the wrong
+ * value.
+ */
+
+const SRC_DIR = join(__dirname, "..", "..", "src");
+const GUIDE_DIR = join(__dirname, "..", "..", "..", "..", "docs", "guide");
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function guideSlugs(): Set<string> {
+  return new Set(
+    readdirSync(GUIDE_DIR)
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, "")),
+  );
+}
+
+/** Collect every literal `/docs?page=<slug>` occurrence with its source file. */
+function collectDeepLinks(): { file: string; slug: string }[] {
+  const found: { file: string; slug: string }[] = [];
+  for (const file of walk(SRC_DIR)) {
+    const source = readFileSync(file, "utf-8");
+    // Only literal slugs; template-interpolated ones are resolved at runtime
+    // from the same docs listing and cannot be checked statically.
+    for (const match of source.matchAll(/\/docs\?page=([A-Za-z0-9_-]+)/g)) {
+      found.push({ file, slug: match[1] });
+    }
+  }
+  return found;
+}
+
+describe("in-app docs deep links", () => {
+  test("every /docs?page= slug resolves to a file in docs/guide/", () => {
+    const slugs = guideSlugs();
+    const broken = collectDeepLinks()
+      .filter((link) => !slugs.has(link.slug))
+      .map((link) => `${link.file.replace(SRC_DIR, "src")} -> ${link.slug}`);
+
+    expect(broken).toEqual([]);
+  });
+
+  test("the guide directory is actually readable (guards a vacuous pass)", () => {
+    // If GUIDE_DIR were wrong, guideSlugs() would throw rather than return an
+    // empty set -- but assert non-empty anyway so a future refactor that makes
+    // it return [] cannot turn the test above into a no-op.
+    expect(guideSlugs().size).toBeGreaterThan(0);
+  });
+
+  test("at least one deep link exists to check (guards a vacuous pass)", () => {
+    expect(collectDeepLinks().length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/tests/unit/explore-status-panel.test.tsx
+++ b/apps/web/tests/unit/explore-status-panel.test.tsx
@@ -72,7 +72,7 @@ describe("<ExploreStatusPanel> (#607 PR 2)", () => {
       await screen.findByText(/Explore notebook is not running/i),
     ).toBeInTheDocument();
     const docsLink = screen.getByRole("link", { name: /^Docs/i });
-    expect(docsLink).toHaveAttribute("href", "/docs?page=16-explore");
+    expect(docsLink).toHaveAttribute("href", "/docs?page=15-explore");
 
     // CLI commands hidden by default.
     expect(screen.queryByText(/^make explore$/m)).toBeNull();

--- a/docs/guide/14-meta-analysis.md
+++ b/docs/guide/14-meta-analysis.md
@@ -1,46 +1,57 @@
 # Meta-Analysis Dashboard
 
-The Meta-Analysis page at `/meta-analysis` aggregates metrics across all your feeds into one view. Useful for spotting outlier episodes, comparing podcasts, and tracking how much of your library is fully processed.
+The Meta-Analysis page at `/meta-analysis` charts who talks, and for how long, across your library. It answers questions the search box cannot: is this show host-led or guest-led, is a cohost's airtime growing over the run, which episodes are outliers.
+
+It is a speaker-analytics page, not a general library dashboard. Episode counts, processing times and costs live on the [Queue Dashboard](08-queue.md) and the episode pages.
 
 ## Opening the dashboard
 
-From the navbar click **Meta-Analysis**, or go directly to [http://localhost:3000/meta-analysis](http://localhost:3000/meta-analysis).
+From the navbar click **Meta-analysis**, or press <kbd>G</kbd> <kbd>M</kbd>, or go to [http://localhost:3000/meta-analysis](http://localhost:3000/meta-analysis).
 
-The page shows:
+If nothing has been computed yet you'll see *"No analysis yet — hit ↻ Refresh or wait for the queue to drain."* The dashboard never computes on page load; see [Refreshing the snapshot](#refreshing-the-snapshot) below.
 
-- A **Coverage strip** at the top — how many episodes are fully processed, still queued, partially transcribed, or missing speakers.
-- A **Filters bar** — narrow the view to a subset of feeds, a date range, or episode length.
-- Nine **charts** (see below). Click a chart to open a full-size modal with the raw data table underneath.
+## What's on the page
 
-## Charts
+**A coverage line** at the top: how many podcasts and how many processed episodes the snapshot covers, plus a **missing speakers** link that opens a per-podcast breakdown of speakers excluded from the host/guest chart.
+
+**A filter bar** listing **All podcasts** plus one button per feed. It is single-select — click a podcast to restrict every chart to it, click **All podcasts** to go back. There is no date or episode-length filter.
+
+**A Confirmed / Inferred — HIGH switch.** Every chart is drawn from one of two speaker sets:
+
+- **Confirmed** — only names you have confirmed yourself. Fewer rows, no guesses.
+- **Inferred — HIGH** — adds high-confidence automatic detections. More rows, and some noise: obvious platform tokens (Twitter, LinkedIn, …) are filtered out, and first-name fragments are merged into the longest matching name within the same feed, so "Marko" folds into "Marko Papic".
+
+**Three charts**, stacked in one column.
+
+## The charts
 
 | Chart | What it shows |
 |---|---|
-| **Release Timeline** | Episode release cadence per feed over time |
-| **Length per Feed** | Episode duration distribution by feed |
-| **Episode Length Trend** | How episode length has evolved per feed over time |
-| **WPM per Speaker** | Words-per-minute by speaker (useful for spotting hosts vs. guests) |
-| **Turn Density** | How often speakers switch per minute — a proxy for conversational format vs. monologue |
-| **Host / Guest Share** | Time-share between inferred hosts and guests per episode |
-| **Tokens per Episode** | LLM token count per episode (approximate; used for cost estimation) |
-| **Processing Time Distribution** | How long each pipeline stage takes per episode |
-| **Cost per Feed** | Cumulative pyannote cloud + remote-inference cost per feed (only populated if you use paid providers) |
+| **Per-speaker minutes per episode** | Each host's airtime across the podcast's run, episode by episode. Guests are collapsed into a single dashed trace per feed — hover to see who they were. |
+| **Per-speaker word count per episode** | The same shape, measured in words instead of minutes. Reading the two together separates "talked longer" from "talked faster". |
+| **Host vs Guest talking time per episode** | One signed value per episode: guest average minus host average. Above zero, guests dominated; below zero, the hosts did. The shaded band shows the widest delta the individual speaker variation allows. |
+
+The page has a collapsible **What do these charts show?** panel at the bottom repeating this in the app itself.
 
 ## Refreshing the snapshot
 
-The dashboard reads from a cached snapshot so the page loads instantly. To recompute:
+The dashboard reads a stored snapshot so the page loads instantly — it never recomputes on view.
 
-- Click **Refresh snapshot** in the top-right.
-- Or call `POST /api/meta-analysis/refresh` directly — the pipeline recomputes and stores the snapshot.
+- Click **↻ Refresh** in the top-right to recompute now.
+- Or call `POST /api/meta-analysis/refresh` directly.
 
-Staleness indicators show the snapshot age next to the refresh button.
+Under the header you'll see **Updated \<date and time\>**, or **Never computed**. When something has changed the numbers since the snapshot was taken — a rename, a newly finished episode — a **Refresh pending** badge appears next to it. The worker also recomputes stale snapshots on its own once the queue drains, so the badge usually clears by itself.
+
+## Jupyter status
+
+If you use the optional [Jupyter explore container](15-explore.md), a small panel on this page shows whether it is running and links to it. When it isn't running, the panel links to the guide instead. Starting and stopping it stays on the command line.
 
 ## When to use it
 
-- After a large batch ingest, to confirm all episodes reached the archive stage.
-- Before running a big Ask AI query, to see which feeds have full speaker inference.
-- To compare podcasts by pace, format, or topic density.
-- To track spend if you use the pyannote cloud provider or Fireworks remote inference.
+- To see whether a show is host-led or guest-led, and whether that has changed over its run.
+- To spot an episode where one speaker's airtime is wildly out of line with the rest.
+- To check how much of your library has confirmed speaker names — compare the Confirmed and Inferred — HIGH views, and use the missing-speakers link to see what's excluded.
+- Before a broad Ask AI question, to confirm the speakers you care about are actually named.
 
 ---
 


### PR DESCRIPTION
First of four PRs from the #412 docs audit. **These are stacked** — 2 of 4 branches off this one, so merge in order.

## What was wrong

`docs/guide/14-meta-analysis.md` described a dashboard that does not exist. It listed **nine** charts:

> Release Timeline, Length per Feed, Episode Length Trend, WPM per Speaker, Turn Density, Host / Guest Share, Tokens per Episode, Processing Time Distribution, Cost per Feed

The page renders **three**, in `MetaAnalysisClient.tsx`: *Per-speaker minutes per episode*, *Per-speaker word count per episode*, *Host vs Guest talking time per episode*, under a Confirmed / Inferred—HIGH switch. None of the nine exist.

Also corrected:

| Doc claimed | Reality |
|---|---|
| "Click a chart to open a full-size modal with the raw data table underneath" | `ChartCard` renders its expand control only when a `detail` prop is passed. None of the three call sites pass one — there is no modal and no table. |
| "Filters bar — narrow to a subset of feeds, a date range, or episode length" | `FiltersBar` is single-select by feed. No date, no length. |
| "Click **Refresh snapshot**" | The control is labelled `↻ Refresh`. |
| "Staleness indicators show the snapshot age" | Shows `Updated <datetime>` plus a `Refresh pending` badge. |
| Coverage strip shows episodes "still queued" | Hardcoded to `0` upstream — see #970. Dropped from the description. |

The README's Meta-Analysis feature bullet repeated the same invented metric list; rewritten to match.

## Bonus: two broken in-app links

The Jupyter panel on this page linked to `/docs?page=16-explore` in two places. **16 is the Backups page; Explore is 15.** `DocsClient` falls back to the guide index when a slug matches nothing, so both links silently landed users on the wrong page — and `explore-status-panel.test.tsx` asserted the wrong value, so the bug was pinned in place by its own test.

Fixed both links and the test, and added `tests/unit/docs-deep-links.test.ts`: every literal `/docs?page=` slug in `src/` must resolve to a file in `docs/guide/`. It includes two anti-vacuous-pass assertions.

**Verified the guard actually catches it** — reintroduced `16-explore` and confirmed the failure names the file and slug:

```
- Array []
+ Array [
+   "src/app/meta-analysis/ExploreStatusPanel.tsx -> 16-explore",
+   "src/app/meta-analysis/ExploreStatusPanel.tsx -> 16-explore",
+ ]
```

then restored the fix and re-ran green.

## Verification

- `npx jest tests/unit/docs-deep-links.test.ts tests/unit/explore-status-panel.test.tsx` — 7 passed
- `npx jest tests/unit/changelog-format.test.ts` — passed
- `npx eslint` on both changed source files — clean
- `python3 scripts/check_docs_sync.py` — OK on all four checks

## Not fixed here

The three code defects the audit turned up are filed separately: #968 (queue blind to chunking/embedding/no_speech), #969 (pyannote rate has no Settings input), #970 (dead coverage button). This PR documents current behaviour; if those land, the affected pages need a follow-up pass.

Refs #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)