### PR TITLE
docs: make docs accuracy part of the per-change routine (#991)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- Documentation accuracy is now part of the routine for every change, written into the agent-context file alongside the existing changelog and design-doc obligations, with a table mapping each area of the code to the pages that describe it. The gap it closes is that a code change could land, get its changelog line, pass CI, and leave the user manual quietly describing the old behaviour — which is exactly what the recent documentation audit found across a third of the guide. Deliberately a convention rather than a build gate: a check that cannot judge whether prose is *true* would only verify that some documentation file was touched, which manufactures confidence instead of providing it. The existing path check has also been widened from 2 files to 26, so the whole user manual now gets the broken-link checking that only the agent-context files had. ([#991](https://github.com/brlauuu/podlog/issues/991))
+
 ### Major changes
 - `make up` now tells you where Podlog is running, including the address to use from a phone or another computer on the same network — previously you had to work that out yourself, and the obvious way of doing so also lists Docker's internal addresses, which do not work. It prints only the address that actually reaches Podlog, says nothing if there isn't one, and respects the setting if you have restricted access to the local machine.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,35 @@ make shell-db          # Open psql shell
   - Web: `jest` + `@testing-library/react` for unit, `playwright` for e2e.
 - **PRD references:** When implementing a feature, cite the PRD section (e.g. "per PRD-02 §5.6") in code comments only where the requirement is non-obvious.
 - **Security model (#960, #988):** Podlog assumes a single trusted host **on a trusted network**. The pipeline API has **no authentication** — every write endpoint (settings, which holds the Fireworks/pyannote keys; feed CRUD; upload; retry; backfill; backup deletion) is open to anything that can reach port 8000. Binding db/pipeline/ollama to `127.0.0.1` (#952) protects port 8000 *directly*, but **the web app is an unauthenticated write proxy to it** — there is no `middleware.ts` and no auth check anywhere in `apps/web`, and 23 mutating routes under `apps/web/src/app/api/` forward straight through. So the effective trust boundary is the **LAN**, not the host: anyone who can reach `:3000` can delete feeds, episodes and backups. Do not describe LAN exposure as read-only browsing. Two changes break what boundary remains and require adding auth first: re-publishing db/pipeline/ollama to `0.0.0.0`, or moving the `web` container to a different host. Documented in `docs/guide/01-installation.md`; options weighed in #960.
+- **Per-change obligations (#991):** Three things are expected of every PR. They live together here because they are one habit, not three.
+
+  1. **CHANGELOG.** A one-line entry under `## Unreleased` for user-visible behaviour, grouped Major / Minor / Fixes / Internal. Enforced by `.github/workflows/changelog.yml`; the escape hatch is the `no-changelog` label.
+  2. **Docs accuracy.** Before opening the PR, work out which docs describe the behaviour you changed and update them in the same PR — or state explicitly in the PR body that you checked and none apply. Saying "checked, none apply" is most of the value: it is the difference between deciding and forgetting. Use the map below. This is **not** CI-enforced on purpose — a gate that cannot judge correctness degrades into touching any docs file to go green, which manufactures assurance rather than providing it. `scripts/check_docs_sync.py` only verifies that paths named in the docs exist; it cannot tell that a documented default changed.
+  3. **Design docs.** If the change alters the design, update the relevant PRD and `prds/RISKS-AND-GAPS.md` (this is the pre-existing rule, folded in here so all three obligations are in one place).
+
+  **Which doc covers what.** The step most likely to be skipped is "which doc describes this?", so it is written down. Not exhaustive — when in doubt, grep `docs/guide/` for the feature name.
+
+  | If you changed… | Check |
+  |---|---|
+  | `apps/pipeline/app/config.py`, `.env.example` | `docs/configuration.md`, `docs/guide/10-configuration.md` |
+  | `docker-compose.yml` ports, `Makefile` startup, `scripts/print-access.sh` | `docs/guide/01-installation.md` (incl. the Security model section) |
+  | `apps/pipeline/app/tasks/ingest.py`, feeds API/UI | `docs/guide/03-feeds.md` |
+  | `apps/web/src/lib/search.ts`, search routes | `docs/guide/04-search.md` |
+  | Episode page, transcript rendering | `docs/guide/05-episodes.md` |
+  | `apps/pipeline/app/services/inference.py`, `tasks/infer.py`, speaker UI | `docs/guide/06-speakers.md` |
+  | `apps/web/src/components/AudioPlayer.tsx` | `docs/guide/07-audio-playback.md` |
+  | `apps/pipeline/app/api/queue.py`, `apps/web/src/lib/queueStatus.ts` | `docs/guide/08-queue.md` |
+  | Notification settings, digest, healthcheck | `docs/guide/09-notifications.md` |
+  | Timings, image sizes, storage figures | `docs/guide/11-hardware.md`, `docs/hardware.md` |
+  | `apps/pipeline/app/services/rag.py`, `apps/web/src/lib/rag-models.ts` | `docs/guide/12-rag-search.md` |
+  | `apps/pipeline/app/services/pyannote_cloud.py`, diarization providers | `docs/guide/13-pyannote-cloud.md`, `docs/guide/19-inference-providers.md` |
+  | `apps/web/src/app/meta-analysis` | `docs/guide/14-meta-analysis.md` |
+  | `apps/explore`, notebooks | `docs/guide/15-explore.md` |
+  | `apps/backup`, `apps/pipeline/app/services/backup_files.py` | `docs/guide/16-backups.md` |
+  | `apps/web/src/lib/keyboardShortcuts.ts` | `docs/guide/18-keyboard-shortcuts.md` |
+
+  This table is itself checked: `check_docs_sync.py` scans `CLAUDE.md` for path mentions and fails CI if any stops existing.
+
 - **Versioning (#936):** `/VERSION` at the repo root is the **only file containing a version**. The git tag is the only other place a version appears, and `scripts/release_notes.py` asserts the two agree before a release publishes. `apps/pipeline/pyproject.toml` and `apps/web/package.json` are both pinned to the `0.0.0` sentinel on purpose — neither is read at runtime, and keeping them "in sync by hand" is exactly how `package.json` drifted five minor versions behind without anything noticing. Do not reintroduce a version number anywhere else.
 - **Semver policy:** **Major** — a change the operator must act on: a removed or renamed env var, a migration that cannot be rolled back by restoring the previous dump, a new external service requirement (e.g. a newly mandatory API key), or a breaking change to the pipeline API the web app consumes. **Minor** — new user-visible capability, additive env vars with working defaults, additive migrations. **Patch** — fixes, dependency refreshes, docs, internal work.
 - **Releasing:** bump `/VERSION`, graduate `## Unreleased` into a dated section, merge, then push a `vX.Y.Z` annotated tag. `.github/workflows/release.yml` validates and publishes. It refuses to publish if the tag disagrees with `VERSION`, or if `## Unreleased` still holds entries. No fixed calendar — cut a release when `Unreleased` has accumulated user-visible entries and CI is green.

--- a/scripts/check_docs_sync.py
+++ b/scripts/check_docs_sync.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
-"""Docs-sync CI check (#679).
+"""Docs-sync CI check (#679, widened in #991).
 
-Scans agent-context docs that drift quickly — CLAUDE.md and
-docs/development.md — for path mentions under top-level project
-directories (apps/, prds/, docs/, scripts/, .github/) and verifies each
-referenced path exists on disk. Exits non-zero with a list of missing
-paths so CI fails the PR before the stale reference lands on main.
+Scans docs for path mentions under top-level project directories
+(apps/, prds/, docs/, scripts/, .github/) and verifies each referenced
+path exists on disk. Exits non-zero with a list of missing paths so CI
+fails the PR before the stale reference lands on main.
+
+Targets are CLAUDE.md, docs/development.md, the reference docs under
+docs/, and the whole user-facing manual in docs/guide/. The manual was
+outside the default targets until #991 -- 20 files that get rendered at
+/docs and had none of the path checking CLAUDE.md got, which is part of
+how the drift catalogued in #412 went unnoticed.
+
+What this does NOT do, deliberately: judge whether a doc still describes
+what the code does. It confirms a file exists at a path. It cannot tell
+that a documented default changed last week. That check is semantic and
+lives in the per-change routine in CLAUDE.md, not here -- see #991 for
+why a CI gate that cannot judge correctness is worse than none.
 
 Heuristic, not a parser: we extract candidate paths via a regex that
 matches the common forms in the docs (bare references, backtick-wrapped
@@ -42,7 +53,17 @@ PATH_RE = re.compile(
     r"(?P<path>(?:apps|prds|docs|scripts|\.github)/[A-Za-z0-9_./-]+(?:/[A-Za-z0-9_.-]+)*)/?",
 )
 
-DEFAULT_TARGETS = ("CLAUDE.md", "docs/development.md")
+def _default_targets() -> tuple[str, ...]:
+    """CLAUDE.md, the reference docs, and every page of the user manual."""
+    targets = ["CLAUDE.md"]
+    for pattern in ("docs/*.md", "docs/guide/*.md"):
+        targets.extend(
+            str(p.relative_to(REPO_ROOT)) for p in sorted(REPO_ROOT.glob(pattern))
+        )
+    return tuple(targets)
+
+
+DEFAULT_TARGETS = _default_targets()
 
 # Bare-name listing checks (#898).
 #


### PR DESCRIPTION
Closes #991.

A code change could land, take its CHANGELOG line, pass CI, and leave `docs/guide/` describing the old behaviour. Nothing checked. #412 found that had happened across roughly a third of the manual — nine charts documented on a page that has three, an auto-poll table that was backwards, disk requirements off by 3× in the direction that breaks installs.

## 1. `CLAUDE.md` — one section, three obligations

CHANGELOG, docs accuracy, and design docs now live together, because they're one habit rather than three. The pre-existing PRD / RISKS-AND-GAPS rule is folded in rather than left stranded elsewhere.

The obligation: identify which docs describe what you changed and update them in the same PR — **or say in the PR body that you checked and none apply**. Being required to say "checked, none apply" is most of the value; it's the difference between deciding and forgetting.

It carries a **code → docs map**, because "which doc covers this?" is the step most likely to be skipped. Every path in it was verified to exist, and the table is **self-enforcing**: `check_docs_sync.py` scans `CLAUDE.md`, so a path that stops existing fails CI.

## 2. Path check widened: 2 files → 26

`check_docs_sync.py` targeted only `CLAUDE.md` and `docs/development.md`. The user-facing manual — 20 files, rendered at `/docs` — got none of the checking the agent-context files got, which is part of how the #412 drift went unnoticed.

Now covers `CLAUDE.md`, `docs/*.md` and all of `docs/guide/`. **All 26 pass today**, so this is free. Verified it bites:

```
[FAIL] docs/guide/12-rag-search.md references 1 missing path(s):
  - apps/web/src/lib/rag-models-renamed.ts
```

## 3. Deliberately NOT adding a CI gate

Per the decision on the issue. A "services/ changed but no docs/ touched" check cannot judge whether prose is *true* — the only thing it can enforce is that some docs file was touched, which makes "touch any doc to go green" the path of least resistance.

That's not hypothetical here. This codebase has produced that exact failure twice in recent memory: a snapshot test in #968 that asserted a hardcoded copy of the bug it was meant to catch, and an audit in #977 whose finding count silently dropped from 14 to 6 when torch stopped being resolvable — both looked green while checking nothing.

The convention is the substance; CI can only ever check that *something happened*. The script's docstring now says plainly what it does not do, so a passing path check isn't mistaken for a correctness check.

## Verification

```
ALL BLOCKING CI CHECKS PASS LOCALLY   (make ci-local, 9 checks)
```

Docs accuracy per the new rule: this PR changes agent-facing conventions and a CI script, not user-visible behaviour — no `docs/guide/` page describes either, so none apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)