### PR TITLE
feat: show processing speed by provider on Meta-Analysis (#976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Major changes
+- The Meta-Analysis page now shows how fast each inference provider actually processes your audio, so "is remote inference worth it on my hardware?" is answerable without opening a database console. It reports transcription and diarization time per second of audio, split by provider, with the median alongside the mean and the date range each figure was measured over. Two things it deliberately does not do: it never shows diarization on its own, because on the remote path the speaker labels arrive inside the transcription result and a separate figure would suggest cloud diarization is thousands of times faster than it is; and it compares time per second of audio rather than per episode, because episodes handled by different providers are rarely the same length. Episodes missing timings are excluded and counted rather than quietly dropped. ([#976](https://github.com/brlauuu/podlog/issues/976))
+
 ### Internal
 - Added `make ci-local`, which runs every blocking CI check on your machine using the same commands CI does — including the two coverage gates that are easy to miss when running the test suites by hand. Useful before pushing, and useful when GitHub Actions is slow or down. It also fails if a new job appears in a workflow that the script does not cover, so it cannot quietly stop being an equivalent and report a pass it has not earned.
 

--- a/apps/web/src/app/meta-analysis/MetaAnalysisClient.tsx
+++ b/apps/web/src/app/meta-analysis/MetaAnalysisClient.tsx
@@ -12,6 +12,7 @@ import ChartCard from "./ChartCard";
 import SpeakerMinutesChart from "./charts/SpeakerMinutesChart";
 import SpeakerWordsChart from "./charts/SpeakerWordsChart";
 import HostGuestDiffChart from "./charts/HostGuestDiffChart";
+import ProviderTimingChart from "./charts/ProviderTimingChart";
 import InfoBlock from "./InfoBlock";
 import ExploreStatusPanel from "./ExploreStatusPanel";
 import { formatDateTime } from "@/lib/dateFormat";
@@ -177,6 +178,17 @@ export default function MetaAnalysisClient() {
                 </ChartCard>
                 <ChartCard title="Host vs Guest talking time per episode" subtitle={sourceSubtitle}>
                   <HostGuestDiffChart rows={filteredDiffRows} source={source} />
+                </ChartCard>
+                {/*
+                  #976: not affected by the Confirmed / Inferred switch --
+                  this is about processing cost, not speaker attribution --
+                  so it reads the unfiltered per-episode rows.
+                */}
+                <ChartCard
+                  title="Processing speed by provider"
+                  subtitle="Transcription + diarization per second of audio"
+                >
+                  <ProviderTimingChart rows={snap.per_episode ?? []} />
                 </ChartCard>
               </div>
             );

--- a/apps/web/src/app/meta-analysis/charts/ProviderTimingChart.tsx
+++ b/apps/web/src/app/meta-analysis/charts/ProviderTimingChart.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo } from "react";
+import type { PerEpisode } from "@/lib/metaAnalysisTypes";
+import { summarizeProviderTiming } from "./transforms/providerTiming";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  local: "Local (WhisperX + pyannote)",
+  fireworks: "Fireworks (bundled)",
+  unknown: "Unrecorded",
+};
+
+function fmtFactor(v: number): string {
+  if (v === 0) return "—";
+  // Precision scales with magnitude. Two decimals is right for ~1.87x but
+  // rounds the Fireworks figure (~0.013x) to "0.01x", throwing away the digit
+  // that distinguishes it from a tenth of that.
+  if (v >= 1) return `${v.toFixed(2)}×`;
+  if (v >= 0.01) return `${v.toFixed(3)}×`;
+  return `${v.toFixed(4)}×`;
+}
+
+function fmtDuration(secs: number): string {
+  if (!secs) return "—";
+  if (secs < 60) return `${secs.toFixed(1)}s`;
+  const h = Math.floor(secs / 3600);
+  const m = Math.round((secs % 3600) / 60);
+  return h ? `${h}h ${m}m` : `${m}m`;
+}
+
+function fmtWindow(first: string | null, last: string | null): string {
+  if (!first || !last) return "—";
+  const d = (s: string) => s.slice(0, 10);
+  return d(first) === d(last) ? d(first) : `${d(first)} → ${d(last)}`;
+}
+
+/**
+ * Rendered as a table rather than a bar chart (#976): with two providers and
+ * a ~140x spread, a linear bar makes the faster one invisible and a log axis
+ * makes the numbers hard to read — and this is a decision-support figure
+ * where the values matter more than the shape.
+ */
+export default function ProviderTimingChart({ rows }: { rows: PerEpisode[] }) {
+  const stats = useMemo(() => summarizeProviderTiming(rows), [rows]);
+  const usable = stats.filter((s) => s.episodes > 0);
+
+  if (usable.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No episodes with recorded transcription and diarization timings yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs text-muted-foreground">
+              <th className="py-1 pr-4 font-medium">Provider</th>
+              <th className="py-1 pr-4 font-medium text-right">Episodes</th>
+              <th className="py-1 pr-4 font-medium text-right">Median × realtime</th>
+              <th className="py-1 pr-4 font-medium text-right">Mean × realtime</th>
+              <th className="py-1 pr-4 font-medium text-right">Mean wall clock</th>
+              <th className="py-1 font-medium">Sample window</th>
+            </tr>
+          </thead>
+          <tbody>
+            {usable.map((s) => (
+              <tr key={s.provider} className="border-t border-border">
+                <td className="py-1.5 pr-4">
+                  {PROVIDER_LABELS[s.provider] ?? s.provider}
+                </td>
+                <td className="py-1.5 pr-4 text-right tabular-nums">
+                  {s.episodes}
+                  {s.excluded > 0 && (
+                    <span
+                      className="text-muted-foreground"
+                      title={`${s.excluded} excluded for missing timings or zero duration`}
+                    >
+                      {" "}(+{s.excluded})
+                    </span>
+                  )}
+                </td>
+                <td className="py-1.5 pr-4 text-right tabular-nums font-medium">
+                  {fmtFactor(s.medianRealtime)}
+                </td>
+                <td className="py-1.5 pr-4 text-right tabular-nums text-muted-foreground">
+                  {fmtFactor(s.meanRealtime)}
+                </td>
+                <td className="py-1.5 pr-4 text-right tabular-nums text-muted-foreground">
+                  {fmtDuration(s.meanCombinedSecs)}
+                </td>
+                <td className="py-1.5 text-xs text-muted-foreground whitespace-nowrap">
+                  {fmtWindow(s.firstPublished, s.lastPublished)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Transcription and diarization <strong>combined</strong>, per second of
+        audio. They are not shown separately on purpose: on the Fireworks path
+        the speaker labels arrive inside the transcription result, so its
+        diarization step is a fraction of a second of reading JSON. Comparing
+        that against local pyannote would suggest cloud diarization is
+        thousands of times faster, when the work is simply billed in the
+        transcription step. Figures reflect the hardware and providers in use
+        during each sample window.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/meta-analysis/charts/transforms/providerTiming.ts
+++ b/apps/web/src/app/meta-analysis/charts/transforms/providerTiming.ts
@@ -1,0 +1,96 @@
+import type { PerEpisode } from "@/lib/metaAnalysisTypes";
+
+/**
+ * Aggregate processing speed per inference provider (#976).
+ *
+ * Two things this deliberately gets right, because getting either wrong
+ * produces a confidently wrong answer:
+ *
+ * 1. **Combined transcribe + diarize, never diarize alone.** On the Fireworks
+ *    path the speaker labels arrive inside the transcription artifact and the
+ *    diarize task only reads that JSON and rebuilds segments, so its diarize
+ *    time is ~0.2s. Charting that against local pyannote's hours would read as
+ *    "cloud diarization is 40,000x faster". The diarization cost is real; it
+ *    is just billed inside the transcribe step.
+ *
+ * 2. **Normalized by audio length.** The local sample averages ~120 min per
+ *    episode against Fireworks' ~74 min, so raw seconds overstate the gap.
+ *    Seconds of processing per second of audio ("x realtime") is the honest
+ *    unit.
+ *
+ * Grouping is by whatever provider string the episode carries, so a third
+ * provider appears on its own rather than needing a code change.
+ */
+export interface ProviderTiming {
+  provider: string;
+  /** Episodes with usable timings. */
+  episodes: number;
+  /** Episodes dropped for missing timings or zero duration. */
+  excluded: number;
+  medianRealtime: number;
+  meanRealtime: number;
+  /** Mean seconds, secondary to the normalized figure above. */
+  meanCombinedSecs: number;
+  firstPublished: string | null;
+  lastPublished: string | null;
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+export function summarizeProviderTiming(rows: PerEpisode[]): ProviderTiming[] {
+  interface Acc {
+    factors: number[];
+    combinedSecs: number[];
+    excluded: number;
+    published: string[];
+  }
+  const acc = new Map<string, Acc>();
+
+  for (const r of rows) {
+    const provider = r.inference_provider_used ?? "unknown";
+    let a = acc.get(provider);
+    if (!a) {
+      a = { factors: [], combinedSecs: [], excluded: 0, published: [] };
+      acc.set(provider, a);
+    }
+
+    const t = r.transcribe_duration_secs;
+    const d = r.diarize_duration_secs;
+    // A zero-length episode would divide by zero; a missing timing would make
+    // the episode look instantaneous. Both are excluded and counted, rather
+    // than silently skewing the average.
+    if (t == null || d == null || !r.duration_secs || r.duration_secs <= 0) {
+      a.excluded++;
+      continue;
+    }
+
+    a.factors.push((t + d) / r.duration_secs);
+    a.combinedSecs.push(t + d);
+    if (r.published_at) a.published.push(r.published_at);
+  }
+
+  const out: ProviderTiming[] = [];
+  for (const [provider, a] of acc) {
+    const sorted = [...a.factors].sort((x, y) => x - y);
+    const n = a.factors.length;
+    const dates = [...a.published].sort();
+    out.push({
+      provider,
+      episodes: n,
+      excluded: a.excluded,
+      medianRealtime: median(sorted),
+      meanRealtime: n ? a.factors.reduce((s, v) => s + v, 0) / n : 0,
+      meanCombinedSecs: n ? a.combinedSecs.reduce((s, v) => s + v, 0) / n : 0,
+      firstPublished: dates[0] ?? null,
+      lastPublished: dates[dates.length - 1] ?? null,
+    });
+  }
+
+  return out.sort((x, y) => y.episodes - x.episodes);
+}

--- a/apps/web/tests/unit/meta-analysis/providerTiming.test.ts
+++ b/apps/web/tests/unit/meta-analysis/providerTiming.test.ts
@@ -1,0 +1,107 @@
+import { summarizeProviderTiming } from "@/app/meta-analysis/charts/transforms/providerTiming";
+import type { PerEpisode } from "@/lib/metaAnalysisTypes";
+
+function ep(over: Partial<PerEpisode> = {}): PerEpisode {
+  return {
+    episode_id: "e1", feed_id: "f1", published_at: "2026-06-01T00:00:00Z",
+    duration_secs: 3600, word_count: 0, token_count_segments: 0,
+    token_count_chunks: 0, speaker_count: 2, turn_count: 0, wpm: 0,
+    host_share: null, fireworks_cost_usd: null,
+    transcribe_duration_secs: 1800, diarize_duration_secs: 1800,
+    inference_provider_used: "local",
+    ...over,
+  };
+}
+
+describe("summarizeProviderTiming (#976)", () => {
+  it("groups by provider and reports episode counts", () => {
+    const rows = summarizeProviderTiming([
+      ep({ inference_provider_used: "local" }),
+      ep({ inference_provider_used: "local" }),
+      ep({ inference_provider_used: "fireworks" }),
+    ]);
+    const byProvider = Object.fromEntries(rows.map((r) => [r.provider, r.episodes]));
+    expect(byProvider).toEqual({ local: 2, fireworks: 1 });
+  });
+
+  it("uses transcribe + diarize combined, never diarize alone", () => {
+    // The trap this guards: on the Fireworks path the speaker labels arrive
+    // inside the transcription artifact, so diarize is ~0.2s of JSON reading.
+    // A diarize-only figure would read as "40,000x faster", which is false.
+    const [row] = summarizeProviderTiming([
+      ep({ duration_secs: 100, transcribe_duration_secs: 60, diarize_duration_secs: 40 }),
+    ]);
+    expect(row.medianRealtime).toBeCloseTo(1.0, 6);   // (60+40)/100
+    expect(row.medianRealtime).not.toBeCloseTo(0.4, 6); // diarize alone
+  });
+
+  it("normalizes by audio length rather than comparing raw seconds", () => {
+    // Local episodes are much longer on average, so raw seconds overstate the
+    // gap. Two providers doing identical work per second of audio must come
+    // out equal even when episode lengths differ.
+    const rows = summarizeProviderTiming([
+      ep({ inference_provider_used: "local", duration_secs: 7200,
+           transcribe_duration_secs: 3600, diarize_duration_secs: 3600 }),
+      ep({ inference_provider_used: "fireworks", duration_secs: 1800,
+           transcribe_duration_secs: 900, diarize_duration_secs: 900 }),
+    ]);
+    const [a, b] = rows;
+    expect(a.medianRealtime).toBeCloseTo(b.medianRealtime, 6);
+  });
+
+  it("reports median separately from mean", () => {
+    // Median matters more here: the real local sample's max is 17x its min.
+    const [row] = summarizeProviderTiming([
+      ep({ duration_secs: 100, transcribe_duration_secs: 100, diarize_duration_secs: 0 }),
+      ep({ duration_secs: 100, transcribe_duration_secs: 200, diarize_duration_secs: 0 }),
+      ep({ duration_secs: 100, transcribe_duration_secs: 900, diarize_duration_secs: 0 }),
+    ]);
+    expect(row.medianRealtime).toBeCloseTo(2.0, 6);
+    expect(row.meanRealtime).toBeCloseTo(4.0, 6);
+  });
+
+  it("excludes episodes with missing timings and counts them", () => {
+    const [row] = summarizeProviderTiming([
+      ep(),
+      ep({ transcribe_duration_secs: null }),
+      ep({ diarize_duration_secs: null }),
+    ]);
+    expect(row.episodes).toBe(1);
+    expect(row.excluded).toBe(2);
+  });
+
+  it("excludes zero-length episodes rather than dividing by zero", () => {
+    const rows = summarizeProviderTiming([ep({ duration_secs: 0 })]);
+    expect(rows.every((r) => Number.isFinite(r.medianRealtime))).toBe(true);
+    expect(rows[0]?.episodes ?? 0).toBe(0);
+    expect(rows[0]?.excluded ?? 0).toBe(1);
+  });
+
+  it("buckets a null provider as unknown instead of dropping it", () => {
+    const rows = summarizeProviderTiming([ep({ inference_provider_used: null })]);
+    expect(rows.map((r) => r.provider)).toEqual(["unknown"]);
+  });
+
+  it("carries the sample window, since the numbers reflect that period's hardware", () => {
+    const [row] = summarizeProviderTiming([
+      ep({ published_at: "2026-05-06T00:00:00Z" }),
+      ep({ published_at: "2026-07-02T00:00:00Z" }),
+      ep({ published_at: null }),
+    ]);
+    expect(row.firstPublished).toBe("2026-05-06T00:00:00Z");
+    expect(row.lastPublished).toBe("2026-07-02T00:00:00Z");
+  });
+
+  it("returns nothing for an empty library rather than a zero row", () => {
+    expect(summarizeProviderTiming([])).toEqual([]);
+  });
+
+  it("orders providers by episode count, descending", () => {
+    const rows = summarizeProviderTiming([
+      ep({ inference_provider_used: "local" }),
+      ep({ inference_provider_used: "fireworks" }),
+      ep({ inference_provider_used: "fireworks" }),
+    ]);
+    expect(rows.map((r) => r.provider)).toEqual(["fireworks", "local"]);
+  });
+});

--- a/apps/web/tests/unit/meta-analysis/providerTimingChart.test.tsx
+++ b/apps/web/tests/unit/meta-analysis/providerTimingChart.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within } from "@testing-library/react";
+import ProviderTimingChart from "@/app/meta-analysis/charts/ProviderTimingChart";
+import type { PerEpisode } from "@/lib/metaAnalysisTypes";
+
+function ep(over: Partial<PerEpisode> = {}): PerEpisode {
+  return {
+    episode_id: "e1", feed_id: "f1", published_at: "2026-06-01T00:00:00Z",
+    duration_secs: 3600, word_count: 0, token_count_segments: 0,
+    token_count_chunks: 0, speaker_count: 2, turn_count: 0, wpm: 0,
+    host_share: null, fireworks_cost_usd: null,
+    transcribe_duration_secs: 1800, diarize_duration_secs: 1800,
+    inference_provider_used: "local",
+    ...over,
+  };
+}
+
+describe("ProviderTimingChart (#976)", () => {
+  it("shows a row per provider with the combined realtime factor", () => {
+    render(
+      <ProviderTimingChart
+        rows={[
+          ep({ inference_provider_used: "local", duration_secs: 100,
+               transcribe_duration_secs: 60, diarize_duration_secs: 40 }),
+          ep({ inference_provider_used: "fireworks", duration_secs: 100,
+               transcribe_duration_secs: 1, diarize_duration_secs: 0.2 }),
+        ]}
+      />
+    );
+    // Scope to each row: median and mean coincide on a one-episode sample,
+    // so an unscoped text query matches twice.
+    const localRow = screen.getByText(/Local \(WhisperX \+ pyannote\)/).closest("tr")!;
+    expect(within(localRow).getAllByText("1.00×").length).toBeGreaterThan(0);
+
+    const fwRow = screen.getByText(/Fireworks \(bundled\)/).closest("tr")!;
+    expect(within(fwRow).getAllByText("0.012×").length).toBeGreaterThan(0);
+  });
+
+  it("explains why diarization is not broken out separately", () => {
+    // Without this note the numbers invite the wrong conclusion, which is the
+    // main risk the issue called out.
+    render(<ProviderTimingChart rows={[ep()]} />);
+    expect(screen.getByText(/billed in the transcription step/i)).toBeInTheDocument();
+    expect(screen.getByText(/combined/i)).toBeInTheDocument();
+  });
+
+  it("shows the sample window, since figures reflect that period's hardware", () => {
+    render(
+      <ProviderTimingChart
+        rows={[
+          ep({ published_at: "2026-05-06T00:00:00Z" }),
+          ep({ published_at: "2026-07-02T00:00:00Z" }),
+        ]}
+      />
+    );
+    expect(screen.getByText(/2026-05-06 → 2026-07-02/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state rather than a table of dashes", () => {
+    render(<ProviderTimingChart rows={[ep({ transcribe_duration_secs: null })]} />);
+    expect(screen.getByText(/No episodes with recorded/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("surfaces excluded episodes rather than hiding them", () => {
+    render(
+      <ProviderTimingChart
+        rows={[ep(), ep({ diarize_duration_secs: null }), ep({ duration_secs: 0 })]}
+      />
+    );
+    expect(screen.getByText(/\(\+2\)/)).toBeInTheDocument();
+  });
+});

--- a/docs/guide/14-meta-analysis.md
+++ b/docs/guide/14-meta-analysis.md
@@ -30,8 +30,19 @@ If nothing has been computed yet you'll see *"No analysis yet — hit ↻ Refres
 | **Per-speaker minutes per episode** | Each host's airtime across the podcast's run, episode by episode. Guests are collapsed into a single dashed trace per feed — hover to see who they were. |
 | **Per-speaker word count per episode** | The same shape, measured in words instead of minutes. Reading the two together separates "talked longer" from "talked faster". |
 | **Host vs Guest talking time per episode** | One signed value per episode: guest average minus host average. Above zero, guests dominated; below zero, the hosts did. The shaded band shows the widest delta the individual speaker variation allows. |
+| **Processing speed by provider** | How long transcription and diarization take per second of audio, split by the provider that ran them. A table rather than a chart — with providers often orders of magnitude apart, the numbers matter more than the shape. |
 
 The page has a collapsible **What do these charts show?** panel at the bottom repeating this in the app itself.
+
+### Reading the processing-speed table
+
+Two details make the difference between a useful number and a misleading one.
+
+**Transcription and diarization are combined, never separated.** If you run Fireworks, its diarization step takes a fraction of a second — but that is not a fast diarizer. The speaker labels arrive inside the transcription result, so the diarize step is only reading them back. Showing it on its own would suggest cloud diarization is thousands of times faster than local, when the work is simply being paid for in the transcription step.
+
+**Times are per second of audio, not per episode.** Episodes processed by different providers are rarely the same length, so raw minutes would flatter whichever provider happened to get the shorter ones. A figure of `1.87×` means processing took 1.87 seconds for every second of audio.
+
+The median is the headline because the spread is wide — the slowest local episode can take many times the fastest. The mean and the average wall-clock time sit beside it for context, and each row shows the date range it was measured over, since the numbers reflect the hardware you were running at the time. Episodes missing timings are excluded and shown as a count in brackets rather than quietly dropped.
 
 ## Refreshing the snapshot
 


### PR DESCRIPTION
Closes #976.

Podlog records `transcribe_duration_secs`, `diarize_duration_secs` and `inference_provider_used` per episode but aggregated them nowhere, so *"how much does remote inference actually buy me on this hardware?"* required a psql session.

**Placement per your call: one `ChartCard` on `/meta-analysis`, web-only.** No pipeline change — `per_episode` in the snapshot already carries `duration_secs`, both timings and the provider.

## The two things this had to get right

Get either wrong and it produces a confidently wrong answer.

**1. Combined transcribe + diarize, never diarize alone.** On the Fireworks path the speaker labels arrive inside the transcription artifact; the diarize task only reads that JSON back, so its diarize time is ~0.2s against local pyannote's hours. Charting those side by side reads as *"cloud diarization is 40,000× faster."* The cost is real — it's billed inside the transcribe step. The card says so in prose, because the numbers otherwise invite exactly that conclusion.

**2. Normalized by audio length.** The local sample averages ~120 min/episode against Fireworks' ~74 min, so raw seconds overstate the gap. Seconds of processing per second of audio is the honest unit; mean wall clock stays as secondary context.

Median leads, because the spread is wide — the real local sample's slowest episode is ~17× its fastest. Each row carries its own date range, since the figures reflect whatever hardware was running then.

## A table, not a Plotly bar

With two providers ~140× apart, a linear axis makes the faster one invisible and a log axis makes the values hard to read. This is a decision-support figure where the numbers matter more than the shape. `ChartCard` takes arbitrary children so it still sits on the page consistently.

Grouping is on the provider string, not a hardcoded two-way split — pyannote `precision-2` would get its own row without a code change. It has never run here, so today's "local vs cloud" is really "local pyannote vs Fireworks-bundled".

Episodes with missing timings or zero duration are excluded and surfaced as a bracketed count, rather than dividing by zero or averaging a missing timing as instantaneous.

## One thing the tests caught

The formatter originally used two decimals throughout, which reads right for `1.87×` but rounds the Fireworks figure (`0.013×`) to `0.01×` — throwing away the digit that distinguishes it from a tenth of that. Precision now scales with magnitude. That surfaced as a failing component test, not a review comment.

## Testing

Transform tests written **before** the implementation: 10 covering median vs mean, combined-not-diarize, length normalization, null/zero exclusion, the unknown-provider bucket, ordering and empty input. Plus 5 component tests, including one asserting the "why not diarize alone" explanation is actually rendered.

Verified with `make ci-local` (merged in #986) — every blocking check, using CI's own commands:

```
PASS: every workflow job is accounted for
PASS: check_docs_sync.py / check_workflow_injection.py
PASS: CHANGELOG.md touched since merge-base
PASS: pipeline unit fast / full + cov>=82
PASS: web unit fast / full + coverage thresholds
ALL BLOCKING CI CHECKS PASS LOCALLY
```

`docs/guide/14-meta-analysis.md` gains a "Reading the processing-speed table" section covering both traps in user-facing terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)