### PR TITLE
feat(docs-ask): accept caller-supplied context in /api/ask (#990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Internal
+- Third step of the documentation Ask bubble: the question-answering endpoint can now be handed the passages to answer from, instead of always searching podcast transcripts for them. This is what lets the documentation be answered over at all — the transcripts live in the database, but the documentation lives in files that only the web app can read. Asking about podcast content is unchanged, and a test now guards that specifically. ([#990](https://github.com/brlauuu/podlog/issues/990))
+
+### Internal
 - Second step of the documentation Ask bubble: picking which sections of the documentation are relevant to a question. Matches on the individual meaningful words rather than the whole phrase, and caps how much text it returns so answers fit even the smallest local model. Still not wired to anything. ([#990](https://github.com/brlauuu/podlog/issues/990))
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Internal
-- Third step of the documentation Ask bubble: the question-answering endpoint can now be handed the passages to answer from, instead of always searching podcast transcripts for them. This is what lets the documentation be answered over at all — the transcripts live in the database, but the documentation lives in files that only the web app can read. Asking about podcast content is unchanged, and a test now guards that specifically. ([#990](https://github.com/brlauuu/podlog/issues/990))
+- Third step of the documentation Ask bubble: the question-answering endpoint can now be handed the passages to answer from, instead of always searching podcast transcripts for them. This is what lets the documentation be answered over at all — the transcripts live in the database, but the documentation lives in files that only the web app can read. Asking about podcast content is unchanged, and a test now guards that specifically. Also fixes the local CI script, which could report a pass while running an out-of-date copy of the test suite — it now rebuilds the test image first. ([#990](https://github.com/brlauuu/podlog/issues/990))
 
 ### Internal
 - Second step of the documentation Ask bubble: picking which sections of the documentation are relevant to a question. Matches on the individual meaningful words rather than the whole phrase, and caps how much text it returns so answers fit even the smallest local model. Still not wired to anything. ([#990](https://github.com/brlauuu/podlog/issues/990))

--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -24,6 +24,7 @@ from app.services.prompts import get_prompt
 from app.services.rag import (
     DEFAULT_MODEL,
     build_prompt,
+    build_prompt_from_text,
     check_model_available,
     chunks_to_sources,
     retrieve_chunks,
@@ -45,6 +46,23 @@ class ChatMessage(BaseModel):
     content: str
 
 
+class ContextSection(BaseModel):
+    """A documentation passage supplied by the caller (#990).
+
+    When AskRequest.context is present the endpoint answers over these
+    instead of retrieving transcript chunks. That makes /api/ask a
+    general-purpose "answer over supplied text" endpoint -- see the
+    consequences section of the docs-Ask design spec.
+    """
+
+    title: str
+    source: str          # guide | reference | prd
+    slug: str
+    anchor: str | None = None
+    repo_path: str
+    text: str
+
+
 class AskRequest(BaseModel):
     question: str
     model: str | None = None
@@ -57,6 +75,9 @@ class AskRequest(BaseModel):
     speaker_display: str | None = None
     # Issue #699: prior turns of the conversation for follow-up awareness.
     history: list[ChatMessage] | None = None
+    # #990: documentation passages supplied by the web app, which is the only
+    # container with the docs mounted. Present => skip transcript retrieval.
+    context: list[ContextSection] | None = None
 
 
 def _sse_event(event: str, data: dict | list | str) -> str:
@@ -71,6 +92,7 @@ async def _stream_ask(
     episode_id: str | None = None,
     speaker_display: str | None = None,
     history: list[dict] | None = None,
+    context: list[ContextSection] | None = None,
 ):
     db = SessionLocal()
     try:
@@ -109,35 +131,62 @@ async def _stream_ask(
             yield _sse_event("done", {})
             return
 
-        # 1. Retrieve relevant chunks
-        chunks = retrieve_chunks(
-            db, question, feed_ids=feed_ids, episode_id=episode_id,
-            speaker_display=speaker_display,
-        )
+        if context:
+            # #990: the caller supplied the passages, so there is nothing to
+            # retrieve. The web app does that, being the only container with
+            # the documentation mounted. An empty list is not special-cased:
+            # the docs route returns its "nothing matched" stream without
+            # calling us at all, so this branch only runs with passages in hand.
+            yield _sse_event(
+                "sources",
+                [
+                    {
+                        "title": c.title,
+                        "source": c.source,
+                        "slug": c.slug,
+                        "anchor": c.anchor,
+                        "repo_path": c.repo_path,
+                        "text": c.text[:200],
+                    }
+                    for c in context
+                ],
+            )
+            messages = build_prompt_from_text(
+                question,
+                [c.text for c in context],
+                system_prompt=get_prompt(db, "ask_page_system"),
+                history=(history or [])[-MAX_HISTORY_MESSAGES:],
+            )
+        else:
+            # 1. Retrieve relevant chunks
+            chunks = retrieve_chunks(
+                db, question, feed_ids=feed_ids, episode_id=episode_id,
+                speaker_display=speaker_display,
+            )
 
-        if not chunks:
-            yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
-            yield _sse_event("done", {})
-            return
+            if not chunks:
+                yield _sse_event("error", {"message": "No relevant transcript excerpts found for your question."})
+                yield _sse_event("done", {})
+                return
 
-        # 2. Send sources first
-        sources = chunks_to_sources(chunks)
-        yield _sse_event("sources", sources)
+            # 2. Send sources first
+            sources = chunks_to_sources(chunks)
+            yield _sse_event("sources", sources)
 
-        # 3. Build prompt and stream response. Issue #643: per-episode Ask
-        # popup and the global /ask page get separate, user-editable system
-        # prompts (defaulting to the same text). Issue #699: prior turns
-        # are inserted between system and user — capped to MAX_HISTORY_MESSAGES
-        # defensively even if the client over-sent.
-        prompt_key = "ask_episode_system" if episode_id else "ask_page_system"
-        system_prompt = get_prompt(db, prompt_key)
-        capped_history = (history or [])[-MAX_HISTORY_MESSAGES:]
-        messages = build_prompt(
-            question,
-            chunks,
-            system_prompt=system_prompt,
-            history=capped_history,
-        )
+            # 3. Build prompt and stream response. Issue #643: per-episode Ask
+            # popup and the global /ask page get separate, user-editable system
+            # prompts (defaulting to the same text). Issue #699: prior turns
+            # are inserted between system and user — capped to MAX_HISTORY_MESSAGES
+            # defensively even if the client over-sent.
+            prompt_key = "ask_episode_system" if episode_id else "ask_page_system"
+            system_prompt = get_prompt(db, prompt_key)
+            capped_history = (history or [])[-MAX_HISTORY_MESSAGES:]
+            messages = build_prompt(
+                question,
+                chunks,
+                system_prompt=system_prompt,
+                history=capped_history,
+            )
 
         async for token in stream_response(messages, model=resolved_model, runtime=runtime):
             yield _sse_event("token", {"content": token})
@@ -175,6 +224,7 @@ async def ask_endpoint(req: AskRequest):
             episode_id=req.episode_id,
             speaker_display=req.speaker_display,
             history=history,
+            context=req.context,
         ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -230,6 +230,35 @@ Question: {question}"""
     return messages
 
 
+def build_prompt_from_text(
+    question: str,
+    passages: list[str],
+    system_prompt: str | None = None,
+    history: list[dict] | None = None,
+) -> list[dict]:
+    """Build chat messages from caller-supplied passages (#990).
+
+    Mirrors build_prompt's message shape exactly -- system, then prior
+    turns, then the user turn with context inline -- so the provider paths
+    downstream cannot tell the two apart. Used by /api/ask when the caller
+    supplies the text to answer over (documentation sections, retrieved by
+    the web app, which is the only container with the docs mounted).
+    """
+    context_block = "\n\n---\n\n".join(passages)
+    messages: list[dict] = [
+        {"role": "system", "content": system_prompt or SYSTEM_PROMPT}
+    ]
+    if history:
+        messages.extend(history)
+    messages.append(
+        {
+            "role": "user",
+            "content": f"Context:\n\n{context_block}\n\nQuestion: {question}",
+        }
+    )
+    return messages
+
+
 def chunks_to_sources(chunks: list[ChunkResult]) -> list[dict]:
     """Convert chunks to a serializable sources list for the SSE stream."""
     return [

--- a/apps/pipeline/tests/unit/test_ask_supplied_context.py
+++ b/apps/pipeline/tests/unit/test_ask_supplied_context.py
@@ -1,0 +1,112 @@
+"""#990: /api/ask can answer over caller-supplied passages.
+
+The transcript path must be untouched -- a request without `context`
+still retrieves chunks. That regression guard is the point of this file
+as much as the new behaviour is.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api.ask import AskRequest, ContextSection
+
+
+class TestAskRequestContext:
+    def test_context_defaults_to_none(self):
+        req = AskRequest(question="why?")
+        assert req.context is None
+
+    def test_context_accepts_sections(self):
+        req = AskRequest(
+            question="why is Whisper unloaded?",
+            context=[
+                ContextSection(
+                    title="Memory", source="guide", slug="19-inference-providers",
+                    anchor="a-note-on-memory", repo_path="docs/guide/19-inference-providers.md",
+                    text="Whisper is unloaded before pyannote loads.",
+                )
+            ],
+        )
+        assert req.context is not None
+        assert req.context[0].source == "guide"
+
+
+class TestBuildPromptFromText:
+    def test_passages_appear_in_the_prompt(self):
+        from app.services.rag import build_prompt_from_text
+
+        msgs = build_prompt_from_text(
+            "why?", ["Whisper is unloaded before pyannote loads."],
+            system_prompt="SYS",
+        )
+        joined = " ".join(m["content"] for m in msgs)
+        assert "Whisper is unloaded" in joined
+        assert "why?" in joined
+
+    def test_system_prompt_is_honoured(self):
+        from app.services.rag import build_prompt_from_text
+
+        msgs = build_prompt_from_text("q", ["p"], system_prompt="CUSTOM")
+        assert msgs[0]["role"] == "system"
+        assert msgs[0]["content"] == "CUSTOM"
+
+    def test_history_is_inserted_between_system_and_user(self):
+        from app.services.rag import build_prompt_from_text
+
+        msgs = build_prompt_from_text(
+            "q", ["p"], system_prompt="SYS",
+            history=[{"role": "user", "content": "earlier"}],
+        )
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["content"] == "earlier"
+        assert msgs[-1]["role"] == "user"
+
+
+class TestTranscriptPathUnchanged:
+    """The branch must not disturb /ask. This is the guard for that."""
+
+    async def _drain(self, gen):
+        return [frame async for frame in gen]
+
+    @pytest.mark.asyncio
+    async def test_no_context_still_retrieves_chunks(self):
+        from app.api import ask as ask_mod
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value={}),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "retrieve_chunks", return_value=[]) as mock_ret,
+        ):
+            await self._drain(ask_mod._stream_ask("carbon pricing", None, None))
+
+        mock_ret.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_supplied_context_skips_retrieval(self):
+        from app.api import ask as ask_mod
+
+        section = ContextSection(
+            title="Memory", source="guide", slug="19-inference-providers",
+            anchor="a-note-on-memory",
+            repo_path="docs/guide/19-inference-providers.md",
+            text="Whisper is unloaded before pyannote loads.",
+        )
+
+        async def _fake_stream(*args, **kwargs):
+            yield "answer"
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value={}),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "get_prompt", return_value="SYS"),
+            patch.object(ask_mod, "stream_response", _fake_stream),
+            patch.object(ask_mod, "retrieve_chunks") as mock_ret,
+        ):
+            frames = await self._drain(
+                ask_mod._stream_ask("why?", None, None, context=[section])
+            )
+
+        mock_ret.assert_not_called()
+        assert any("a-note-on-memory" in f for f in frames)

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -71,6 +71,14 @@ else
 fi
 
 # --- Pipeline --------------------------------------------------------------
+# The test image bakes tests in at build time (COPY . .), so a run against a
+# stale image silently executes the OLD test files and reports a pass. That is
+# not hypothetical: it happened on #990's own branch, where this script printed
+# PASS while running the pre-change suite. Rebuild before the first pytest.
+step "Rebuild test image"
+docker compose -f docker-compose.test.yml build test >/dev/null 2>&1
+res $? "test image rebuilt (baked-in tests are current)"
+
 step "Pipeline Unit Fast"
 docker compose -f docker-compose.test.yml run --rm test pytest \
   tests/unit/test_api.py tests/unit/test_rag_helpers.py tests/unit/test_rag_endpoint.py \


### PR DESCRIPTION
Task 3 of `docs/superpowers/plans/2026-08-26-docs-ask-bubble.md`. Independent of Tasks 1–2; Task 4 needs all three.

## Summary

`/api/ask` gains an optional `context` field — a list of passages the caller has already retrieved. When present, the endpoint answers over those instead of retrieving transcript chunks.

This is the endpoint half of the topology decided in the spec (D3): the documentation lives in files that only the `web` container has mounted, so the web app retrieves and the pipeline generates.

## Changes

- `ContextSection` model and `AskRequest.context` in `apps/pipeline/app/api/ask.py`
- `build_prompt_from_text` in `apps/pipeline/app/services/rag.py` — mirrors `build_prompt`'s message shape exactly, so the provider paths downstream cannot tell the two apart
- `_stream_ask` gains a `context` parameter and branches on it; the existing retrieval block becomes the `else`, unchanged
- `scripts/ci-local.sh` now rebuilds the test image before running pytest (see below)

Provider routing, prompt assembly and SSE streaming are otherwise untouched. An empty `context` list is not special-cased: Task 4's route returns its "nothing matched" stream without calling the pipeline at all.

## Testing

7 new tests (1043 → 1050). Both branch guards were verified to fail against a deliberately broken build:

| Mutant | Test that failed |
|---|---|
| `if context:` → `if True:` | `test_no_context_still_retrieves_chunks` |
| `if context:` → `if False:` | `test_supplied_context_skips_retrieval` |

Neither mutant broke the other's guard, so each is testing what it claims to.

`make ci-local`: all checks pass, pipeline coverage 92.54%.

## The ci-local fix

Worth flagging on its own. `make ci-local` reported **ALL BLOCKING CI CHECKS PASS** on this branch while running the *pre-change* suite — 1043 tests, not 1050. The test image bakes test files in at build time, and the script never rebuilt it.

A script whose entire purpose is to be trusted instead of waiting for CI cannot have a silent-stale mode, so it now rebuilds first. Verified by rebuilding the image without the new test file and re-running: reports 1050.

## Docs

Checked, none apply. `docs/guide/12-rag-search.md` describes the user-facing Ask page, whose behaviour is unchanged — this adds a capability nothing user-visible reaches until Task 5.

Refs #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin