### PR TITLE
fix(mobile): let the queue tables scroll instead of clipping (#989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- The queue's episode tables now scroll sideways when they are wider than the screen, instead of quietly cutting off the right-hand columns with no way to reach them. ([#989](https://github.com/brlauuu/podlog/issues/989))
+
 ### Minor changes
 - The navigation bar now collapses behind a menu button on a phone. Eight links in one row wrapped to four rows on a narrow screen, and because the bar is pinned to the top that cost about a fifth of the screen on every page. Menu entries are also sized for a fingertip rather than a mouse pointer.
 - Several pages no longer scroll sideways on a phone: the home screen buttons, the Ask model selector, the queue's stage bar and summary line, the Settings tabs, and long web addresses in the release notes and Telegram setup instructions. ([#989](https://github.com/brlauuu/podlog/issues/989))

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -351,8 +351,13 @@ export default function QueueStatus() {
         </div>
       )}
 
+      {/* #989: overflow-x-auto, not overflow-hidden, on both table wrappers.
+          The hidden was for the rounded corners, but it also meant a table too
+          wide for its box lost the right-hand columns with no scrollbar to get
+          them back -- and a clipped table does not widen the page, so the
+          horizontal-scroll check could not see it either. */}
       {filtered.length > 0 && (
-        <div className="rounded-lg border border-border overflow-hidden">
+        <div className="rounded-lg border border-border overflow-x-auto overflow-y-hidden">
           <table className="w-full">
             <TableHeader />
             <tbody>
@@ -381,7 +386,7 @@ export default function QueueStatus() {
             {effectiveShowDone ? "▴" : "▾"}
           </button>
           {effectiveShowDone && filteredDone.length > 0 && (
-            <div className="mt-2 rounded-lg border border-border overflow-hidden">
+            <div className="mt-2 rounded-lg border border-border overflow-x-auto overflow-y-hidden">
               <table className="w-full">
                 <TableHeader />
                 <tbody>

--- a/apps/web/tests/e2e/mobile-layout.spec.ts
+++ b/apps/web/tests/e2e/mobile-layout.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "@playwright/test";
+import type { Pool } from "pg";
+import { getFixturePool, seedEpisode, type SeededEpisode } from "./fixtures/db";
 
 /**
  * Mobile layout guards (#989).
@@ -24,6 +26,29 @@ import { test, expect } from "@playwright/test";
  * jsdom has no layout engine, so a real browser is the only way to measure
  * this at all, and the fast PR workflow is deliberately kept fast.
  */
+
+// One seeded episode, so the queue's tables actually render. Without it the
+// completed list is empty, no <table> exists, and the clipping check below
+// passes by measuring nothing -- which is the failure mode it exists to
+// prevent. A deliberately long title, because the whole question is what
+// happens when a cell is wider than a phone.
+let pool: Pool | null = null;
+let seeded: SeededEpisode | null = null;
+
+test.beforeAll(async () => {
+  pool = getFixturePool();
+  if (!pool) return;
+  seeded = await seedEpisode(pool, {
+    title:
+      "A deliberately very long seeded episode title, used to push the queue table past the width of a phone screen",
+    feedTitle: "Mobile layout fixture feed with a long name too",
+  });
+});
+
+test.afterAll(async () => {
+  await seeded?.cleanup();
+  await pool?.end();
+});
 
 const VIEWPORTS = [
   { name: "iPhone 14 (390px)", width: 390, height: 844 },
@@ -103,6 +128,68 @@ for (const vp of VIEWPORTS) {
         ).toBeLessThanOrEqual(clientWidth + 1);
       });
     }
+
+    test("no table is silently clipped instead of scrolling", async ({ page }) => {
+      // #989: a table that outgrows its box should scroll, not vanish. The
+      // queue's two tables sat in `overflow-hidden` wrappers (there for the
+      // rounded corners), so once the columns stopped fitting the right-hand
+      // ones were cut off with no scrollbar and nothing to reveal them --
+      // invisible to the horizontal-scroll check above, because a clipped
+      // element does not widen the page.
+      //
+      // This asserts the structure rather than a width: any table whose
+      // content can overflow must sit inside something scrollable. That way
+      // it holds for data we have not seen, which is the case that matters --
+      // a long episode title on someone else's install.
+      // Every page holding a <table>: two on /queue, one on /meta-analysis.
+      const clipped: string[] = [];
+      let tablesSeen = 0;
+
+      for (const path of ["/queue", "/meta-analysis"]) {
+      await page.goto(path);
+      await page.locator("nav").first().waitFor();
+      await page.waitForLoadState("networkidle");
+
+      // The queue tables only render when there are rows; expand the
+      // completed list so this measures something.
+      const showDone = page.getByRole("button", { name: /Show \d+ completed/ });
+      if (await showDone.count()) {
+        await showDone.first().click();
+        await page.waitForTimeout(1000);
+      }
+
+      tablesSeen += await page.locator("table").count();
+      clipped.push(...await page.evaluate(() => {
+        const bad: string[] = [];
+        document.querySelectorAll("table").forEach((t) => {
+          let el: HTMLElement | null = t.parentElement;
+          while (el && el !== document.body) {
+            const ox = getComputedStyle(el).overflowX;
+            if (ox === "hidden") {
+              bad.push(`table in <${el.tagName.toLowerCase()} class="${el.className}">`);
+              return;
+            }
+            if (ox === "auto" || ox === "scroll") return; // scrollable: fine
+            el = el.parentElement;
+          }
+        });
+        return bad;
+      }));
+      }
+
+      // Without this the whole check passes on a page that rendered no
+      // tables at all -- which is exactly what /queue does when the queue is
+      // empty and the completed list is collapsed.
+      expect(
+        tablesSeen,
+        "no tables were rendered, so nothing was checked " +
+          "(set DATABASE_URL so the fixture episode can be seeded)",
+      ).toBeGreaterThan(0);
+      expect(
+        clipped,
+        "these tables would be cut off rather than scroll once their columns stop fitting",
+      ).toEqual([]);
+    });
 
     test("the sticky navbar does not eat the viewport", async ({ page }) => {
       await page.goto("/search");


### PR DESCRIPTION
Second pass of #989. Follows #1008 (navbar + page overflow).

## Measuring first changed what the work was

The issue expected the three `<table>` instances to force horizontal page scroll. **They don't.** Measured at 390px and 360px against real data:

| Table | State |
|---|---|
| `QueueStatus` ×2 | already hide Podcast and Retries under `sm:`, and fit *exactly* — `scrollWidth == clientWidth` |
| `ProviderTimingChart` | already sits in an `overflow-x-auto` box |

So there was no page-scroll bug to fix here.

## The real defect is the opposite failure mode

Both queue tables sat in `overflow-hidden` wrappers — there for the rounded corners. A table too wide for its box therefore loses its right-hand columns **silently**: no scrollbar, no way to reach them.

Reproduced at 280px: 272px of table in a 246px box. That's narrower than any mainstream phone, so this is not a live bug on target devices — but it is the behaviour on any install whose data is wider than mine, and a long episode title is not exotic.

Crucially, **a clipped table doesn't widen the page**, so the horizontal-scroll check from #1008 could never have caught this. Different failure, different detector.

## The guard

It asserts *structure*, not a width: any table whose content can overflow must sit inside something scrollable. That holds for data nobody has seen yet, which is the case that matters.

Two things it needed before it was worth having:

- **It visits `/meta-analysis` too**, not just the two tables on `/queue` I happened to start with.
- **It fails when no tables rendered at all.** Not hypothetical: on the empty CI database the queue renders no table, and the check passed by measuring nothing. It now seeds an episode with a deliberately long title — the whole question being what happens when a cell is wider than the screen.

## Verification

- 40 passed in the real `web_test` image; 24 locally against production data.
- Mutant (`overflow-x-auto` → `overflow-hidden`): 2 fail.
- Mutant (skip both pages): fails with "no tables were rendered, so nothing was checked".

I also broke the build mid-change by putting a JSX comment in an invalid position, and my `tsc=$?` read `head`'s exit status rather than tsc's — so the first check reported clean while 5 syntax errors stood. Caught when 19 e2e tests suddenly failed to render.

## Still to do on #989

Meta-analysis at 390px (Plotly sizing, legends, `max-w-7xl`), the audio player, and a touch-target sweep beyond the nav.

`make ci-local`: all checks pass.

Refs #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin