### PR TITLE
fix(mobile): finger-sized tap targets on the navbar and shared buttons (#989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Fixes
+- Buttons are easier to hit on a phone. The dark-mode switch in particular only responded to a tap on the small bulb icon itself; it now has a proper finger-sized area, and shared buttons across the app get the same treatment on narrow screens. Nothing changes on a desktop. ([#989](https://github.com/brlauuu/podlog/issues/989))
+
+### Fixes
 - The queue's episode tables now scroll sideways when they are wider than the screen, instead of quietly cutting off the right-hand columns with no way to reach them. ([#989](https://github.com/brlauuu/podlog/issues/989))
 
 ### Minor changes

--- a/apps/web/src/components/DarkModeToggle.tsx
+++ b/apps/web/src/components/DarkModeToggle.tsx
@@ -30,16 +30,20 @@ export default function DarkModeToggle() {
     localStorage.setItem(STORAGE_KEY, next ? "dark" : "light");
   }
 
-  // Prevent flash of wrong icon on SSR
+  // Prevent flash of wrong icon on SSR. Reserves the same box as the real
+  // control so the navbar does not shift when it mounts.
   if (!mounted) {
-    return <div className="w-[18px] h-[18px]" />;
+    return <div className="h-11 w-11" />;
   }
 
   return (
     <button
       onClick={toggle}
       aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
-      className="hover:scale-[1.15] active:scale-95 transition-transform duration-200"
+      // #989: the tap area was the 18px image itself. The icon stays 18px --
+      // this only grows the area a finger has to hit, to the 44px iOS and
+      // Android both ask for.
+      className="inline-flex h-11 w-11 items-center justify-center rounded-md hover:scale-[1.15] active:scale-95 transition-transform duration-200"
     >
       <Image
         src={dark ? "/imgs/lightbulb-on.png" : "/imgs/lightbulb-off.png"}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,7 +5,12 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // #989: max-md:min-h-11 gives every shadcn Button a 44px tap area on phones
+  // without changing a single pixel at desktop widths, where the h-9/h-10
+  // sizes below are right. NOTE: this line does not exist upstream -- if this
+  // file is ever re-copied from shadcn, it comes back out, the same way the
+  // dropdown token fix did in #848.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium max-md:min-h-11 ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/web/tests/e2e/mobile-layout.spec.ts
+++ b/apps/web/tests/e2e/mobile-layout.spec.ts
@@ -129,6 +129,50 @@ for (const vp of VIEWPORTS) {
       });
     }
 
+    test("navbar controls are big enough to tap", async ({ page }) => {
+      // #989: 44px is what iOS and Android both ask for. Scoped to the navbar
+      // deliberately -- it is the chrome present on every page, and it is
+      // where the dark-mode toggle sat at 18px.
+      //
+      // NOT applied site-wide on purpose: /about renders the changelog, which
+      // is ~480 inline prose links. A blanket rule would fail there forever
+      // and be silenced, which is worse than not having it. The rest of the
+      // sweep is tracked on the issue rather than pretended at here.
+      await page.goto("/search");
+      await page.locator("nav").first().waitFor();
+      // Wait for hydration. Before it, DarkModeToggle is an SSR placeholder
+      // <div>, not a <button> -- so this check found only the menu button and
+      // passed while the 18px toggle it was written for was not even present.
+      await page.getByRole("button", { name: /switch to (light|dark) mode/i }).waitFor();
+
+      const tooSmall = await page.evaluate(() => {
+        const nav = document.querySelector("nav")!;
+        const bad: string[] = [];
+        nav.querySelectorAll("button").forEach((el) => {
+          const r = el.getBoundingClientRect();
+          if (r.width === 0 || r.height === 0) return; // not shown at this width
+          if (r.height < 44) {
+            bad.push(
+              `${el.getAttribute("aria-label") || el.textContent?.trim() || "<button>"} = ${Math.round(r.height)}px`,
+            );
+          }
+        });
+        return bad;
+      });
+      const measured = await page.evaluate(() => {
+        let n = 0;
+        document.querySelector("nav")!.querySelectorAll("button").forEach((el) => {
+          const r = el.getBoundingClientRect();
+          if (r.width > 0 && r.height > 0) n += 1;
+        });
+        return n;
+      });
+
+      // Both the menu button and the dark-mode toggle must have been measured.
+      expect(measured, "fewer navbar buttons than expected were measured").toBeGreaterThanOrEqual(2);
+      expect(tooSmall, "navbar controls smaller than a fingertip").toEqual([]);
+    });
+
     test("no table is silently clipped instead of scrolling", async ({ page }) => {
       // #989: a table that outgrows its box should scroll, not vanish. The
       // queue's two tables sat in `overflow-hidden` wrappers (there for the

--- a/apps/web/tests/unit/button-touch-target.test.tsx
+++ b/apps/web/tests/unit/button-touch-target.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * #989: every shadcn Button gets a 44px minimum tap area below md:, while
+ * desktop keeps the h-9 / h-10 sizes it was designed with.
+ *
+ * This is a class-string assertion because jsdom applies no CSS and has no
+ * layout engine -- it cannot measure a rendered height. What it really
+ * guards is the re-copy hazard: `max-md:min-h-11` is not in upstream
+ * shadcn, so pasting a fresh copy of button.tsx silently removes it, which
+ * is exactly how the dropdown token fix was lost in #848. Whether the
+ * result is actually 44px on a phone is measured in a real browser by
+ * tests/e2e/mobile-layout.spec.ts.
+ */
+describe("Button touch target (#989)", () => {
+  it.each(["default", "sm", "lg", "icon"] as const)(
+    "size=%s carries the mobile minimum height",
+    (size) => {
+      render(<Button size={size}>Press</Button>);
+      expect(screen.getByRole("button").className).toContain("max-md:min-h-11");
+    }
+  );
+
+  it("keeps its desktop height unchanged", () => {
+    render(<Button size="sm">Press</Button>);
+    // h-9 is 36px: correct for a mouse, too small for a finger. Both apply;
+    // the breakpoint decides which wins.
+    expect(screen.getByRole("button").className).toContain("h-9");
+  });
+});

--- a/apps/web/tests/unit/dark-mode-toggle.test.tsx
+++ b/apps/web/tests/unit/dark-mode-toggle.test.tsx
@@ -98,3 +98,14 @@ describe("DarkModeToggle", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("DarkModeToggle — touch target (#989)", () => {
+  // The tap area used to be the 18px image itself, on every page. The icon is
+  // still 18px; only the area a finger has to hit changed.
+  it("offers a 44px tap area", () => {
+    render(<DarkModeToggle />);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("h-11");
+    expect(btn.className).toContain("w-11");
+  });
+});


### PR DESCRIPTION
Third pass of #989. Follows #1008 (navbar, page overflow) and #1009 (tables).

## Two of the issue's concerns turned out to be non-problems

Measured at 390px and 360px before changing anything:

| Surface | Finding |
|---|---|
| Meta-analysis / Plotly | charts size correctly to their container — 292px at 390px wide, 262px at 360px. No overflow. |
| Episode page / audio player | no horizontal scroll at either width. |

Whether a 292px chart is *legible* — legends, axis labels — is a judgement call no assertion can make. I've left that to your eye rather than dressing it up as a passing test.

## What was measurable: tap targets

A sweep at 390px found the **dark-mode toggle at 18px** — its tap area was the bulb image itself, on every page.

The shared `Button` now carries `max-md:min-h-11`, which fixes most of the rest at once and changes nothing at desktop widths:

| Page | undersized controls, before → after |
|---|---|
| `/feeds` | 29 → 3 |
| `/queue` | 5 → 4 |
| `/podcasts` | 10 → 7 |

## Why the guard is scoped, not site-wide

`/about` renders the changelog: **~480 inline prose links**. A blanket 44px assertion would fail there forever and get silenced — worse than not having it.

The browser guard covers the navbar: the chrome on every page, and where the 18px control actually was. The remainder of the sweep stays on the issue rather than being pretended at here.

## The guard was broken twice, and mutation-testing is what found it

Neither showed up as a failing test — both showed up as a mutant that *should* have failed and didn't:

1. **It measured before hydration.** `DarkModeToggle` is an SSR placeholder `<div>` until hydrated, so a check looking only at `<button>` found just the menu button and passed — while the 18px control it was written for wasn't on the page yet.
2. **It didn't assert what it measured.** Now it requires at least two navbar buttons, so that failure mode can't return quietly.

I also had two mutants *appear* to survive that hadn't actually been applied: one regex matched the explanatory comment instead of the code, the other the SSR placeholder. Worth stating because "mutant survived" nearly became a wrong conclusion about the guards.

## Verification

- 42 passed in the real `web_test` image; 26 locally; 1161 web unit tests.
- Mutants caught: dark toggle reverted to 18px (names it — `"Switch to dark mode = 18px"`), shared Button loses `max-md:min-h-11` (4 unit tests fail).
- `check_ui_tokens.py` clean — the `button.tsx` edit carries a note that it doesn't exist upstream, since a re-copy would silently drop it the way #848 dropped the dropdown fix.

## Remaining on #989

Touch targets outside the navbar (`/docs` 28, `/settings` 15, `/meta-analysis` 18 undersized controls), and a human look at chart legibility at 390px.

`make ci-local`: all checks pass.

Refs #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin