### PR TITLE
fix(mobile): finger-sized controls across the app (#989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Fixes
+- Buttons, filters, tabs and checkboxes across the app are now sized for a fingertip on a phone, including the Settings tabs, the search and Ask filters, the podcast chips on Meta-Analysis and the notification form. Desktop is unchanged.
+- The chart toolbars on Meta-Analysis are hidden on a phone. Each chart added nine tiny buttons for zoom, pan and lasso-select — none of them usable with a finger, and they cluttered a screen that has little room to spare. They still appear on a larger screen. ([#989](https://github.com/brlauuu/podlog/issues/989))
+
+### Fixes
 - Buttons are easier to hit on a phone. The dark-mode switch in particular only responded to a tap on the small bulb icon itself; it now has a proper finger-sized area, and shared buttons across the app get the same treatment on narrow screens. Nothing changes on a desktop. ([#989](https://github.com/brlauuu/podlog/issues/989))
 
 ### Fixes

--- a/apps/web/src/app/ask/page.tsx
+++ b/apps/web/src/app/ask/page.tsx
@@ -335,7 +335,7 @@ export default function AskPage() {
               <button
                 type="submit"
                 disabled={!question.trim() || isProcessing}
-                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground disabled:opacity-40 transition-colors"
+                className="p-1.5 max-md:min-h-11 max-md:min-w-11 max-md:inline-flex max-md:items-center max-md:justify-center rounded-md text-muted-foreground hover:text-foreground disabled:opacity-40 transition-colors"
               >
                 <ArrowRight size={18} />
               </button>
@@ -370,7 +370,7 @@ export default function AskPage() {
                 id="model-select"
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
-                className="min-w-0 max-w-full truncate text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground"
+                className="min-w-0 max-w-full truncate text-sm border border-input rounded-md px-2 py-1 max-md:min-h-11 bg-background text-foreground"
               >
                 {modelsFor(ragProvider).map((m) => (
                   <option key={m.value} value={m.value}>

--- a/apps/web/src/app/meta-analysis/CoverageStrip.tsx
+++ b/apps/web/src/app/meta-analysis/CoverageStrip.tsx
@@ -36,7 +36,7 @@ export default function CoverageStrip({
           <span>·</span>
           <Link
             href="/queue"
-            className="underline-offset-2 hover:underline hover:text-foreground"
+            className="underline-offset-2 hover:underline hover:text-foreground max-md:min-h-11 max-md:inline-flex max-md:items-center"
             title="Not yet in this snapshot — open the queue"
           >
             {queuedFailed} queued/failed ▸
@@ -47,7 +47,7 @@ export default function CoverageStrip({
       <button
         type="button"
         onClick={onOpenMissingSpeakers}
-        className="underline-offset-2 hover:underline hover:text-foreground"
+        className="underline-offset-2 hover:underline hover:text-foreground max-md:min-h-11 max-md:inline-flex max-md:items-center"
       >
         {missingSpeakers} missing speakers ▸
       </button>

--- a/apps/web/src/app/meta-analysis/ExploreStatusPanel.tsx
+++ b/apps/web/src/app/meta-analysis/ExploreStatusPanel.tsx
@@ -76,7 +76,7 @@ export default function ExploreStatusPanel() {
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline max-md:min-h-11 max-md:inline-flex max-md:items-center"
           aria-expanded={open}
         >
           {open

--- a/apps/web/src/app/meta-analysis/FiltersBar.tsx
+++ b/apps/web/src/app/meta-analysis/FiltersBar.tsx
@@ -17,7 +17,7 @@ export default function FiltersBar({ feeds, selectedFeedId, onSelectionChange }:
       <button
         type="button"
         onClick={() => onSelectionChange(null)}
-        className={`px-2 py-1 rounded ${selectedFeedId === null ? "bg-accent text-accent-foreground" : "hover:bg-accent"}`}
+        className={`px-2 py-1 max-md:min-h-11 rounded ${selectedFeedId === null ? "bg-accent text-accent-foreground" : "hover:bg-accent"}`}
       >
         All podcasts
       </button>
@@ -26,7 +26,7 @@ export default function FiltersBar({ feeds, selectedFeedId, onSelectionChange }:
           key={f.feed_id}
           type="button"
           onClick={() => onSelectionChange(f.feed_id)}
-          className={`px-2 py-1 rounded ${selectedFeedId === f.feed_id ? "bg-accent text-accent-foreground" : "hover:bg-accent"}`}
+          className={`px-2 py-1 max-md:min-h-11 rounded ${selectedFeedId === f.feed_id ? "bg-accent text-accent-foreground" : "hover:bg-accent"}`}
         >
           {f.title}
         </button>

--- a/apps/web/src/app/meta-analysis/InfoBlock.tsx
+++ b/apps/web/src/app/meta-analysis/InfoBlock.tsx
@@ -10,7 +10,7 @@ export default function InfoBlock() {
         type="button"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
-        className="flex items-center gap-2 text-left w-full font-medium"
+        className="flex items-center gap-2 text-left w-full font-medium max-md:min-h-11"
       >
         <span aria-hidden="true">{open ? "▾" : "▸"}</span>
         What do these charts show?

--- a/apps/web/src/app/meta-analysis/MetaAnalysisClient.tsx
+++ b/apps/web/src/app/meta-analysis/MetaAnalysisClient.tsx
@@ -126,7 +126,7 @@ export default function MetaAnalysisClient() {
           ) : null}
         </div>
         <button
-          className="px-3 py-1.5 rounded-md border text-sm"
+          className="px-3 py-1.5 rounded-md border text-sm max-md:min-h-11"
           onClick={() => refresh.mutate()}
           disabled={refresh.isPending}
           aria-label="Refresh meta-analysis"

--- a/apps/web/src/app/meta-analysis/charts/PlotlyChart.tsx
+++ b/apps/web/src/app/meta-analysis/charts/PlotlyChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import type { ComponentType } from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { Loader2 } from "lucide-react";
 import type { Data, Layout, Config } from "plotly.js";
 import type { PlotParams } from "react-plotly.js";
@@ -42,6 +42,21 @@ interface Props {
 }
 
 export default function PlotlyChart({ data, layout, config, onPointClick, height = 360 }: Props) {
+  // Tailwind's md: is 768px. Matched in JS because Plotly's modebar is not
+  // ours to style with a class.
+  const [isNarrow, setIsNarrow] = useState(false);
+  useEffect(() => {
+    // Guarded: matchMedia is missing in jsdom and in any other non-browser
+    // consumer. Without this the whole chart throws rather than falling back
+    // to desktop behaviour -- it took out six existing tests when added.
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const apply = () => setIsNarrow(mq.matches);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
+
   const template = usePlotlyTheme();
 
   const themeLayout: Partial<Layout> = template === "plotly_dark"
@@ -88,7 +103,16 @@ export default function PlotlyChart({ data, layout, config, onPointClick, height
           legend: { ...themeLayout.legend, ...layout?.legend },
           hoverlabel: { ...themeLayout.hoverlabel, ...layout?.hoverlabel },
         }}
-        config={{ displaylogo: false, responsive: true, ...config }}
+        // #989: the modebar is nine 22px buttons per chart -- 27 unhittable
+        // targets on a phone, for interactions (box select, lasso) that need a
+        // pointer regardless. Hidden below md: rather than enlarged. An
+        // explicit `config.displayModeBar` from a caller still wins.
+        config={{
+          displaylogo: false,
+          responsive: true,
+          displayModeBar: isNarrow ? false : undefined,
+          ...config,
+        }}
         useResizeHandler
         style={{ width: "100%", height: "100%" }}
         onClick={(ev) => {

--- a/apps/web/src/components/EpisodeCard.tsx
+++ b/apps/web/src/components/EpisodeCard.tsx
@@ -383,7 +383,7 @@ export default function EpisodeCard({
           aria-label="Delete upload"
           onClick={handleDeleteClick}
           disabled={deleting}
-          className="absolute bottom-2 right-2 z-10 p-1.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="absolute bottom-2 right-2 z-10 p-1.5 max-md:min-h-11 max-md:min-w-11 max-md:inline-flex max-md:items-center max-md:justify-center rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {deleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
         </button>

--- a/apps/web/src/components/HelpPopover.tsx
+++ b/apps/web/src/components/HelpPopover.tsx
@@ -39,9 +39,15 @@ export default function HelpPopover({ title, children }: HelpPopoverProps) {
             setPinned(nextPinned);
             setOpen(nextPinned);
           }}
-          className="h-5 w-5 rounded-full border border-input text-xs font-semibold text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
+          // #989: the button carries the 44px tap area on a phone; the ring
+          // stays 20px. Growing the circle itself to 44px would put a heavy
+          // disc next to the page heading, so the visual and the target are
+          // separated rather than compromised.
+          className="inline-flex items-center justify-center h-5 w-5 max-md:h-11 max-md:w-11 text-muted-foreground hover:text-foreground transition-colors"
         >
-          ?
+          <span className="inline-flex items-center justify-center h-5 w-5 rounded-full border border-input text-xs font-semibold hover:bg-accent/30">
+            ?
+          </span>
         </button>
         {open && (
           <div

--- a/apps/web/src/components/NotificationSectionCards.tsx
+++ b/apps/web/src/components/NotificationSectionCards.tsx
@@ -173,7 +173,7 @@ function SetupGuide({
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <div className="rounded-lg border border-border bg-muted/50 p-4 mb-6">
-        <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
+        <CollapsibleTrigger className="flex w-full items-center justify-between text-left max-md:min-h-11">
           <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
           <span className="text-xs text-muted-foreground">
             {open ? "Hide" : "Show"}
@@ -264,7 +264,7 @@ export function TelegramNotificationCard({
       </FieldGroup>
 
       <button
-        className="px-4 py-2 rounded-md border border-border text-sm text-muted-foreground hover:text-foreground hover:border-muted-foreground disabled:opacity-50 mt-2"
+        className="px-4 py-2 max-md:min-h-11 rounded-md border border-border text-sm text-muted-foreground hover:text-foreground hover:border-muted-foreground disabled:opacity-50 mt-2"
         onClick={() => onTest("telegram")}
         disabled={!settings.telegram_configured || testing}
       >
@@ -344,7 +344,7 @@ export function EmailNotificationCard({
 
       <Collapsible open={smtpOpen} onOpenChange={setSmtpOpen}>
         <div className="border-t border-border my-4" />
-        <CollapsibleTrigger className="flex w-full items-center justify-between text-left text-sm mb-4">
+        <CollapsibleTrigger className="flex w-full items-center justify-between text-left text-sm mb-4 max-md:min-h-11">
           <span className="font-medium">SMTP Configuration</span>
           <span className="text-xs text-muted-foreground">
             {smtpOpen ? "Hide" : "Show"} — optional, defaults work with local
@@ -411,9 +411,10 @@ export function EmailNotificationCard({
                 />
               </FieldGroup>
             </div>
-            <label className="flex items-center gap-2 text-sm">
+            <label className="flex items-center gap-2 text-sm max-md:min-h-11">
               <input
                 type="checkbox"
+                className="max-md:h-5 max-md:w-5"
                 checked={settings.smtp_use_tls}
                 onChange={(e) => onChange("smtp_use_tls", e.target.checked)}
               />
@@ -427,7 +428,7 @@ export function EmailNotificationCard({
       </Collapsible>
 
       <button
-        className="px-4 py-2 rounded-md border border-border text-sm text-muted-foreground hover:text-foreground hover:border-muted-foreground disabled:opacity-50 mt-2"
+        className="px-4 py-2 max-md:min-h-11 rounded-md border border-border text-sm text-muted-foreground hover:text-foreground hover:border-muted-foreground disabled:opacity-50 mt-2"
         onClick={() => onTest("email")}
         disabled={!settings.notification_email_to || testing}
       >
@@ -451,7 +452,7 @@ export function GeneralNotificationCard({
       >
         <select
           id="notification-frequency"
-          className={inputClass}
+          className={`${inputClass} max-md:min-h-11`}
           value={settings.notification_frequency}
           onChange={(e) => onChange("notification_frequency", e.target.value)}
         >
@@ -473,9 +474,10 @@ export function GeneralNotificationCard({
         label="Health Check Notifications"
         hint="Host-level monitoring alerts (service status, zombie jobs). Runs via cron every 15 minutes."
       >
-        <label className="flex items-center gap-2 text-sm mt-2">
+        <label className="flex items-center gap-2 text-sm mt-2 max-md:min-h-11">
           <input
             type="checkbox"
+            className="max-md:h-5 max-md:w-5"
             checked={settings.health_check_notifications_enabled}
             onChange={(e) =>
               onChange("health_check_notifications_enabled", e.target.checked)

--- a/apps/web/src/components/NotificationSettings.tsx
+++ b/apps/web/src/components/NotificationSettings.tsx
@@ -189,7 +189,7 @@ export default function NotificationSettings() {
   }
 
   const actionButtonClass =
-    "px-5 py-2 rounded-md bg-action text-action-foreground text-sm font-medium hover:bg-action/90 disabled:opacity-50";
+    "px-5 py-2 max-md:min-h-11 rounded-md bg-action text-action-foreground text-sm font-medium hover:bg-action/90 disabled:opacity-50";
 
   return (
     <div>

--- a/apps/web/src/components/PodcastFilter.tsx
+++ b/apps/web/src/components/PodcastFilter.tsx
@@ -52,7 +52,7 @@ export default function PodcastFilter({
         type="button"
         onClick={() => setOpen((o) => !o)}
         disabled={loading && !hasAnyOptions}
-        className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
+        className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 max-md:min-h-11 bg-background text-foreground hover:bg-accent/30 transition-colors"
       >
         <span className="text-muted-foreground">Source:</span>
         {loading && !hasAnyOptions

--- a/apps/web/src/components/PodcastsList.tsx
+++ b/apps/web/src/components/PodcastsList.tsx
@@ -115,7 +115,7 @@ function ViewToggle({
             aria-label={opt.label}
             aria-pressed={active}
             onClick={() => onChange(opt.mode)}
-            className={`h-7 w-8 flex items-center justify-center transition-colors ${
+            className={`h-7 w-8 max-md:h-11 max-md:w-11 flex items-center justify-center transition-colors ${
               active
                 ? "bg-accent text-foreground"
                 : "text-muted-foreground hover:bg-accent/60"

--- a/apps/web/src/components/QueueStatus.tsx
+++ b/apps/web/src/components/QueueStatus.tsx
@@ -380,7 +380,7 @@ export default function QueueStatus() {
         <div>
           <button
             onClick={() => { setShowDone(!effectiveShowDone); if (stageFilter === "done") setStageFilter(null); }}
-            className="text-sm text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground max-md:min-h-11 max-md:inline-flex max-md:items-center"
           >
             {effectiveShowDone ? "Hide" : "Show"} {doneCount} completed episode{doneCount !== 1 ? "s" : ""}{" "}
             {effectiveShowDone ? "▴" : "▾"}

--- a/apps/web/src/components/RemoteInferencePipelineSteps.ts
+++ b/apps/web/src/components/RemoteInferencePipelineSteps.ts
@@ -162,7 +162,7 @@ export const PIPELINE_STEPS: PipelineStep[] = [
 ];
 
 export const inputClass =
-  "w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring";
+  "w-full rounded-md border border-border bg-background px-3 py-2 max-md:min-h-11 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring";
 
 export function isRemoteStep(settings: Settings, step: PipelineStep): boolean {
   if (!step.providerField) return false;

--- a/apps/web/src/components/ReprocessButton.tsx
+++ b/apps/web/src/components/ReprocessButton.tsx
@@ -34,7 +34,7 @@ export default function ReprocessButton({ episodeId }: ReprocessButtonProps) {
     <button
       onClick={handleReprocess}
       disabled={loading}
-      className="inline-flex items-center gap-1 rounded border border-input bg-background px-1.5 py-0.5 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
+      className="inline-flex items-center gap-1 rounded border border-input bg-background px-1.5 py-0.5 max-md:min-h-11 max-md:px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
     >
       <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
       {loading ? "Reprocessing..." : "Reprocess"}

--- a/apps/web/src/components/SpeakerFilter.tsx
+++ b/apps/web/src/components/SpeakerFilter.tsx
@@ -76,7 +76,7 @@ export default function SpeakerFilter({
         type="button"
         onClick={() => setOpen((o) => !o)}
         disabled={loading && speakers.length === 0}
-        className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 bg-background text-foreground hover:bg-accent/30 transition-colors"
+        className="flex items-center gap-1.5 text-sm border border-input rounded-md px-2 py-1 max-md:min-h-11 bg-background text-foreground hover:bg-accent/30 transition-colors"
       >
         <User size={13} className="text-muted-foreground shrink-0" />
         <span className="text-muted-foreground">Speaker:</span>

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -29,7 +29,9 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      // #989: max-md:min-h-11 gives tab triggers a 44px tap area on phones.
+      // Not upstream shadcn -- a re-copy of this file drops it (cf. #848).
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium max-md:min-h-11 ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}

--- a/apps/web/tests/e2e/mobile-layout.spec.ts
+++ b/apps/web/tests/e2e/mobile-layout.spec.ts
@@ -129,6 +129,58 @@ for (const vp of VIEWPORTS) {
       });
     }
 
+    test("our own controls are big enough to tap", async ({ page }) => {
+      // #989: the site-wide sweep, with two categories excluded on purpose.
+      //
+      //  - Prose and inline links. /about renders the changelog and /docs the
+      //    guide body: ~525 inline links between them. A 44px rule on body
+      //    text is not what the guideline means, and a check that fails
+      //    forever gets silenced.
+      //  - Plotly's modebar. ~27 buttons at 22px, injected by the library, not
+      //    ours to restyle. They are hidden below md: instead -- see
+      //    PlotlyChart.tsx.
+      //
+      // What remains is the controls Podlog itself renders as chrome.
+      const PAGES_WITH_CONTROLS = ["/", "/search", "/ask", "/queue", "/feeds", "/podcasts", "/settings", "/meta-analysis"];
+      const offenders: string[] = [];
+      let measured = 0;
+
+      for (const path of PAGES_WITH_CONTROLS) {
+        await page.goto(path);
+        await page.locator("nav").first().waitFor();
+        await page.waitForLoadState("networkidle");
+        await page.waitForTimeout(1200); // charts and async panels
+
+        const found = await page.evaluate((p) => {
+          const bad: string[] = [];
+          let seen = 0;
+          document.querySelectorAll("button, select, a[role=button], input[type=checkbox]").forEach((el) => {
+            const r = el.getBoundingClientRect();
+            if (r.width === 0 || r.height === 0) return;
+            if (el.closest("article, .prose, p, li, aside")) return;   // prose
+            if (el.closest(".js-plotly-plot, .modebar")) return;        // third-party
+            seen += 1;
+            // A checkbox wrapped in a <label> is tapped via the label -- that
+            // is the target, and a 44px checkbox would look absurd. Measure
+            // what the finger actually hits.
+            const label = el.closest("label");
+            const box = label ? label.getBoundingClientRect() : r;
+            if (box.height < 44) {
+              const name = (el.getAttribute("aria-label") || label?.textContent || el.textContent || "").trim().slice(0, 40);
+              bad.push(`${p} — "${name}" ${Math.round(box.height)}px`);
+            }
+          });
+          return { bad, seen };
+        }, path);
+
+        offenders.push(...found.bad);
+        measured += found.seen;
+      }
+
+      expect(measured, "no controls were measured at all").toBeGreaterThan(20);
+      expect(offenders, "controls smaller than a fingertip").toEqual([]);
+    });
+
     test("navbar controls are big enough to tap", async ({ page }) => {
       // #989: 44px is what iOS and Android both ask for. Scoped to the navbar
       // deliberately -- it is the chrome present on every page, and it is

--- a/apps/web/tests/unit/plotly-chart.test.tsx
+++ b/apps/web/tests/unit/plotly-chart.test.tsx
@@ -121,3 +121,42 @@ describe("<PlotlyChart>", () => {
     fireEvent.click(screen.getByTestId("plot-stub"));
   });
 });
+
+describe("PlotlyChart — modebar on phones (#989)", () => {
+  // Plotly injects nine 22px toolbar buttons per chart. Three charts on the
+  // Meta-Analysis page is 27 targets no finger can hit, for interactions
+  // (box select, lasso) that need a pointer anyway. Hidden below md:.
+  function mockWidth(matches: boolean) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        onchange: null,
+      })),
+    });
+  }
+
+  it("hides the modebar on a narrow viewport", () => {
+    mockWidth(true);
+    render(<PlotlyChart data={[]} layout={{}} />);
+    expect((captured.props?.config as Record<string, unknown>).displayModeBar).toBe(false);
+  });
+
+  it("leaves it to Plotly on a wide viewport", () => {
+    mockWidth(false);
+    render(<PlotlyChart data={[]} layout={{}} />);
+    expect((captured.props?.config as Record<string, unknown>).displayModeBar).toBeUndefined();
+  });
+
+  it("still lets a caller ask for it explicitly", () => {
+    mockWidth(true);
+    render(<PlotlyChart data={[]} layout={{}} config={{ displayModeBar: true }} />);
+    expect((captured.props?.config as Record<string, unknown>).displayModeBar).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/tabs-touch-target.test.tsx
+++ b/apps/web/tests/unit/tabs-touch-target.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+/**
+ * #989: tab triggers get a 44px tap area below md:. Settings uses four of
+ * them, and the Meta-Analysis page two more.
+ *
+ * A class-string assertion, like the Button one: jsdom has no layout engine.
+ * What it guards is the re-copy hazard -- `max-md:min-h-11` is not upstream
+ * shadcn, so pasting a fresh tabs.tsx silently removes it (cf. #848). The
+ * rendered height is measured in a browser by tests/e2e/mobile-layout.spec.ts.
+ */
+describe("TabsTrigger touch target (#989)", () => {
+  it("carries the mobile minimum height", () => {
+    render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">First</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    );
+    expect(screen.getByRole("tab").className).toContain("max-md:min-h-11");
+  });
+});


### PR DESCRIPTION
Fourth pass of #989, and the last of the touch-target work. Follows #1008, #1009, #1010.

## The count was wrong in my own last PR

#1010 said "`/docs` 28, `/settings` 15, `/meta-analysis` 18 undersized controls" remained. Classifying them showed most of that wasn't ours:

| Category | Count | Ours? |
|---|---|---|
| Prose / inline links (`/about` changelog, `/docs` body) | ~525 | **No** — a 44px rule on body text isn't what the guideline means |
| Plotly modebar buttons | ~27 | **No** — injected by the library |
| Podlog's own controls | ~30 | Yes |

I'd have carried that wrong number forward if I hadn't measured before starting.

## Plotly's modebar: hidden, not enlarged

Each chart renders nine 22px buttons — Zoom, Pan, Box Select, Lasso Select. Three charts is **27 targets no finger can hit**, for interactions that need a pointer regardless. `displayModeBar: false` below `md:`, which also gives back space on a screen with little to spare. An explicit `config.displayModeBar` from a caller still wins.

## The rest, fixed where they live

Search and Ask filters, help popovers, view toggles, Reprocess and Delete, the queue's done toggle, the Meta-Analysis chips and Refresh, and the notification form's disclosures, selects, checkboxes and Save.

Two needed more than a class:

- **The help `?`** keeps its 20px ring; the *button* carries the 44px area. A 44px disc beside the page heading would be worse than the problem it solves.
- **Checkboxes** are measured by their wrapping `<label>`, which is what a thumb actually hits. A 44px checkbox looks absurd; the label is the honest target.

## The guard is now site-wide

With the two exclusions above written into the test with their reasons, so the next person doesn't quietly widen them.

## I broke six tests adding this

The `matchMedia` call in `PlotlyChart` threw in jsdom, taking out six existing chart tests. Guarded now, so a consumer without `matchMedia` falls back to desktop behaviour rather than crashing — which is the right behaviour anyway, not just a test fix.

## Verification

- **44 passed** in the real `web_test` image; 28 locally; full web unit suite green.
- Mutants caught, each naming the control it broke:

| Mutant | Reported |
|---|---|
| tabs lose `max-md:min-h-11` | `"Confirmed" 32px`, `"Inferred — HIGH" 32px` |
| help button loses its tap area | `"Search help" 20px`, `"Ask help" 20px` |

- Unit guards on both shared primitives (`Button`, `TabsTrigger`) against the shadcn re-copy hazard that lost the dropdown fix in #848.

## What's left on #989

Only a human judgement: whether the charts are *legible* at 390px (legends, axis labels). No assertion can answer that, so I've not pretended one can.

`make ci-local`: all checks pass.

Refs #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin