### PR TITLE
feat(docs-ask): docs Ask bubble with section citations (#990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ fresh empty `Unreleased` is left at the top.
 
 ### Major changes
 - The documentation now has its own Ask box. Open any docs page and the bubble in the corner answers questions about Podlog itself — how to configure something, why it behaves the way it does — drawing on the user guide, the reference documentation and the design documents, and linking to the exact section each answer came from. It is separate from Ask AI, which searches your podcast transcripts: this one never looks at your episodes. It works the same on a local-only install as on remote inference, because it sends only the handful of relevant sections rather than the whole manual. ([#990](https://github.com/brlauuu/podlog/issues/990))
+- Ask AI waits longer for a local model to start replying before giving up. On a CPU-only machine the first words can take several minutes, and the previous limit cut some questions off mid-thought — reporting a connection error for what was really just a slow answer. ([#990](https://github.com/brlauuu/podlog/issues/990))
 
 ### Internal
 - Fourth step of the documentation Ask bubble: the piece that joins the two halves together. It finds the relevant parts of the documentation and hands them to the answering service, which writes the answer and streams it back. If nothing in the documentation matches the question it says so, rather than letting the model invent an answer from nothing. Still no way to reach this from the interface — that is the last step. ([#990](https://github.com/brlauuu/podlog/issues/990))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Major changes
+- The documentation now has its own Ask box. Open any docs page and the bubble in the corner answers questions about Podlog itself — how to configure something, why it behaves the way it does — drawing on the user guide, the reference documentation and the design documents, and linking to the exact section each answer came from. It is separate from Ask AI, which searches your podcast transcripts: this one never looks at your episodes. It works the same on a local-only install as on remote inference, because it sends only the handful of relevant sections rather than the whole manual. ([#990](https://github.com/brlauuu/podlog/issues/990))
+
 ### Internal
 - Fourth step of the documentation Ask bubble: the piece that joins the two halves together. It finds the relevant parts of the documentation and hands them to the answering service, which writes the answer and streams it back. If nothing in the documentation matches the question it says so, rather than letting the model invent an answer from nothing. Still no way to reach this from the interface — that is the last step. ([#990](https://github.com/brlauuu/podlog/issues/990))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ fresh empty `Unreleased` is left at the top.
 
 ### Major changes
 - The documentation now has its own Ask box. Open any docs page and the bubble in the corner answers questions about Podlog itself — how to configure something, why it behaves the way it does — drawing on the user guide, the reference documentation and the design documents, and linking to the exact section each answer came from. It is separate from Ask AI, which searches your podcast transcripts: this one never looks at your episodes. It works the same on a local-only install as on remote inference, because it sends only the handful of relevant sections rather than the whole manual. ([#990](https://github.com/brlauuu/podlog/issues/990))
+- The documentation Ask box follows your existing Ask AI provider setting, so switching between local inference and Fireworks switches both. It also uses whichever model you have configured there, rather than a fixed one. ([#990](https://github.com/brlauuu/podlog/issues/990))
 - Ask AI waits longer for a local model to start replying before giving up. On a CPU-only machine the first words can take several minutes, and the previous limit cut some questions off mid-thought — reporting a connection error for what was really just a slow answer. ([#990](https://github.com/brlauuu/podlog/issues/990))
 
 ### Internal

--- a/apps/pipeline/app/api/ask.py
+++ b/apps/pipeline/app/api/ask.py
@@ -78,6 +78,11 @@ class AskRequest(BaseModel):
     # #990: documentation passages supplied by the web app, which is the only
     # container with the docs mounted. Present => skip transcript retrieval.
     context: list[ContextSection] | None = None
+    # #990: overrides the stored ask_page_system prompt, but only on the
+    # supplied-context path. The stored prompt mandates transcript-style
+    # [Episode Title, MM:SS] citations; a docs caller has neither, and the
+    # model dutifully emitted "[Context, N/A]" against every claim.
+    system_prompt: str | None = None
 
 
 def _sse_event(event: str, data: dict | list | str) -> str:
@@ -93,6 +98,7 @@ async def _stream_ask(
     speaker_display: str | None = None,
     history: list[dict] | None = None,
     context: list[ContextSection] | None = None,
+    system_prompt: str | None = None,
 ):
     db = SessionLocal()
     try:
@@ -154,7 +160,7 @@ async def _stream_ask(
             messages = build_prompt_from_text(
                 question,
                 [c.text for c in context],
-                system_prompt=get_prompt(db, "ask_page_system"),
+                system_prompt=system_prompt or get_prompt(db, "ask_page_system"),
                 history=(history or [])[-MAX_HISTORY_MESSAGES:],
             )
         else:
@@ -179,12 +185,15 @@ async def _stream_ask(
             # are inserted between system and user — capped to MAX_HISTORY_MESSAGES
             # defensively even if the client over-sent.
             prompt_key = "ask_episode_system" if episode_id else "ask_page_system"
-            system_prompt = get_prompt(db, prompt_key)
+            # Deliberately ignores the request's system_prompt: the transcript
+            # path answers with the operator's stored, user-editable prompt and
+            # is not overridable per request (#990).
+            stored_prompt = get_prompt(db, prompt_key)
             capped_history = (history or [])[-MAX_HISTORY_MESSAGES:]
             messages = build_prompt(
                 question,
                 chunks,
-                system_prompt=system_prompt,
+                system_prompt=stored_prompt,
                 history=capped_history,
             )
 
@@ -225,6 +234,7 @@ async def ask_endpoint(req: AskRequest):
             speaker_display=req.speaker_display,
             history=history,
             context=req.context,
+            system_prompt=req.system_prompt,
         ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},

--- a/apps/pipeline/app/services/rag.py
+++ b/apps/pipeline/app/services/rag.py
@@ -317,7 +317,15 @@ async def _stream_ollama_once(messages: list[dict], model: str):
     }
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=120, write=10, pool=10)) as client:
+        # read=300, not 120 (#990). The read timeout is the wait for the FIRST
+        # token, which on CPU is dominated by prefill over num_ctx -- not by
+        # prompt length. Measured on a CPU-only host with qwen2.5:3b at
+        # num_ctx=8192: a ~1000-token prompt took 108s and a ~2500-token one
+        # 164s. At read=120 the shorter one squeaks through and the longer one
+        # fails, which is how this surfaced: one docs question answered and the
+        # next timed out. Raising it only lets slow requests finish; nothing
+        # that already succeeded changes.
+        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=300, write=10, pool=10)) as client:
             async with client.stream("POST", url, json=payload) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()

--- a/apps/pipeline/tests/unit/test_ask_supplied_context.py
+++ b/apps/pipeline/tests/unit/test_ask_supplied_context.py
@@ -222,3 +222,72 @@ class TestSuppliedSystemPrompt:
             )
 
         assert captured["system_prompt"] == "STORED"
+
+
+class TestProviderRoutingOnTheContextPath:
+    """#990: the docs path must obey the same Settings as transcript Ask.
+
+    Provider comes from rag_provider, model from rag_local_model /
+    fireworks_chat_model. A caller that pins a model wins over the stored
+    one -- which is why the docs bubble sends none.
+    """
+
+    async def _drain(self, gen):
+        return [frame async for frame in gen]
+
+    def _section(self):
+        return ContextSection(
+            title="Memory", source="guide", slug="19-inference-providers",
+            anchor=None, repo_path="docs/guide/19-inference-providers.md",
+            text="Whisper is unloaded before pyannote loads.",
+        )
+
+    async def _resolved_model(self, runtime, model=None):
+        from app.api import ask as ask_mod
+
+        captured = {}
+
+        async def _fake_stream(messages, model=None, runtime=None):
+            captured["model"] = model
+            yield "x"
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value=runtime),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "get_prompt", return_value="SYS"),
+            patch.object(ask_mod, "stream_response", _fake_stream),
+        ):
+            await self._drain(
+                ask_mod._stream_ask(
+                    "why?", model, None, context=[self._section()]
+                )
+            )
+        return captured["model"]
+
+    @pytest.mark.asyncio
+    async def test_unpinned_uses_the_configured_local_model(self):
+        got = await self._resolved_model(
+            {"rag_provider": "local", "rag_local_model": "phi3:mini"}
+        )
+        assert got == "phi3:mini"
+
+    @pytest.mark.asyncio
+    async def test_unpinned_uses_the_configured_fireworks_model(self):
+        got = await self._resolved_model(
+            {
+                "rag_provider": "fireworks",
+                "fireworks_api_key": "fw-key",
+                "fireworks_chat_model": "accounts/fireworks/models/llama-v3p1-70b",
+            }
+        )
+        assert got == "accounts/fireworks/models/llama-v3p1-70b"
+
+    @pytest.mark.asyncio
+    async def test_a_pinned_model_overrides_the_configured_one(self):
+        """This is the trap the bubble avoids by sending no model."""
+        got = await self._resolved_model(
+            {"rag_provider": "local", "rag_local_model": "phi3:mini"},
+            model="qwen2.5:3b",
+        )
+        assert got == "qwen2.5:3b"

--- a/apps/pipeline/tests/unit/test_ask_supplied_context.py
+++ b/apps/pipeline/tests/unit/test_ask_supplied_context.py
@@ -110,3 +110,115 @@ class TestTranscriptPathUnchanged:
 
         mock_ret.assert_not_called()
         assert any("a-note-on-memory" in f for f in frames)
+
+
+class TestSuppliedSystemPrompt:
+    """#990: the docs caller needs its own instructions.
+
+    The stored ask_page_system prompt mandates [Episode Title, MM:SS]
+    citations. A documentation answer has no episode and no timestamp, and
+    the model emitted "[Context, N/A]" after every sentence -- found by
+    asking a real question through a real stack, not by a unit test.
+    """
+
+    async def _drain(self, gen):
+        return [frame async for frame in gen]
+
+    def _section(self):
+        return ContextSection(
+            title="Memory", source="guide", slug="19-inference-providers",
+            anchor="a-note-on-memory",
+            repo_path="docs/guide/19-inference-providers.md",
+            text="Whisper is unloaded before pyannote loads.",
+        )
+
+    def test_request_accepts_a_system_prompt(self):
+        req = AskRequest(question="q", system_prompt="DOCS")
+        assert req.system_prompt == "DOCS"
+
+    @pytest.mark.asyncio
+    async def test_supplied_prompt_is_used_instead_of_the_stored_one(self):
+        from app.api import ask as ask_mod
+
+        captured = {}
+
+        def _capture(question, passages, system_prompt=None, history=None):
+            captured["system_prompt"] = system_prompt
+            return [{"role": "system", "content": system_prompt or ""}]
+
+        async def _fake_stream(*args, **kwargs):
+            yield "x"
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value={}),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "get_prompt", return_value="STORED"),
+            patch.object(ask_mod, "stream_response", _fake_stream),
+            patch.object(ask_mod, "build_prompt_from_text", _capture),
+        ):
+            await self._drain(
+                ask_mod._stream_ask(
+                    "why?", None, None,
+                    context=[self._section()], system_prompt="DOCS",
+                )
+            )
+
+        assert captured["system_prompt"] == "DOCS"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_stored_prompt_when_none_supplied(self):
+        from app.api import ask as ask_mod
+
+        captured = {}
+
+        def _capture(question, passages, system_prompt=None, history=None):
+            captured["system_prompt"] = system_prompt
+            return [{"role": "system", "content": system_prompt or ""}]
+
+        async def _fake_stream(*args, **kwargs):
+            yield "x"
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value={}),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "get_prompt", return_value="STORED"),
+            patch.object(ask_mod, "stream_response", _fake_stream),
+            patch.object(ask_mod, "build_prompt_from_text", _capture),
+        ):
+            await self._drain(
+                ask_mod._stream_ask("why?", None, None, context=[self._section()])
+            )
+
+        assert captured["system_prompt"] == "STORED"
+
+    @pytest.mark.asyncio
+    async def test_transcript_path_ignores_a_supplied_prompt(self):
+        """The operator's stored prompt is not overridable per request."""
+        from app.api import ask as ask_mod
+
+        captured = {}
+
+        def _capture(question, chunks, system_prompt=None, history=None):
+            captured["system_prompt"] = system_prompt
+            return [{"role": "system", "content": system_prompt or ""}]
+
+        async def _fake_stream(*args, **kwargs):
+            yield "x"
+
+        with (
+            patch.object(ask_mod, "SessionLocal", return_value=MagicMock()),
+            patch.object(ask_mod, "get_runtime_inference_settings", return_value={}),
+            patch.object(ask_mod, "check_model_available", return_value=True),
+            patch.object(ask_mod, "get_prompt", return_value="STORED"),
+            patch.object(ask_mod, "retrieve_chunks", return_value=["chunk"]),
+            patch.object(ask_mod, "chunks_to_sources", return_value=[]),
+            patch.object(ask_mod, "stream_response", _fake_stream),
+            patch.object(ask_mod, "build_prompt", _capture),
+        ):
+            await self._drain(
+                ask_mod._stream_ask("q", None, None, system_prompt="ATTACKER")
+            )
+
+        assert captured["system_prompt"] == "STORED"

--- a/apps/web/src/app/api/docs/ask/route.ts
+++ b/apps/web/src/app/api/docs/ask/route.ts
@@ -7,6 +7,25 @@ import { PIPELINE_API } from "@/lib/pipeline";
 export const dynamic = "force-dynamic";
 
 /**
+ * Instructions for answering over documentation (#990).
+ *
+ * Sent explicitly rather than reusing the pipeline's stored
+ * `ask_page_system` prompt, which mandates transcript-style
+ * `[Episode Title, MM:SS]` citations. Documentation has neither, and the
+ * model dutifully appended "[Context, N/A]" to every claim. Citations are
+ * rendered as links from the `sources` event, so the model is told to leave
+ * them out of the prose entirely.
+ */
+const DOCS_SYSTEM_PROMPT = `You are answering questions about Podlog, a self-hosted podcast transcription and search app, using excerpts from its own documentation.
+
+RULES:
+- Answer ONLY from the provided documentation excerpts.
+- If the excerpts do not cover the question, say so plainly rather than guessing.
+- Do NOT add inline citations, source markers, or bracketed references of any kind. The interface shows the sources separately.
+- Format with Markdown: **bold** for emphasis, bullet lists for multiple points.
+- Be concise and direct.`;
+
+/**
  * POST /api/docs/ask — Ask over Podlog's own documentation (#990).
  *
  * Retrieval happens here because this is the only container with the docs
@@ -50,6 +69,7 @@ export async function POST(req: Request) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       question,
+      system_prompt: DOCS_SYSTEM_PROMPT,
       model: body.model,
       history: body.history,
       context: sections.map((s) => ({

--- a/apps/web/src/app/docs/DocsClient.tsx
+++ b/apps/web/src/app/docs/DocsClient.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { Search, X } from "lucide-react";
+import DocsAskBubble from "@/components/DocsAskBubble";
 import { slugifyHeading, makeUniqueSlugger } from "@/lib/docs-slug";
 import {
   searchIndex as searchDocs,
@@ -445,6 +446,9 @@ export default function DocsClient({ docs, searchIndex }: DocsClientProps) {
         </div>
       </aside>
       </div>
+      {/* #990: fixed to the viewport, so it sits outside the scrolling
+          content and stays reachable from any docs page. */}
+      <DocsAskBubble />
     </div>
   );
 }

--- a/apps/web/src/components/DocsAskBubble.tsx
+++ b/apps/web/src/components/DocsAskBubble.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * #990: Ask about Podlog's own documentation.
+ *
+ * Deliberately distinct from EpisodeChat, which asks about podcast
+ * transcripts. This one posts to /api/docs/ask, where retrieval happens
+ * over the guide, the reference docs and the design docs, and cites the
+ * exact section each answer came from.
+ *
+ * The streaming loop and open/closed structure follow EpisodeChat --
+ * including the `{"content": ...}` token frame shape the pipeline emits.
+ * Do not introduce a second parser for the same stream.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BookOpen, Loader2, Send, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { citationHref, citationSourceLabel } from "@/lib/docs-retrieval";
+import { DEFAULT_RAG_MODEL } from "@/lib/rag-models";
+
+type StreamStatus = "idle" | "connecting" | "streaming" | "error";
+
+/** Mirrors the pipeline's ContextSection, echoed back on the sources event. */
+interface DocSourceRef {
+  title: string;
+  source: string;
+  slug: string;
+  anchor: string | null;
+  repo_path: string;
+  text: string;
+}
+
+interface DocsMessage {
+  role: "user" | "assistant";
+  content: string;
+  /** Citations belong to the answer they produced, not to the panel: with a
+   *  single shared list, a follow-up would silently retitle the previous
+   *  answer's sources. */
+  sources?: DocSourceRef[];
+}
+
+// Mirrors the pipeline's MAX_HISTORY_MESSAGES.
+const MAX_HISTORY_MESSAGES = 8;
+
+export default function DocsAskBubble() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<DocsMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [status, setStatus] = useState<StreamStatus>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const isStreaming = status === "connecting" || status === "streaming";
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const q = input.trim();
+      if (!q) return;
+
+      setInput("");
+      setErrorMsg("");
+      setStatus("connecting");
+
+      const priorHistory = messages
+        .filter((m) => m.content.length > 0)
+        .slice(-MAX_HISTORY_MESSAGES)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: q },
+        { role: "assistant", content: "" },
+      ]);
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const resp = await fetch("/api/docs/ask", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: q,
+            model: DEFAULT_RAG_MODEL,
+            history: priorHistory,
+          }),
+          signal: controller.signal,
+        });
+
+        if (!resp.ok || !resp.body) {
+          setStatus("error");
+          setErrorMsg("Failed to reach the documentation service.");
+          return;
+        }
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          let currentEvent = "";
+          for (const line of lines) {
+            if (line.startsWith("event: ")) {
+              currentEvent = line.slice(7);
+            } else if (line.startsWith("data: ") && currentEvent) {
+              try {
+                const data = JSON.parse(line.slice(6));
+                if (currentEvent === "sources") {
+                  setStatus("streaming");
+                  setMessages((prev) => {
+                    const next = [...prev];
+                    next[next.length - 1] = {
+                      ...next[next.length - 1],
+                      sources: data as DocSourceRef[],
+                    };
+                    return next;
+                  });
+                } else if (currentEvent === "token") {
+                  setStatus("streaming");
+                  setMessages((prev) => {
+                    const next = [...prev];
+                    const last = next[next.length - 1];
+                    next[next.length - 1] = {
+                      ...last,
+                      content: last.content + data.content,
+                    };
+                    return next;
+                  });
+                } else if (currentEvent === "error") {
+                  setErrorMsg(data.message || "Unknown error");
+                  setStatus("error");
+                } else if (currentEvent === "done") {
+                  setStatus((s) => (s === "error" ? "error" : "idle"));
+                }
+              } catch {
+                // skip malformed JSON
+              }
+              currentEvent = "";
+            }
+          }
+        }
+
+        setStatus((s) => (s === "streaming" ? "idle" : s));
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setStatus("error");
+        setErrorMsg("Connection failed. Is the pipeline running?");
+      }
+    },
+    [input, messages],
+  );
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="fixed bottom-6 right-6 z-[60] flex items-center gap-2 rounded-full border bg-background px-4 py-3 shadow-lg transition-colors hover:bg-accent"
+        aria-label="Ask about the docs"
+      >
+        <BookOpen size={18} />
+        <span className="text-sm font-medium">Ask about the docs</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-6 right-6 z-[60] flex flex-col w-[calc(100vw-2rem)] sm:w-96 h-[min(28rem,calc(100vh-4rem))] rounded-xl border bg-background shadow-2xl">
+      <div className="flex items-center justify-between gap-2 px-4 py-3 border-b shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <BookOpen size={16} className="text-link shrink-0" />
+          <span className="text-sm font-medium truncate">Ask about the docs</span>
+        </div>
+        <button
+          onClick={() => setIsOpen(false)}
+          className="text-muted-foreground hover:text-foreground transition-colors p-1"
+          aria-label="Minimize"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+        {messages.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center mt-8">
+            Ask how Podlog works, or why it works the way it does. Answers come
+            from the user guide, the reference documentation and the design
+            documents.
+          </p>
+        )}
+
+        {messages.map((msg, i) => (
+          <div
+            key={i}
+            className={msg.role === "user" ? "text-right" : "text-left"}
+          >
+            <div
+              className={`inline-block max-w-full rounded-lg px-3 py-2 text-sm whitespace-pre-wrap text-left ${
+                msg.role === "user"
+                  ? "bg-accent"
+                  : "bg-muted"
+              }`}
+            >
+              {msg.content}
+              {msg.role === "assistant" &&
+                !msg.content &&
+                isStreaming &&
+                i === messages.length - 1 && (
+                  <Loader2 size={14} className="animate-spin" />
+                )}
+            </div>
+            {msg.sources && msg.sources.length > 0 && (
+              <ul className="mt-2 space-y-1 text-xs text-left">
+                {msg.sources.map((s) => (
+                  <li key={`${s.repo_path}#${s.anchor ?? ""}`}>
+                    <a
+                      href={citationHref(s.source, s.slug, s.anchor, s.repo_path)}
+                      className="text-link hover:underline"
+                      {...(s.source === "guide"
+                        ? {}
+                        : { target: "_blank", rel: "noreferrer" })}
+                    >
+                      {s.title}
+                    </a>
+                    <span className="ml-1 text-muted-foreground">
+                      {citationSourceLabel(s.source)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+
+        {status === "error" && errorMsg && (
+          <div className="text-xs text-destructive bg-destructive/10 rounded-md px-3 py-2">
+            {errorMsg}
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex gap-2 px-4 py-3 border-t shrink-0">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask a question about Podlog..."
+          className="flex-1 px-3 py-2 text-sm border border-input rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring"
+          disabled={isStreaming}
+          autoFocus
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!input.trim() || isStreaming}
+          className="px-3"
+          aria-label="Send"
+        >
+          {isStreaming ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/DocsAskBubble.tsx
+++ b/apps/web/src/components/DocsAskBubble.tsx
@@ -17,7 +17,6 @@ import { BookOpen, Loader2, Send, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { citationHref, citationSourceLabel } from "@/lib/docs-retrieval";
-import { DEFAULT_RAG_MODEL } from "@/lib/rag-models";
 
 type StreamStatus = "idle" | "connecting" | "streaming" | "error";
 
@@ -89,9 +88,13 @@ export default function DocsAskBubble() {
         const resp = await fetch("/api/docs/ask", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          // No `model` on purpose (#990). The pipeline resolves it from
+          // Settings: rag_provider chooses local vs Fireworks, then
+          // rag_local_model / fireworks_chat_model chooses the model. Pinning
+          // one here would win over `model or runtime.get("rag_local_model")`
+          // in api/ask.py and silently ignore the configured local model.
           body: JSON.stringify({
             question: q,
-            model: DEFAULT_RAG_MODEL,
             history: priorHistory,
           }),
           signal: controller.signal,

--- a/apps/web/src/lib/docs-retrieval.ts
+++ b/apps/web/src/lib/docs-retrieval.ts
@@ -102,3 +102,32 @@ export function selectSections(
   }
   return out;
 }
+
+const REPO_BLOB_BASE_URL = "https://github.com/brlauuu/podlog/blob/main";
+
+/**
+ * Where a cited section lives (#990).
+ *
+ * Guide pages are rendered at /docs and get a deep link to the exact
+ * heading. PRDs and reference docs have no rendered surface in the app, so
+ * they cite to the repository instead -- the same convention DocsClient
+ * already uses for links that leave the rendered guide.
+ */
+export function citationHref(
+  source: string,
+  slug: string,
+  anchor: string | null,
+  repoPath: string,
+): string {
+  if (source === "guide") {
+    return `/docs?page=${encodeURIComponent(slug)}${anchor ? `#${anchor}` : ""}`;
+  }
+  return `${REPO_BLOB_BASE_URL}/${repoPath}`;
+}
+
+/** Human label for where a citation came from. */
+export function citationSourceLabel(source: string): string {
+  if (source === "guide") return "guide";
+  if (source === "prd") return "design doc";
+  return "reference";
+}

--- a/apps/web/src/lib/docs-retrieval.ts
+++ b/apps/web/src/lib/docs-retrieval.ts
@@ -8,9 +8,16 @@ export const MAX_SECTIONS = 8;
  *
  * The smallest supported local model is qwen2.5:3b at 8192 context
  * (rag.py::MODEL_NUM_CTX), shared with the system prompt and the
- * conversation history, so 4000 leaves room for both.
+ * conversation history, so this leaves room for both.
+ *
+ * Lowered from 4000 for latency, not for context: on a CPU-only host,
+ * generation time grows with the prompt (~108s at 1000 tokens, ~164s at
+ * 2500, same num_ctx), and every second here is a second the reader waits
+ * for the first token. 2500 keeps answers well-sourced -- the 8-section cap
+ * usually binds first -- without paying for passages that rarely change the
+ * answer. rag.py's read timeout was raised to 300s in the same change.
  */
-export const MAX_CONTEXT_TOKENS = 4000;
+export const MAX_CONTEXT_TOKENS = 2500;
 
 const CHARS_PER_TOKEN = 4;
 
@@ -41,15 +48,61 @@ function terms(question: string): string[] {
 const TITLE_WEIGHT = 3;
 const CONTENT_WEIGHT = 1;
 
-function scoreSection(section: DocSection, qTerms: string[]): number {
+/**
+ * How much one term is worth, by how rare it is in the corpus.
+ *
+ * Without this, every term counts the same, and a question like "why is
+ * there no authentication on the pipeline API?" is decided by "pipeline"
+ * and "api" -- which appear in most of the corpus -- while
+ * "authentication", the one term that actually identifies the answer, is
+ * outvoted. Asked against the real corpus, that question returned eight
+ * sections about pipeline stages and Dockerfiles and missed the Security
+ * model section entirely.
+ *
+ * Standard inverse document frequency, smoothed so a term present in every
+ * section still scores slightly above zero rather than being discarded.
+ */
+function idfWeights(index: DocSection[], qTerms: string[]): Map<string, number> {
+  const weights = new Map<string, number>();
+  for (const t of qTerms) {
+    let df = 0;
+    for (const section of index) {
+      if (
+        section.sectionTitle.toLowerCase().includes(t) ||
+        section.content.toLowerCase().includes(t)
+      ) {
+        df += 1;
+      }
+    }
+    weights.set(t, Math.log((index.length + 1) / (df + 1)) + 1);
+  }
+  return weights;
+}
+
+function scoreSection(
+  section: DocSection,
+  qTerms: string[],
+  idf: Map<string, number>,
+): number {
   const title = section.sectionTitle.toLowerCase();
   const body = section.content.toLowerCase();
   let score = 0;
+  let matched = 0;
   for (const t of qTerms) {
-    if (title.includes(t)) score += TITLE_WEIGHT;
-    if (body.includes(t)) score += CONTENT_WEIGHT;
+    const w = idf.get(t) ?? 1;
+    const inTitle = title.includes(t);
+    const inBody = body.includes(t);
+    if (inTitle) score += TITLE_WEIGHT * w;
+    if (inBody) score += CONTENT_WEIGHT * w;
+    if (inTitle || inBody) matched += 1;
   }
-  return score;
+  // Scale by how much of the question a section actually covers. IDF alone
+  // is not enough: "why is there no authentication on the pipeline API?"
+  // put eight sections titled after "pipeline" or "API" above the Security
+  // model section, which was the only one matching all three terms -- it
+  // landed at rank 8, one place outside the cutoff. Covering the whole
+  // question is a better signal than matching one word of it loudly.
+  return score * (matched / qTerms.length);
 }
 
 /**
@@ -76,8 +129,9 @@ export function selectSections(
   const qTerms = terms(question);
   if (qTerms.length === 0 || index.length === 0) return [];
 
+  const idf = idfWeights(index, qTerms);
   const scored = index
-    .map((section) => ({ section, score: scoreSection(section, qTerms) }))
+    .map((section) => ({ section, score: scoreSection(section, qTerms, idf) }))
     .filter((s) => s.score > 0)
     .sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;

--- a/apps/web/tests/unit/docs-ask-bubble.test.tsx
+++ b/apps/web/tests/unit/docs-ask-bubble.test.tsx
@@ -115,6 +115,22 @@ describe("DocsAskBubble (#990)", () => {
     expect(JSON.parse(init.body as string).question).toBe("how do I add a feed?");
   });
 
+  it("does not pin a model, so Settings decides the provider and model", async () => {
+    // The pipeline resolves: rag_provider picks local vs Fireworks, then
+    // rag_local_model / fireworks_chat_model picks the model. Sending a
+    // model here wins over `model or runtime.get("rag_local_model")` in
+    // api/ask.py, silently ignoring the operator's configured local model.
+    mockAsk(`event: done\ndata: {}\n\n`);
+
+    render(<DocsAskBubble />);
+    openAndAsk("anything");
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sent = JSON.parse(init.body as string);
+    expect(sent.model).toBeUndefined();
+  });
+
   it("deep-links a guide citation to its heading", async () => {
     mockAsk(
       `event: sources\ndata: [{"title":"A note on memory","source":"guide","slug":"19-inference-providers","anchor":"a-note-on-memory","repo_path":"docs/guide/19-inference-providers.md","text":"..."}]\n\n` +

--- a/apps/web/tests/unit/docs-ask-bubble.test.tsx
+++ b/apps/web/tests/unit/docs-ask-bubble.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * #990: the docs Ask bubble.
+ *
+ * Two things follow existing house patterns rather than being invented here:
+ *
+ * - The fake `getReader` response shape, from episode-chat-streaming.test.tsx.
+ *   jsdom has no `Response`, and a real one cannot be streamed anyway.
+ * - Unrecognised URLs are recorded and asserted in afterEach, not thrown.
+ *   The component wraps its fetch in try/catch, so a throw inside the mock
+ *   surfaces as a generic "Connection failed" and hides the real cause (#895).
+ *
+ * Note the token frames use `{"content": ...}` -- the shape the pipeline
+ * actually emits (app/api/ask.py::_stream_ask). A fixture using `text` would
+ * pass against a component reading the wrong field and fail against the real
+ * stream.
+ *
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import DocsAskBubble from "@/components/DocsAskBubble";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+let unmockedUrls: string[] = [];
+
+function streamResponse(sse: string) {
+  const chunks = [new TextEncoder().encode(sse)];
+  let i = 0;
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { done: false, value: chunks[i++] }
+            : { done: true, value: undefined },
+      }),
+    },
+  };
+}
+
+/** Queue one SSE stream per call, in order. */
+function mockAsk(...streams: string[]) {
+  let n = 0;
+  mockFetch.mockImplementation((url: string) => {
+    if (url === "/api/docs/ask") {
+      const sse = streams[Math.min(n, streams.length - 1)];
+      n += 1;
+      return Promise.resolve(streamResponse(sse));
+    }
+    unmockedUrls.push(url);
+    return Promise.resolve({ ok: false, status: 404 });
+  });
+}
+
+function send(question: string) {
+  fireEvent.change(screen.getByPlaceholderText(/ask a question/i), {
+    target: { value: question },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+}
+
+function openAndAsk(question: string) {
+  fireEvent.click(screen.getByRole("button", { name: /ask about the docs/i }));
+  send(question);
+}
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+beforeEach(() => {
+  unmockedUrls = [];
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  expect(unmockedUrls).toEqual([]);
+});
+
+describe("DocsAskBubble (#990)", () => {
+  it("is collapsed until opened", () => {
+    render(<DocsAskBubble />);
+    expect(screen.getByRole("button", { name: /ask about the docs/i })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/ask a question/i)).toBeNull();
+  });
+
+  it("streams an answer and shows it", async () => {
+    mockAsk(
+      `event: token\ndata: {"content":"Whisper "}\n\n` +
+      `event: token\ndata: {"content":"is unloaded."}\n\n` +
+      `event: done\ndata: {}\n\n`,
+    );
+
+    render(<DocsAskBubble />);
+    openAndAsk("why is Whisper unloaded?");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Whisper is unloaded\./)).toBeInTheDocument(),
+    );
+  });
+
+  it("sends the question to the docs endpoint, not the transcript one", async () => {
+    mockAsk(`event: done\ndata: {}\n\n`);
+
+    render(<DocsAskBubble />);
+    openAndAsk("how do I add a feed?");
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/docs/ask");
+    expect(JSON.parse(init.body as string).question).toBe("how do I add a feed?");
+  });
+
+  it("deep-links a guide citation to its heading", async () => {
+    mockAsk(
+      `event: sources\ndata: [{"title":"A note on memory","source":"guide","slug":"19-inference-providers","anchor":"a-note-on-memory","repo_path":"docs/guide/19-inference-providers.md","text":"..."}]\n\n` +
+      `event: done\ndata: {}\n\n`,
+    );
+
+    render(<DocsAskBubble />);
+    openAndAsk("memory");
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /A note on memory/ })).toHaveAttribute(
+        "href",
+        "/docs?page=19-inference-providers#a-note-on-memory",
+      );
+    });
+  });
+
+  it("links a PRD citation to the repository, since PRDs are not rendered", async () => {
+    mockAsk(
+      `event: sources\ndata: [{"title":"Memory","source":"prd","slug":"PRD-01-ingestion-pipeline","anchor":null,"repo_path":"prds/PRD-01-ingestion-pipeline.md","text":"..."}]\n\n` +
+      `event: done\ndata: {}\n\n`,
+    );
+
+    render(<DocsAskBubble />);
+    openAndAsk("memory");
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /Memory/ });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://github.com/brlauuu/podlog/blob/main/prds/PRD-01-ingestion-pipeline.md",
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+  });
+
+  it("shows the error text when the stream reports one", async () => {
+    mockAsk(
+      `event: error\ndata: {"message":"No documentation matched your question."}\n\n` +
+      `event: done\ndata: {}\n\n`,
+    );
+
+    render(<DocsAskBubble />);
+    openAndAsk("zzzz");
+
+    await waitFor(() =>
+      expect(screen.getByText(/No documentation matched/)).toBeInTheDocument(),
+    );
+  });
+
+  it("keeps each answer's citations with that answer across turns", async () => {
+    // A single panel-level `sources` list would move the first answer's
+    // citations onto the second, silently misattributing them.
+    mockAsk(
+      `event: sources\ndata: [{"title":"First Source","source":"guide","slug":"03-feeds","anchor":"adding","repo_path":"docs/guide/03-feeds.md","text":"..."}]\n\n` +
+      `event: token\ndata: {"content":"one"}\n\n` +
+      `event: done\ndata: {}\n\n`,
+      `event: sources\ndata: [{"title":"Second Source","source":"guide","slug":"04-search","anchor":"basics","repo_path":"docs/guide/04-search.md","text":"..."}]\n\n` +
+      `event: token\ndata: {"content":"two"}\n\n` +
+      `event: done\ndata: {}\n\n`,
+    );
+
+    render(<DocsAskBubble />);
+    openAndAsk("first question");
+    await waitFor(() => expect(screen.getByText("one")).toBeInTheDocument());
+
+    send("second question");
+    await waitFor(() => expect(screen.getByText("two")).toBeInTheDocument());
+
+    expect(screen.getByRole("link", { name: /First Source/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Second Source/ })).toBeInTheDocument();
+  });
+
+  it("reports a failed connection rather than sitting silent", async () => {
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, status: 502 }));
+
+    render(<DocsAskBubble />);
+    openAndAsk("anything");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to reach the documentation service/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/tests/unit/docs-ask-route.test.ts
+++ b/apps/web/tests/unit/docs-ask-route.test.ts
@@ -43,6 +43,21 @@ describe("POST /api/docs/ask (#990)", () => {
     expect(sent.context[0].text).toContain("Whisper is unloaded");
   });
 
+  it("sends documentation instructions, not the transcript prompt", async () => {
+    // The pipeline's stored ask_page_system prompt mandates
+    // [Episode Title, MM:SS] citations; docs have neither, and the model
+    // emitted "[Context, N/A]" after every claim until this was sent.
+    const fetchMock = jest.fn(async () => new Response("data: {}\n\n", { status: 200 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await POST(req({ question: "why is Whisper unloaded before pyannote?" }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent.system_prompt).toContain("Podlog");
+    expect(sent.system_prompt).toMatch(/do not add inline citations/i);
+  });
+
   it("answers 400 for a missing question rather than calling the pipeline", async () => {
     const fetchMock = jest.fn();
     global.fetch = fetchMock as unknown as typeof fetch;

--- a/apps/web/tests/unit/docs-retrieval.test.ts
+++ b/apps/web/tests/unit/docs-retrieval.test.ts
@@ -156,3 +156,56 @@ describe("against the real corpus (#990)", () => {
     expect(worst).toBeLessThan(4096);
   });
 });
+
+describe("scoring: rare terms and question coverage (#990)", () => {
+  // Both behaviours below were added after retrieval was probed against the
+  // real 485-section corpus. "why is there no authentication on the pipeline
+  // API?" returned eight sections about pipeline stages and Dockerfiles and
+  // missed the Security model section, which is the answer.
+
+  function sec(
+    docSlug: string,
+    sectionTitle: string,
+    content: string,
+  ): DocSection {
+    return {
+      docSlug,
+      docTitle: docSlug,
+      sectionId: sectionTitle.toLowerCase().replace(/\s+/g, "-"),
+      sectionTitle,
+      level: 2,
+      source: "guide",
+      repoPath: `docs/guide/${docSlug}.md`,
+      content,
+    };
+  }
+
+  it("prefers the section holding the rare term over one titled for a common one", () => {
+    const index: DocSection[] = [
+      // "pipeline" is everywhere; only one section mentions "authentication".
+      ...Array.from({ length: 20 }, (_, i) =>
+        sec(`common-${i}`, "The pipeline", "pipeline pipeline details"),
+      ),
+      sec("security", "Security model", "There is no authentication on the pipeline."),
+    ];
+
+    const got = selectSections("why is there no authentication on the pipeline?", index, {
+      maxSections: 1,
+    });
+    expect(got[0].sectionTitle).toBe("Security model");
+  });
+
+  it("prefers a section covering the whole question over one matching a single term loudly", () => {
+    const index: DocSection[] = [
+      // Matches one term, but in the title, three times over.
+      sec("loud", "backup backup backup", "backup"),
+      // Matches every term, only in the body.
+      sec("complete", "Restoring", "To restore a backup, decrypt the archive first."),
+    ];
+
+    const got = selectSections("how do I restore a backup archive?", index, {
+      maxSections: 1,
+    });
+    expect(got[0].docSlug).toBe("complete");
+  });
+});

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -38,9 +38,11 @@ It is separate from [Ask AI](12-rag-search.md), which searches your podcast
 transcripts. This one never looks at your episodes; that one never looks at the
 documentation.
 
-It uses the same local model as Ask AI, so it works on a local-only install. Only
-the handful of sections relevant to your question are sent to the model, not the
-whole manual.
+It uses the same provider and model as [Ask AI](12-rag-search.md) — whatever you
+have set under **Settings → Inference**. Switching that between local inference
+and Fireworks switches this too; there is no separate setting to keep in step.
+Only the handful of sections relevant to your question are sent to the model, not
+the whole manual, so it works on a local-only install.
 
 ## Quick Start
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -26,6 +26,22 @@ Everything runs in Docker on your own machine. **In the default configuration no
 18. [Keyboard Shortcuts](18-keyboard-shortcuts.md) — `J`/`K` episode nav, `/` focus search, `Space` / arrows for playback, `?` help overlay
 19. [Inference Providers](19-inference-providers.md) — Local vs remote choices for transcription + diarization, decision matrix, and providers we evaluated but didn't ship
 
+## Ask about the docs
+
+Every page of this guide has an **Ask about the docs** bubble in the bottom
+corner of the web app. It answers questions about Podlog itself — how to
+configure something, or why it works the way it does — drawing on this guide,
+the reference documentation and the design documents, and it links to the exact
+section each answer came from.
+
+It is separate from [Ask AI](12-rag-search.md), which searches your podcast
+transcripts. This one never looks at your episodes; that one never looks at the
+documentation.
+
+It uses the same local model as Ask AI, so it works on a local-only install. Only
+the handful of sections relevant to your question are sent to the model, not the
+whole manual.
+
 ## Quick Start
 
 If you just want to get running, head to [Installation](01-installation.md).


### PR DESCRIPTION
Task 5, the last of `docs/superpowers/plans/2026-08-26-docs-ask-bubble.md`. Completes #990.

## Summary

A bubble on every `/docs` page that answers questions about Podlog itself and cites the exact section each answer came from. Guide sections deep-link to the heading; PRDs and reference docs link to the repository, since neither has a rendered surface in the app.

Streaming follows `EpisodeChat` rather than introducing a second SSE parser.

## Two deliberate deviations from the plan

- **The plan's test fixtures used `{"text": ...}` token frames.** The pipeline emits `{"content": ...}`. Written to the real shape — and a mutant restoring the plan's version fails two tests, which is exactly what that fixture would have shipped.
- **Citations attach to the message that produced them**, not to one panel-level list. With a shared list, a follow-up silently relabels the previous answer's sources. There is a test for that.

## What only a real stack could find

The bubble was complete and green at this point. Then I rebuilt `web` and `pipeline` and asked real questions, which surfaced three defects no unit test could have:

**1. Answers were littered with `[Context, N/A]`.** The supplied-context path reused the stored `ask_page_system` prompt, which mandates `[Episode Title, MM:SS]` citations. `/api/ask` now accepts a `system_prompt`, used *only* on that path — the transcript path keeps the operator's stored prompt and is not overridable per request, with a test asserting that.

**2. "why is there no authentication on the pipeline API?" missed the Security model section entirely**, returning eight sections titled after "pipeline" or "API". Scoring now weights terms by inverse document frequency and scales by how much of the question a section covers. Security model went from **rank 8** — one place outside the cutoff — to **rank 0**, with the other probe questions holding or improving. Both changes have tests that fail against a mutant removing them.

**3. Questions timed out at exactly 120s.** The read timeout is the wait for the *first* token, dominated on CPU by prefill over `num_ctx`, not by prompt length. Raised to 300s, and the docs context budget lowered to 2500 tokens for latency.

## A measurement I got wrong

My first timing of point 3 was invalid, and none of the numbers above rest on it. I timed Ollama without passing `num_ctx`, so it fell back to a 2048 window and silently truncated the prompt — I was measuring a much shorter prompt than I thought, and concluded that shrinking the context budget would fix the timeouts. It did not; the rebuilt stack still timed out at exactly 120s, which is what exposed the error. Re-measured with the `num_ctx` `rag.py` actually sends: **~108s at 1000 tokens, ~164s at 2500**. The real constraint is prefill, so the fix is the timeout, not the budget.

## Verification

- 8 bubble tests, 17 retrieval tests, 7 route tests, 11 pipeline context tests. Pipeline suite 1050 → 1054.
- Guards mutation-tested: token field, per-message citations, guide-vs-repo links, IDF, coverage — each mutant broke exactly its own test.
- End to end on a rebuilt stack: the auth question now returns Security model as its top source and a correct, grounded answer.

**Note for the running stack:** on this CPU-only host that answer took ~310s end to end. That is qwen2.5:3b at `num_ctx=8192`, not something this change introduced — but it is worth knowing the bubble is slow locally, and fast on Fireworks.

## Docs

`docs/guide/README.md` gains an "Ask about the docs" section explaining what it draws on and how it differs from Ask AI. CHANGELOG entries for the feature and the timeout change.

`make ci-local`: all checks pass.

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin