### PR TITLE
docs(compose): stop calling the web UI read-mostly (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- Corrected a comment in the Docker configuration that described the web interface as read-mostly when justifying why it is reachable from the local network. It is not: there is no login and it forwards writes, which is what the security documentation says a few files away. The comment sits directly above the setting it justifies, so it was the first thing anyone would read when deciding whether that exposure was acceptable. ([#1012](https://github.com/brlauuu/podlog/issues/1012))
+
 ### Fixes
 - Buttons, filters, tabs and checkboxes across the app are now sized for a fingertip on a phone, including the Settings tabs, the search and Ask filters, the podcast chips on Meta-Analysis and the notification form. Desktop is unchanged.
 - The chart toolbars on Meta-Analysis are hidden on a phone. Each chart added nine tiny buttons for zoom, pan and lasso-select — none of them usable with a finger, and they cluttered a screen that has little room to spare. They still appear on a larger screen. ([#989](https://github.com/brlauuu/podlog/issues/989))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,9 +131,20 @@ services:
         APP_VERSION: ${APP_VERSION:-}
     # Deliberately NOT loopback-bound (#952), unlike db/pipeline/ollama above.
     # This is the user-facing UI and being able to open Podlog from a phone or
-    # another machine on the LAN is a reasonable thing to want. It is read-
-    # mostly and does not expose the API keys the settings endpoint holds.
-    # Change this to 127.0.0.1:3000:3000 if you only ever browse from this host.
+    # another machine on the LAN is a reasonable thing to want.
+    #
+    # Know what that means before leaving it: this is NOT a read-only viewer.
+    # There is no login, and the web app forwards writes to the pipeline API on
+    # your behalf, so anyone who can open port 3000 -- every device on the
+    # network, guests included -- has full control of Podlog: add and delete
+    # feeds, delete episodes and transcripts, delete backups, upload audio,
+    # trigger re-processing, change every setting. API keys are the one
+    # exception; they are masked when read back.
+    #
+    # So the trust boundary is the network, not the host. See "Security model"
+    # in docs/guide/01-installation.md (#960, #988), which is the source this
+    # summarises. Change this to 127.0.0.1:3000:3000 if you only ever browse
+    # from this host.
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Comment-only fix. Found while filing #1012.

## The problem

`docker-compose.yml` justified binding `web` to all interfaces with:

> It is read-mostly and does not expose the API keys the settings endpoint holds.

The first half is wrong, and wrong in the exact way the security model was written to correct.

Verified rather than assumed:

```
$ find apps/web/src -name "middleware.ts"          # nothing
$ grep -rl "getServerSession|requireAuth" apps/web/src   # nothing
```

Per `docs/guide/01-installation.md` and `CLAUDE.md` (#960, #988), the web app is an **unauthenticated write proxy** — 23 mutating routes forwarding to the pipeline API. Anyone who can reach port 3000 can delete feeds, episodes and backups.

## Why a comment is worth a PR

It sits **three lines above the port binding it justifies**. It is the first thing read by someone deciding whether LAN exposure is acceptable, and it told them the reassuring version. `01-installation.md` has been correct since #988 — but nobody reading `docker-compose.yml` to decide about this port was being sent there.

## The fix

Rewritten from the guide's own wording rather than paraphrased afresh, and it now names that section as the source so the two cannot drift apart silently again.

The API-keys half was accurate and is kept — `mask_sensitive` in `apps/pipeline/app/api/notifications.py` really does mask them on read.

I also grepped for the same framing elsewhere (`docker-compose*.yml`, `.env.example`, `scripts/`, `Makefile`) — this was the only instance.

## Verification

`docker compose config` still parses. `make ci-local`: all checks pass.

Refs #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin