### PR TITLE
feat(docs-ask): index reference docs and PRDs alongside the guide (#990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Internal
+- First step of the documentation Ask bubble: the reference documentation and the design documents are now indexed alongside the user guide, each section tagged with where it came from so answers can cite it later. Nothing uses this yet. As a side effect the release notes on the About page now also render when running locally, not just in Docker — they were being read from a path that only existed inside the container. ([#990](https://github.com/brlauuu/podlog/issues/990))
+
+### Internal
 - Wrote the implementation plan for the documentation Ask bubble, following the design spec agreed in #990. Five tasks, each ending in something testable. Still no implementation. ([#990](https://github.com/brlauuu/podlog/issues/990))
 
 ### Internal

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -9,8 +9,13 @@ import { makeUniqueSlugger } from "@/lib/docs-slug";
 
 export const dynamic = "force-dynamic";
 
-async function readDocOrNull(filename: string): Promise<string | null> {
-  const path = join(process.cwd(), "..", "..", "docs", filename);
+async function readDocOrNull(relativePath: string): Promise<string | null> {
+  // Repo-relative, so callers say where a file actually lives. CHANGELOG.md
+  // sits at the root, not under docs/ (#990) -- it used to be bind-mounted
+  // into /docs, which stopped being possible once docs/ became a read-only
+  // directory mount, and which meant the changelog rendered in the
+  // container but never in local dev.
+  const path = join(process.cwd(), "..", "..", relativePath);
   try {
     return await readFile(path, "utf-8");
   } catch {
@@ -78,7 +83,7 @@ function firstOccurrenceMap(headings: HeadingId[]): Map<string, string> {
 
 export default async function AboutPage() {
   const [aboutContent, changelogContent] = await Promise.all([
-    readDocOrNull("about.md"),
+    readDocOrNull("docs/about.md"),
     readDocOrNull("CHANGELOG.md"),
   ]);
 

--- a/apps/web/src/lib/docs-index.ts
+++ b/apps/web/src/lib/docs-index.ts
@@ -14,7 +14,7 @@
 import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 
-import type { DocSection } from "./docs-search";
+import type { DocSection, DocSource } from "./docs-search";
 import { makeUniqueSlugger } from "./docs-slug";
 
 function filenameToTitle(filename: string): string {
@@ -33,6 +33,8 @@ function splitDocIntoSections(
   docSlug: string,
   docTitle: string,
   markdown: string,
+  source: DocSource = "guide",
+  repoPath = `docs/guide/${docSlug}.md`,
 ): DocSection[] {
   const lines = markdown.split("\n");
   const sluggify = makeUniqueSlugger();
@@ -46,6 +48,8 @@ function splitDocIntoSections(
     sectionId: "",
     sectionTitle: "",
     level: 0,
+    source,
+    repoPath,
     content: "",
   };
 
@@ -67,6 +71,8 @@ function splitDocIntoSections(
         sectionId: sluggify(text),
         sectionTitle: text,
         level,
+        source,
+        repoPath,
         content: "",
       };
       continue;
@@ -110,9 +116,102 @@ export async function buildDocsIndex(): Promise<DocSection[]> {
   return cachedIndex;
 }
 
+const REPO_ROOT = join(process.cwd(), "..", "..");
+
+interface CorpusEntry {
+  /** Absolute directory to scan, non-recursively. */
+  dir: string;
+  /** Repo-relative prefix used to build DocSection.repoPath. */
+  repoDir: string;
+  source: DocSource;
+}
+
+/**
+ * Filenames excluded from the corpus even though they sit in a scanned
+ * directory.
+ *
+ * CHANGELOG.md lives at the repo root but is bind-mounted to /docs in the
+ * web container so the About page can render it. That makes it visible to a
+ * `docs/*.md` scan in production and invisible in dev and tests -- the same
+ * code would build a different corpus depending on where it runs. It is
+ * excluded outright rather than left to differ, and release history was not
+ * part of the corpus this feature was scoped to.
+ */
+const CORPUS_EXCLUDE = new Set(["CHANGELOG.md"]);
+
+/**
+ * The corpus the docs Ask bubble answers from (#990).
+ *
+ * Non-recursive per directory on purpose: `docs/` must pick up
+ * docs/configuration.md and its siblings, but never docs/audit/ or
+ * docs/superpowers/, which are agent working files rather than
+ * documentation. A recursive walk would quietly pull both in.
+ */
+const CORPUS: CorpusEntry[] = [
+  { dir: join(REPO_ROOT, "docs", "guide"), repoDir: "docs/guide", source: "guide" },
+  { dir: join(REPO_ROOT, "docs"), repoDir: "docs", source: "reference" },
+  { dir: join(REPO_ROOT, "prds"), repoDir: "prds", source: "prd" },
+];
+
+let cachedCorpus: DocSection[] | null = null;
+
+/**
+ * Build the full documentation corpus: guide, reference docs and PRDs,
+ * split into heading-delimited sections (#990).
+ *
+ * Separate from buildDocsIndex(), which backs the /docs search UI and must
+ * keep returning guide sections only. Memoized the same way; a missing
+ * directory is skipped rather than fatal, so a checkout without prds/
+ * degrades to a smaller corpus instead of failing the request.
+ */
+export async function buildDocsCorpusIndex(): Promise<DocSection[]> {
+  if (cachedCorpus) return cachedCorpus;
+
+  const out: DocSection[] = [];
+  for (const entry of CORPUS) {
+    let files: string[] = [];
+    try {
+      files = (await readdir(entry.dir, { withFileTypes: true }))
+        .filter(
+          (d) =>
+            d.isFile() &&
+            d.name.endsWith(".md") &&
+            !CORPUS_EXCLUDE.has(d.name),
+        )
+        .map((d) => d.name)
+        .sort();
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      const slug = file.replace(/\.md$/, "");
+      let raw = "";
+      try {
+        raw = await readFile(join(entry.dir, file), "utf-8");
+      } catch {
+        continue;
+      }
+      out.push(
+        ...splitDocIntoSections(
+          slug,
+          filenameToTitle(slug),
+          raw,
+          entry.source,
+          `${entry.repoDir}/${file}`,
+        ),
+      );
+    }
+  }
+
+  cachedCorpus = out;
+  return cachedCorpus;
+}
+
 /** Test hook to force a re-read on the next call. Not used in app code. */
 export function _resetDocsIndexCache(): void {
   cachedIndex = null;
+  cachedCorpus = null;
 }
 
 export { splitDocIntoSections };

--- a/apps/web/src/lib/docs-search.ts
+++ b/apps/web/src/lib/docs-search.ts
@@ -6,6 +6,9 @@
  * the corpus and produce the snippet UI.
  */
 
+/** Which corpus a section came from (#990). */
+export type DocSource = "guide" | "reference" | "prd";
+
 export interface DocSection {
   /** Filename without extension, e.g. "06-speakers". Matches DocEntry.name. */
   docSlug: string;
@@ -17,6 +20,10 @@ export interface DocSection {
   sectionTitle: string;
   /** Heading level, 2 for ##, 3 for ###. 0 means "before any heading" (preamble). */
   level: 0 | 2 | 3;
+  /** Which corpus this section came from (#990). */
+  source: DocSource;
+  /** Repo-relative file path, e.g. "docs/guide/08-queue.md" (#990). */
+  repoPath: string;
   /** Section body, raw markdown text. */
   content: string;
 }

--- a/apps/web/tests/unit/docs-corpus-index.test.ts
+++ b/apps/web/tests/unit/docs-corpus-index.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ *
+ * #990: the docs Ask bubble answers from the guide, the reference docs and
+ * the PRDs. Only docs/guide/ was indexed before.
+ */
+import { buildDocsCorpusIndex, _resetDocsIndexCache } from "@/lib/docs-index";
+
+beforeEach(() => _resetDocsIndexCache());
+
+describe("buildDocsCorpusIndex (#990)", () => {
+  it("indexes the guide, the reference docs and the PRDs", async () => {
+    const index = await buildDocsCorpusIndex();
+    const sources = new Set(index.map((s) => s.source));
+    expect(sources).toEqual(new Set(["guide", "reference", "prd"]));
+  });
+
+  it("tags each section with the file it came from", async () => {
+    const index = await buildDocsCorpusIndex();
+    const queue = index.find((s) => s.repoPath === "docs/guide/08-queue.md");
+    expect(queue).toBeDefined();
+    expect(queue!.source).toBe("guide");
+
+    const prd = index.find((s) => s.repoPath.startsWith("prds/"));
+    expect(prd).toBeDefined();
+    expect(prd!.source).toBe("prd");
+  });
+
+  it("never indexes agent artifacts", async () => {
+    // docs/audit/ and docs/superpowers/ are working files, not documentation.
+    const index = await buildDocsCorpusIndex();
+    const leaked = index.filter(
+      (s) =>
+        s.repoPath.startsWith("docs/audit/") ||
+        s.repoPath.startsWith("docs/superpowers/"),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("keeps guide anchors identical to the ones the renderer emits", async () => {
+    // Citations deep-link to these. If the indexer and DocsClient ever use
+    // different slug algorithms, every guide citation 404s silently.
+    const index = await buildDocsCorpusIndex();
+    const guide = index.filter((s) => s.source === "guide" && s.sectionTitle);
+    expect(guide.length).toBeGreaterThan(50);
+    for (const s of guide.slice(0, 20)) {
+      expect(s.sectionId).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("finds a substantial corpus (guards a vacuous pass)", async () => {
+    const index = await buildDocsCorpusIndex();
+    expect(index.length).toBeGreaterThan(300);
+  });
+});
+
+describe("corpus exclusions (#990)", () => {
+  it("excludes CHANGELOG.md, which only exists under docs/ in the container", async () => {
+    // It is bind-mounted to /docs for the About page, so a docs/*.md scan
+    // sees it in production and not in dev. Excluded so the corpus is the
+    // same everywhere, and because release history was not in scope.
+    _resetDocsIndexCache();
+    const index = await buildDocsCorpusIndex();
+    const changelog = index.filter((s) => s.repoPath.endsWith("CHANGELOG.md"));
+    expect(changelog).toEqual([]);
+  });
+
+  it("still indexes the other reference docs", async () => {
+    _resetDocsIndexCache();
+    const index = await buildDocsCorpusIndex();
+    const paths = new Set(index.map((s) => s.repoPath));
+    expect(paths.has("docs/configuration.md")).toBe(true);
+    expect(paths.has("docs/hardware.md")).toBe(true);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,9 +145,19 @@ services:
       EMBED_COOLDOWN_MS: ${EMBED_COOLDOWN_MS:-}
     volumes:
       - audio_data:/data/audio:ro
-      - ./docs/guide:/docs/guide:ro
-      - ./docs/about.md:/docs/about.md:ro
-      - ./CHANGELOG.md:/docs/CHANGELOG.md:ro
+      # #990: the docs Ask bubble retrieves from the guide, the reference
+      # docs and the PRDs at request time, so the whole of docs/ and prds/
+      # is mounted rather than the two files the pages needed before.
+      # Read-only: nothing in the web container ever writes here.
+      - ./docs:/docs:ro
+      - ./prds:/prds:ro
+      # CHANGELOG.md is mounted at the repo-root path it actually has, not
+      # inside /docs. It used to be mapped to /docs/CHANGELOG.md, which a
+      # read-only ./docs mount cannot host -- runc cannot create a
+      # mountpoint inside a :ro bind. Reading it from the root also makes
+      # dev match the container, where the About page previously found no
+      # changelog at all because <repo>/docs/CHANGELOG.md does not exist.
+      - ./CHANGELOG.md:/CHANGELOG.md:ro
       # /api/version reads this at request time and compares against
       # NEXT_PUBLIC_APP_VERSION (baked at build time) so the footer can
       # signal "your running image is stale, rebuild it" when VERSION


### PR DESCRIPTION
Refs #990. **Task 1 of 5** from `docs/superpowers/plans/2026-08-26-docs-ask-bubble.md`.

`DocSection` gains `source` (`guide` | `reference` | `prd`) and `repoPath`, threaded through the existing splitter with defaults so the `/docs` search UI and its tests are untouched. `buildDocsCorpusIndex()` scans `docs/guide/`, `docs/` and `prds/` **non-recursively** — recursion would pull in `docs/audit/` and `docs/superpowers/`, which are agent working files, and there's a test for that.

Nothing consumes the corpus yet. That's Tasks 2–5.

## Two things the plan didn't anticipate

Both found by *running* the task's verification steps, not by reasoning about them.

### 1. The CHANGELOG would have been in the corpus — but only in production

`CHANGELOG.md` is bind-mounted into `/docs` so the About page can read it. So a `docs/*.md` scan picks it up **in the container and not in dev or tests** — the same code building a different corpus depending on where it runs. Release history also wasn't part of the corpus this feature was scoped to; it was offered as an option during design and not chosen.

Excluded via `CORPUS_EXCLUDE`, with a test.

### 2. The mount in the plan cannot work

The plan said to add `./docs:/docs:ro` and keep `./CHANGELOG.md:/docs/CHANGELOG.md:ro`. That fails outright — runc can't create a mountpoint inside a read-only bind:

```
error mounting "/home/.../CHANGELOG.md" to rootfs at "/docs/CHANGELOG.md":
create mountpoint for /docs/CHANGELOG.md mount: read-only file system
```

The container refused to start. **Step 9 of the task existed to catch exactly this**, and did.

The fix is better than the original: `CHANGELOG.md` is mounted at the repo-root path it actually has, and `readDocOrNull` takes a repo-relative path instead of assuming `docs/`. That also fixes a pre-existing bug — the About page's changelog rendered **only in the container**, because `<repo>/docs/CHANGELOG.md` doesn't exist in a checkout. It now renders in local dev too.

## Verification

In the running container:

```
/docs         -> about.md, audit, configuration.md, development.md, …
/prds         -> PRD-01…, PRD-02…, PRD-03…
/CHANGELOG.md -> "# Changelog"
/docs   HTTP 200
/about  HTTP 200
```

About page renders the changelog body — `Unreleased`, `0.7.0` and recent entries all found in the HTML.

7 new web tests. The six existing docs suites (49 tests) and both about-page suites pass unchanged.

`make ci-local` — all 9 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)