### PR TITLE
feat: filter box on the selective episode picker (#982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Minor changes
+- The episode picker for selective feeds now has a filter box. Choosing two specific episodes out of a 357-episode back-catalogue previously meant scrolling and reading titles one at a time. Type part of a title to narrow the list; the filter only changes what you can see, so anything already ticked stays ticked and is still added even while it is hidden. With a filter active, **Select all** applies to just the episodes on screen and says so, which makes "filter to one guest, take all of them" a single click — and in the add-more flow it still refuses to touch episodes the feed already has. ([#982](https://github.com/brlauuu/podlog/issues/982))
+
 ### Major changes
 - The Meta-Analysis page now shows how fast each inference provider actually processes your audio, so "is remote inference worth it on my hardware?" is answerable without opening a database console. It reports transcription and diarization time per second of audio, split by provider, with the median alongside the mean and the date range each figure was measured over. Two things it deliberately does not do: it never shows diarization on its own, because on the remote path the speaker labels arrive inside the transcription result and a separate figure would suggest cloud diarization is thousands of times faster than it is; and it compares time per second of audio rather than per episode, because episodes handled by different providers are rarely the same length. Episodes missing timings are excluded and counted rather than quietly dropped. ([#976](https://github.com/brlauuu/podlog/issues/976))
 

--- a/apps/web/src/app/feeds/_components/EpisodeSelectionStep.tsx
+++ b/apps/web/src/app/feeds/_components/EpisodeSelectionStep.tsx
@@ -5,6 +5,8 @@
  * the selective-mode add flow and the issue #487 "add more" flow against
  * an existing selective feed. Split out of page.tsx in #664.
  */
+import { useMemo, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { formatDate } from "@/lib/dateFormat";
 import type { FeedPreview } from "../_lib/types";
@@ -19,7 +21,12 @@ interface Props {
   error: string | null;
   submitting: boolean;
   onToggleGuid: (guid: string) => void;
-  onToggleAll: () => void;
+  /**
+   * Receives the guids the select-all should act on: the currently visible,
+   * selectable episodes (#982). With no filter that is the whole feed, so
+   * the parent's behaviour is unchanged.
+   */
+  onToggleAll: (visibleGuids: string[]) => void;
   onSubmit: (e: React.FormEvent) => void;
   onBackOrCancel: () => void;
 }
@@ -36,14 +43,36 @@ export default function EpisodeSelectionStep({
   onSubmit,
   onBackOrCancel,
 }: Props) {
+  // #982: long feeds (350+ episodes here) were one flat scroll with no way
+  // to find a specific episode. The filter narrows what is *rendered* only --
+  // never the selection, so an episode checked and then filtered out of view
+  // stays checked and still submits.
+  const [query, setQuery] = useState("");
+  const trimmed = query.trim().toLowerCase();
+  const filtering = trimmed.length > 0;
+
+  const visible = useMemo(() => {
+    if (!filtering) return preview.episodes;
+    return preview.episodes.filter((e) =>
+      (e.title ?? e.guid).toLowerCase().includes(trimmed),
+    );
+  }, [preview.episodes, filtering, trimmed]);
+
+  /** Visible episodes the select-all is allowed to touch. */
+  const togglableVisible = addMoreMode
+    ? visible.filter((e) => !existingGuids.has(e.guid))
+    : visible;
+
   const toggleAllLabel = (() => {
     if (addMoreMode) {
       const remaining = preview.episodes.filter((e) => !existingGuids.has(e.guid));
       const allRemainingSelected =
         remaining.length > 0 &&
         remaining.every((e) => selectedGuids.has(e.guid));
+      if (filtering) return `Select all ${togglableVisible.length} new shown`;
       return allRemainingSelected ? "Deselect all new" : "Select all new";
     }
+    if (filtering) return `Select all ${togglableVisible.length} shown`;
     return selectedGuids.size === preview.episodes.length
       ? "Deselect all"
       : "Select all";
@@ -60,21 +89,36 @@ export default function EpisodeSelectionStep({
     >
       <div className="flex items-center justify-between shrink-0">
         <span className="text-sm text-muted-foreground">
-          {preview.episodes.length} episodes found
+          {filtering
+            ? `${visible.length} of ${preview.episodes.length} episodes`
+            : `${preview.episodes.length} episodes found`}
           {addMoreMode && existingGuids.size > 0
             ? ` · ${existingGuids.size} already added`
             : null}
         </span>
         <button
           type="button"
-          onClick={onToggleAll}
+          onClick={() => onToggleAll(togglableVisible.map((e) => e.guid))}
           className="text-xs text-link underline"
         >
           {toggleAllLabel}
         </button>
       </div>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Filter episodes by title..."
+        aria-label="Filter episodes by title"
+        className="shrink-0 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring"
+      />
       <div className="flex-1 overflow-y-auto overflow-x-hidden divide-y rounded-md border min-h-[80px]">
-        {preview.episodes.map((ep) => {
+        {visible.length === 0 ? (
+          <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+            No episodes match &ldquo;{query.trim()}&rdquo;.
+          </p>
+        ) : null}
+        {visible.map((ep) => {
           const already = addMoreMode && existingGuids.has(ep.guid);
           return (
             <label

--- a/apps/web/src/app/feeds/page.tsx
+++ b/apps/web/src/app/feeds/page.tsx
@@ -226,29 +226,41 @@ export default function FeedsPage() {
     });
   }
 
-  function toggleAll() {
+  /**
+   * Select/deselect in bulk.
+   *
+   * `scopeGuids` is what the selection step currently has on screen (#982).
+   * With no filter active that is the whole feed, so this behaves exactly as
+   * it did before. With a filter active it must touch only the visible
+   * episodes -- clicking "Select all" while looking at 12 of 357 and getting
+   * all 357 would be a nasty surprise.
+   *
+   * Selections outside the scope are always preserved: this adds to or
+   * removes from the existing set rather than replacing it.
+   */
+  function toggleAll(scopeGuids?: string[]) {
     if (!preview) return;
     const allGuids = preview.episodes.map((e) => e.guid);
-    if (addMoreFeed) {
-      // Issue #487: preserve existing selections; toggle only the remaining episodes
-      const togglable = allGuids.filter((g) => !existingGuids.has(g));
-      const allTogglableSelected = togglable.every((g) => selectedGuids.has(g));
-      setSelectedGuids((prev) => {
-        const next = new Set(prev);
-        if (allTogglableSelected) {
-          togglable.forEach((g) => next.delete(g));
-        } else {
-          togglable.forEach((g) => next.add(g));
-        }
-        return next;
-      });
-      return;
-    }
-    if (selectedGuids.size === allGuids.length) {
-      setSelectedGuids(new Set());
-    } else {
-      setSelectedGuids(new Set(allGuids));
-    }
+    // Array check, not a null check: wiring this callback straight to an
+    // onClick hands it a MouseEvent, which `?? allGuids` would happily accept
+    // and then crash on .filter.
+    const scope = Array.isArray(scopeGuids) ? scopeGuids : allGuids;
+    // Issue #487: never touch episodes the feed already has.
+    const togglable = addMoreFeed
+      ? scope.filter((g) => !existingGuids.has(g))
+      : scope;
+    if (togglable.length === 0) return;
+
+    const allTogglableSelected = togglable.every((g) => selectedGuids.has(g));
+    setSelectedGuids((prev) => {
+      const next = new Set(prev);
+      if (allTogglableSelected) {
+        togglable.forEach((g) => next.delete(g));
+      } else {
+        togglable.forEach((g) => next.add(g));
+      }
+      return next;
+    });
   }
 
   const dialogTitle = addMoreFeed

--- a/apps/web/tests/unit/episode-selection-step.test.tsx
+++ b/apps/web/tests/unit/episode-selection-step.test.tsx
@@ -231,3 +231,138 @@ describe("<EpisodeSelectionStep>", () => {
     });
   });
 });
+
+describe("episode filter (#982)", () => {
+  // Two titles start with "The" on purpose, so a "the" query matches exactly
+  // two of the four and the scoped select-all assertions are unambiguous.
+  const many = [
+    ep({ guid: "g1", title: "Sam Altman on building OpenAI" }),
+    ep({ guid: "g2", title: "The King of Israel" }),
+    ep({ guid: "g3", title: "Scotty Doesn't Know" }),
+    ep({ guid: "g4", title: "The Books That Shaped Us" }),
+  ];
+
+  function filterInput() {
+    return screen.getByPlaceholderText(/filter episodes/i);
+  }
+
+  it("narrows the rendered list as you type", () => {
+    renderStep({ preview: preview(many) });
+    fireEvent.change(filterInput(), { target: { value: "king" } });
+
+    expect(screen.getByText("The King of Israel")).toBeInTheDocument();
+    expect(screen.queryByText("Sam Altman on building OpenAI")).toBeNull();
+  });
+
+  it("matches case-insensitively", () => {
+    renderStep({ preview: preview(many) });
+    fireEvent.change(filterInput(), { target: { value: "SCOTTY" } });
+    expect(screen.getByText("Scotty Doesn't Know")).toBeInTheDocument();
+  });
+
+  it("falls back to the guid for episodes with no title", () => {
+    renderStep({ preview: preview([ep({ guid: "abc-123", title: null })]) });
+    fireEvent.change(filterInput(), { target: { value: "abc" } });
+    expect(screen.getByText("abc-123")).toBeInTheDocument();
+  });
+
+  it("shows how much of the feed is visible while filtering", () => {
+    renderStep({ preview: preview(many) });
+    expect(screen.getByText(/4 episodes found/)).toBeInTheDocument();
+
+    fireEvent.change(filterInput(), { target: { value: "the" } });
+    expect(screen.getByText(/2 of 4 episodes/)).toBeInTheDocument();
+  });
+
+  it("keeps a checked episode checked after it is filtered out of view", () => {
+    // The core rule: the filter narrows the *view*, never the selection.
+    const { rerender } = renderStep({
+      preview: preview(many),
+      selectedGuids: new Set(["g1"]),
+    });
+    fireEvent.change(filterInput(), { target: { value: "king" } });
+    expect(screen.queryByText("Sam Altman on building OpenAI")).toBeNull();
+
+    // Clearing the filter brings it back, still checked.
+    fireEvent.change(filterInput(), { target: { value: "" } });
+    const box = screen.getByText("Sam Altman on building OpenAI")
+      .closest("label")!
+      .querySelector("input")!;
+    expect(box).toBeChecked();
+    expect(rerender).toBeDefined();
+  });
+
+  it("still submits a selection made before filtering", () => {
+    const { onSubmit, container } = renderStep({
+      preview: preview(many),
+      selectedGuids: new Set(["g1"]),
+    });
+    fireEvent.change(filterInput(), { target: { value: "king" } });
+    fireEvent.submit(container.querySelector("form")!);
+
+    // Submission reads selectedGuids, which the filter never touches.
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /Add \(1\)/ })).toBeEnabled();
+  });
+
+  it("scopes select-all to the visible episodes and says so", () => {
+    const { onToggleAll } = renderStep({ preview: preview(many) });
+    fireEvent.change(filterInput(), { target: { value: "the" } });
+
+    const link = screen.getByText(/Select all 2 shown/);
+    fireEvent.click(link);
+    expect(onToggleAll).toHaveBeenCalledWith(["g2", "g4"]);
+  });
+
+  it("passes the whole feed to select-all when no filter is active", () => {
+    const { onToggleAll } = renderStep({ preview: preview(many) });
+    fireEvent.click(screen.getByText("Select all"));
+    expect(onToggleAll).toHaveBeenCalledWith(["g1", "g2", "g3", "g4"]);
+  });
+
+  it("never offers already-added episodes to a filtered select-all", () => {
+    // addMoreMode's "don't touch already-added" rule has to survive filtering.
+    const { onToggleAll } = renderStep({
+      preview: preview(many),
+      addMoreMode: true,
+      existingGuids: new Set(["g2"]),
+    });
+    fireEvent.change(filterInput(), { target: { value: "the" } });
+
+    fireEvent.click(screen.getByText(/Select all 1 new shown/));
+    expect(onToggleAll).toHaveBeenCalledWith(["g4"]);
+  });
+
+  it("keeps already-added rows disabled while filtering", () => {
+    renderStep({
+      preview: preview(many),
+      addMoreMode: true,
+      existingGuids: new Set(["g2"]),
+    });
+    fireEvent.change(filterInput(), { target: { value: "king" } });
+
+    const box = screen.getByText("The King of Israel")
+      .closest("label")!
+      .querySelector("input")!;
+    expect(box).toBeDisabled();
+  });
+
+  it("shows an empty state when nothing matches", () => {
+    renderStep({ preview: preview(many) });
+    fireEvent.change(filterInput(), { target: { value: "zzzz" } });
+
+    expect(screen.getByText(/No episodes match/i)).toBeInTheDocument();
+    expect(screen.queryByText("The King of Israel")).toBeNull();
+  });
+
+  it("behaves exactly as before with an empty query", () => {
+    renderStep({ preview: preview(many) });
+    fireEvent.change(filterInput(), { target: { value: "x" } });
+    fireEvent.change(filterInput(), { target: { value: "" } });
+
+    expect(screen.getByText(/4 episodes found/)).toBeInTheDocument();
+    for (const e of many) {
+      expect(screen.getByText(e.title!)).toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/tests/unit/feeds-page-add-more.test.tsx
+++ b/apps/web/tests/unit/feeds-page-add-more.test.tsx
@@ -57,7 +57,7 @@ jest.mock("@/app/feeds/_components/EpisodeSelectionStep", () => ({
     addMoreMode: boolean;
     error: string | null;
     onToggleGuid: (g: string) => void;
-    onToggleAll: () => void;
+    onToggleAll: (visibleGuids: string[]) => void;
     onSubmit: (e: React.FormEvent) => void;
     onBackOrCancel: () => void;
   }) => (
@@ -71,7 +71,13 @@ jest.mock("@/app/feeds/_components/EpisodeSelectionStep", () => ({
           {ep.title}
         </button>
       ))}
-      <button type="button" data-testid="toggle-all" onClick={onToggleAll}>
+      {/* #982: the real component passes the visible guids. Wiring this
+          straight to onClick would hand toggleAll a MouseEvent instead. */}
+      <button
+        type="button"
+        data-testid="toggle-all"
+        onClick={() => onToggleAll(preview.episodes.map((e) => e.guid))}
+      >
         All
       </button>
       <button type="submit" data-testid="submit">

--- a/docs/guide/03-feeds.md
+++ b/docs/guide/03-feeds.md
@@ -23,6 +23,8 @@ When adding a feed, you choose how many episodes to ingest — and, as a consequ
    - **Selective** — click Next to see a list of all episodes, check the ones you want, then Add
    - **Full** — click Add, all episodes are queued
 
+On the Selective episode list there is a **filter box** above the episodes. Type part of a title to narrow the list — useful on a back-catalogue of several hundred, where scrolling to find two specific episodes is painful. The filter only changes what you can see: anything you have already ticked stays ticked and is still added, even while hidden. While a filter is active, **Select all** applies to just the episodes on screen and says so ("Select all 12 shown"), so you can filter to a year or a guest and take the lot in one click.
+
 Feed cards carry a **Test** or **Selective** badge so you can tell at a glance which feeds are being kept current and which are not. Full-mode feeds are unbadged. Each card also shows its episode count and when it was last polled.
 
 ## Promoting a Feed
@@ -36,7 +38,7 @@ Promotion never re-processes episodes that are already done. It is also what swi
 
 ## Adding More Selective Episodes
 
-Selective feeds get an extra **Add episodes** button. It reopens the episode picker with everything you haven't ingested yet, so you can pull in a few more without promoting the whole back-catalog.
+Selective feeds get an extra **Add episodes** button. It reopens the episode picker with everything you haven't ingested yet, so you can pull in a few more without promoting the whole back-catalog. The same filter box is available here, and episodes already in the feed stay greyed out and untouched — including when you use **Select all** on a filtered view.
 
 ## Polling for New Episodes
 


### PR DESCRIPTION
Closes #982.

The episode-selection step rendered every episode as one flat, unfiltered scroll. Picking two specific episodes out of Lenny's Podcast (357 here) or The Jacob Shapiro Podcast (355) meant reading titles one at a time.

Case-insensitive substring filter on title, falling back to guid for untitled episodes — the list already renders `title ?? guid`. No FTS; substring is plenty for a few hundred in-memory titles.

## The property worth protecting

**The filter narrows what is rendered, never the selection.** An episode ticked and then filtered out of view stays ticked and is still submitted. That falls out of the submit buttons reading `selectedGuids`, which the filter doesn't touch — but it's the thing most likely to break later, so it has its own tests.

## Select-all, per your call

Scoped to what's visible, with the label stating the scope (`Select all 12 shown`). "Filter to one guest, take all of them" is the workflow that makes the filter worth having.

Filter state lives in `EpisodeSelectionStep` — it's a view concern and `page.tsx` doesn't need more dialog state. The consequence is that `onToggleAll` grows a parameter: the component tells the parent which guids are in scope. With no filter that's the whole feed, so behaviour is unchanged.

`toggleAll()` was restructured so the #487 rule (*never touch episodes the feed already has*) applies **on top of** the scope rather than beside it, and so bulk selection always adds to / removes from the existing set instead of replacing it. The old non-addMore branch replaced the set wholesale — fine when the scope was always the whole feed, wrong the moment it isn't.

## Two things this surfaced

**A test that was testing a fiction.** `feeds-page-add-more.test.tsx` mocked the step with `onClick={onToggleAll}`, which hands the callback a **MouseEvent** — a call signature the real component never uses. It only showed up because my new parameter made it crash. Fixed the mock to pass guids, and `toggleAll` now checks `Array.isArray` rather than nullishness, because `?? allGuids` happily accepts a MouseEvent and then dies on `.filter`.

**My own fixture was wrong.** I used `"16 Books That Shaped Us"` and expected a `"the"` query to match it. It doesn't — `"That"` isn't `"the"`, so `"the"` matched one episode, not two, and three assertions failed. Retitled so the two-of-four expectation is unambiguous. Worth noting it was the test at fault, not the code.

## Not doing

The optional extras (date range, sort toggle, hide-already-added). The title filter covers the stated need; each of those is a separate lever.

## Testing

12 new component tests covering the four the issue asks for plus the empty state, the guid fallback, case-insensitivity, the count line, and the no-query-equals-old-behaviour case.

Verified with `make ci-local` — every blocking check, CI's own commands:

```
PASS: every workflow job is accounted for
PASS: check_docs_sync.py / check_workflow_injection.py
PASS: CHANGELOG.md touched since merge-base
PASS: pipeline unit fast / full + cov>=82
PASS: web unit fast / full + coverage thresholds
ALL BLOCKING CI CHECKS PASS LOCALLY
```

`docs/guide/03-feeds.md` covers the filter in both flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)