### PR TITLE
build: add `make ci-local` to run the blocking CI checks locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- Added `make ci-local`, which runs every blocking CI check on your machine using the same commands CI does — including the two coverage gates that are easy to miss when running the test suites by hand. Useful before pushing, and useful when GitHub Actions is slow or down. It also fails if a new job appears in a workflow that the script does not cover, so it cannot quietly stop being an equivalent and report a pass it has not earned.
+
 ### Fixes
 - The Meta-Analysis coverage line had a "queued/failed" control that always read zero and did nothing when clicked, styled to look exactly like the working link beside it. It now shows how many episodes are still in flight, queued, failed or stuck, and clicking it opens the queue — so you can tell at a glance whether the charts cover your whole library or only the part that has finished processing. It hides itself when nothing is outstanding, and also when the queue cannot be reached, rather than showing a zero that would wrongly imply everything is done. ([#970](https://github.com/brlauuu/podlog/issues/970))
 - An episode that failed speaker inference once and later succeeded kept the old error recorded against it forever, because the record was only ever written on failure and never cleared on success. Nothing user-facing showed it — the episode page already hides the warning once names exist — but it meant the count of episodes with inference problems was permanently overstated, which is exactly why the fault behind those failures went unnoticed across 39 episodes. Both the error and the "skipped" marker are now cleared when a run succeeds, matching what diarization already did. ([#983](https://github.com/brlauuu/podlog/issues/983))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ make build             # Build Docker images
 make up                # Start the stack (6 services; explore is opt-in, see `make explore`)
 make logs              # Follow logs
 make test-unit         # Run pipeline unit tests + host healthcheck test (no web unit tests)
+make ci-local          # Run every blocking CI check locally, using CI's own commands
 make shell-db          # Open psql shell
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
+.PHONY: up up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e ci-local migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
 
 up:             ## Start full stack
 	docker compose up -d
@@ -39,6 +39,9 @@ test-unit:      ## Run unit tests only (fast, no Docker required for ML models)
 
 test-healthcheck: ## Run host healthcheck script tests
 	python3 -m pytest apps/pipeline/tests/unit/test_healthcheck_script.py -v
+
+ci-local:       ## Run every blocking CI check locally (same commands CI uses)
+	@bash scripts/ci-local.sh
 
 test-integration: ## Run integration tests (requires HF_TOKEN for pyannote)
 	docker compose -f docker-compose.test.yml run --rm test pytest tests/integration/ -v

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Run every blocking CI check locally, using CI's own commands.
+#
+# Point of this script: a full CI round trip is minutes, and when GitHub
+# Actions is degraded it can be much longer or never. This gives the same
+# answer in one command before pushing.
+#
+# It deliberately mirrors the workflows rather than approximating them --
+# notably the coverage gates (`--cov-fail-under=82`, jest coverageThreshold),
+# which are easy to miss when running pytest/jest by hand and are a common
+# way a green local run turns red in CI.
+#
+# Known gap: CI installs the pipeline with `--without ml`, while the test
+# image carries the full ML stack. A stray ML import therefore passes here
+# and fails in CI. When a change touches pipeline imports, check it with:
+#
+#   docker run --rm -v "$PWD/apps/pipeline:/w:ro" -w /w python:3.11-slim sh -c \
+#     'pip install -q poetry && poetry config virtualenvs.create false && \
+#      poetry install --with dev --without ml --no-interaction --no-root -q && \
+#      pytest tests/unit -q'
+#
+# The Pipeline Dependency Audit job is not run here: it is
+# `continue-on-error: true` upstream, needs network access to the advisory
+# database, and reports pre-existing CVEs that are triaged in pyproject.toml.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+FAIL=0
+step() { printf '\n=== %s ===\n' "$1"; }
+res()  { if [ "$1" -eq 0 ]; then echo "PASS: $2"; else echo "FAIL: $2"; FAIL=1; fi; }
+
+# --- Drift guard -----------------------------------------------------------
+# If a new job appears in a workflow, this script silently stops being an
+# equivalent -- and a "PASS" here would be a claim it has not earned. Compare
+# the workflow job names against the ones covered below.
+COVERED="Docs sync|Pipeline Unit Fast|Web Unit Fast|Pipeline Unit Full|Web Unit Full|CHANGELOG.md updated|Pipeline Dependency Audit"
+step "Workflow coverage"
+UNCOVERED=$(grep -hE '^    name: ' \
+              .github/workflows/ci.yml \
+              .github/workflows/ci-full-unit.yml \
+              .github/workflows/changelog.yml 2>/dev/null \
+            | sed 's/^    name: //' \
+            | grep -vE "^($COVERED)$" || true)
+if [ -n "$UNCOVERED" ]; then
+  echo "FAIL: workflow jobs not covered by this script:"
+  echo "$UNCOVERED" | sed 's/^/       - /'
+  echo "       Add them here (or to COVERED if deliberately skipped)."
+  FAIL=1
+else
+  echo "PASS: every workflow job is accounted for"
+fi
+
+# --- Docs sync -------------------------------------------------------------
+step "Docs sync"
+python3 scripts/check_docs_sync.py >/dev/null 2>&1;        res $? "check_docs_sync.py"
+python3 scripts/check_workflow_injection.py >/dev/null 2>&1; res $? "check_workflow_injection.py"
+
+# --- Changelog -------------------------------------------------------------
+# Mirrors changelog.yml, which diffs the PR against its merge-base. Compares
+# committed history, so commit before running.
+step "CHANGELOG.md updated"
+BASE=$(git merge-base origin/main HEAD 2>/dev/null)
+if [ -z "$BASE" ]; then
+  echo "FAIL: no merge-base with origin/main (run: git fetch origin)"; FAIL=1
+else
+  git diff --name-only "$BASE" HEAD | grep -qx 'CHANGELOG.md'
+  res $? "CHANGELOG.md touched since merge-base (commit first)"
+fi
+
+# --- Pipeline --------------------------------------------------------------
+step "Pipeline Unit Fast"
+docker compose -f docker-compose.test.yml run --rm test pytest \
+  tests/unit/test_api.py tests/unit/test_rag_helpers.py tests/unit/test_rag_endpoint.py \
+  tests/unit/test_rag_retrieval.py tests/unit/test_rag_models.py tests/unit/test_rag_streaming.py \
+  tests/unit/test_notification_settings.py tests/unit/test_embed_service.py -q 2>&1 | tail -2
+res ${PIPESTATUS[0]} "pipeline unit fast"
+
+step "Pipeline Unit Full (coverage gate)"
+docker compose -f docker-compose.test.yml run --rm test \
+  pytest tests/unit -q --cov=app --cov-fail-under=82 2>&1 | tail -3
+res ${PIPESTATUS[0]} "pipeline unit full + cov>=82"
+
+# --- Web -------------------------------------------------------------------
+step "Web Unit Fast"
+(cd apps/web && npx jest --runTestsByPath \
+   tests/unit/notification-settings.test.tsx tests/unit/docs.test.tsx 2>&1 | tail -2)
+res ${PIPESTATUS[0]} "web unit fast"
+
+step "Web Unit Full (coverage thresholds)"
+(cd apps/web && npx jest --runInBand --coverage --testPathPatterns=tests/unit 2>&1 | tail -3)
+res ${PIPESTATUS[0]} "web unit full + coverage thresholds"
+
+printf '\n================ RESULT ================\n'
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL BLOCKING CI CHECKS PASS LOCALLY"
+else
+  echo "AT LEAST ONE CHECK FAILED"
+fi
+exit "$FAIL"


### PR DESCRIPTION
## Why

A full CI round trip is minutes, and when GitHub Actions is degraded it can be much longer. During this session jobs sat queued ~25 minutes then failed at exactly **15m01s with no logs at all** (`BlobNotFound`) — infrastructure, not code. `make ci-local` gives the same answer in one command before pushing.

## It mirrors the workflows, not an approximation

Two gates in particular are easy to miss when running `pytest`/`jest` by hand, and are a common way a green local run turns red in CI:

```
pytest tests/unit -q --cov=app --cov-fail-under=82
jest --runInBand --coverage --testPathPatterns=tests/unit
```

The changelog check diffs against the merge-base exactly as `changelog.yml` does, so it must run **after** committing — the failure message says so.

```
PASS: every workflow job is accounted for
PASS: check_docs_sync.py
PASS: check_workflow_injection.py
PASS: CHANGELOG.md touched since merge-base (commit first)
PASS: pipeline unit fast                  (140 passed)
PASS: pipeline unit full + cov>=82        (1043 passed, 92.51%)
PASS: web unit fast
PASS: web unit full + coverage thresholds (1077 passed)
ALL BLOCKING CI CHECKS PASS LOCALLY
```

## Drift guard

The obvious failure mode is someone adding a CI job and this script quietly becoming a *subset* while still printing PASS — a claim it hasn't earned. So it reads job names out of `ci.yml`, `ci-full-unit.yml` and `changelog.yml` and fails on anything not in its covered set.

**Verified it fires** by injecting a fake job:

```
=== Workflow coverage ===
FAIL: workflow jobs not covered by this script:
       - Some New Gate
       Add them here (or to COVERED if deliberately skipped).
```

then restored and confirmed green.

## Documented gap

CI installs the pipeline with `--without ml`; the test image carries the full ML stack. **A stray ML import passes here and fails in CI.** The script header says so and carries the one-liner that reproduces CI's no-ML environment, for changes touching pipeline imports.

`Pipeline Dependency Audit` is deliberately excluded — `continue-on-error` upstream, needs the advisory DB over the network, and reports pre-existing CVEs already triaged in `pyproject.toml`. It's listed in the covered set so the drift guard stays quiet about it.

Also added to the `How to Run` block in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)