### PR TITLE
fix(search): stop refetching speakers on every keystroke (#1006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- The Speaker dropdown on Search and Ask no longer flickers while you type. Every keystroke was re-fetching the speaker list and flashing it back to "Loading...", even though nothing about your filter selection had changed — nineteen wasted requests for a seventeen-character query. ([#1006](https://github.com/brlauuu/podlog/issues/1006))
+
 ### Internal
 - Corrected a comment in the Docker configuration that described the web interface as read-mostly when justifying why it is reachable from the local network. It is not: there is no login and it forwards writes, which is what the security documentation says a few files away. The comment sits directly above the setting it justifies, so it was the first thing anyone would read when deciding whether that exposure was acceptable. ([#1012](https://github.com/brlauuu/podlog/issues/1012))
 

--- a/apps/web/src/components/SpeakerFilter.tsx
+++ b/apps/web/src/components/SpeakerFilter.tsx
@@ -28,11 +28,26 @@ export default function SpeakerFilter({
   const [reloadToken, setReloadToken] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
 
+  // #1006: both call sites pass `Array.from(selectedFeedIds)` inline, so a new
+  // array object arrives on every parent render -- and on /search every
+  // keystroke re-renders the parent long before the query is submitted. The
+  // effect below compares dependencies by reference, so it re-ran each time,
+  // flashing "Loading..." in the label and "Loading speakers..." in the open
+  // dropdown while refetching a result that could not have changed.
+  //
+  // Keying on a derived string instead of the array puts the fix here rather
+  // than asking every present and future caller to remember useMemo. Sorted
+  // because the API filters with `= ANY($1::uuid[])`, where order carries no
+  // meaning, so a reordered selection is the same selection.
+  const feedKey = [...feedIds].sort().join(",");
+
   useEffect(() => {
     setLoading(true);
     setError(false);
     const params = new URLSearchParams();
-    const realIds = feedIds.filter((id) => id !== "__uploads__");
+    const realIds = feedKey
+      ? feedKey.split(",").filter((id) => id && id !== "__uploads__")
+      : [];
     if (realIds.length > 0) params.set("feedId", realIds.join(","));
     if (includeManualUploads) params.set("uploads", "true");
 
@@ -54,7 +69,7 @@ export default function SpeakerFilter({
       .finally(() => setLoading(false));
 
     return () => controller.abort();
-  }, [feedIds, includeManualUploads, reloadToken]);
+  }, [feedKey, includeManualUploads, reloadToken]);
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {

--- a/apps/web/tests/e2e/search.spec.ts
+++ b/apps/web/tests/e2e/search.spec.ts
@@ -53,6 +53,38 @@ test.describe("Search", () => {
     await expect(page.getByText("Found in 1 podcast, 1 episode (1 mention)")).toBeVisible();
   });
 
+  test("typing does not refetch the speaker list on every keystroke (#1006)", async ({ page }) => {
+    // The unit test proves the component no longer refetches on an equal-but-
+    // new array. This proves the reported symptom is actually gone: on the
+    // real page, every keystroke re-rendered the parent (query state lives in
+    // search/page.tsx) and the Speaker dropdown flashed "Loading..." while
+    // refetching a result that could not have changed.
+    let speakerFetches = 0;
+    await page.route("**/api/search/speakers?**", async (route) => {
+      speakerFetches += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([{ speaker_label: "Alice", display_name: "Alice" }]),
+      });
+    });
+
+    await page.goto("/search");
+    const speakerButton = page.getByRole("button", { name: /speaker:/i });
+    await expect(speakerButton).toContainText("All"); // initial load settled
+    const afterLoad = speakerFetches;
+    expect(afterLoad).toBeGreaterThan(0); // the stub is actually being hit
+
+    // Type without submitting -- this is the repro from the issue.
+    await page.getByRole("textbox").first().pressSequentially("machine learning", { delay: 30 });
+
+    await expect(speakerButton).toContainText("All");
+    expect(
+      speakerFetches,
+      `speaker list refetched ${speakerFetches - afterLoad} extra times while typing`,
+    ).toBe(afterLoad);
+  });
+
   test("empty state shown when no results", async ({ page }) => {
     await page.route("**/api/search/grouped?**", async (route) => {
       await route.fulfill({

--- a/apps/web/tests/unit/speaker-filter.test.tsx
+++ b/apps/web/tests/unit/speaker-filter.test.tsx
@@ -202,3 +202,71 @@ describe("SpeakerFilter", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("SpeakerFilter — refetch discipline (#1006)", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ speaker_label: "Alice", display_name: "Alice" }],
+    });
+  });
+
+  function renderWith(feedIds: string[]) {
+    return (
+      <SpeakerFilter
+        feedIds={feedIds}
+        includeManualUploads={false}
+        selectedSpeaker={null}
+        onSelectionChange={jest.fn()}
+      />
+    );
+  }
+
+  it("does not refetch when the parent re-renders with an equal but new array", async () => {
+    // The bug: both call sites pass `Array.from(selectedFeedIds)` inline, so a
+    // fresh array object arrives on every parent render. useEffect compares
+    // deps by reference, so every keystroke on /search re-ran the fetch and
+    // flashed "Loading..." in the label.
+    const { rerender } = render(renderWith(["feed-1", "feed-2"]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Same contents, new object -- exactly what Array.from produces.
+    rerender(renderWith(["feed-1", "feed-2"]));
+    rerender(renderWith(["feed-1", "feed-2"]));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /speaker:/i })).toHaveTextContent("All"));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refetch when the same ids arrive in a different order", async () => {
+    // The API filters with `= ANY($1::uuid[])`, so order carries no meaning.
+    const { rerender } = render(renderWith(["feed-1", "feed-2"]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    rerender(renderWith(["feed-2", "feed-1"]));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /speaker:/i })).toHaveTextContent("All"));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refetches when the selection genuinely changes", async () => {
+    // The guard above must not be achieved by never refetching at all.
+    const { rerender } = render(renderWith(["feed-1"]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    rerender(renderWith(["feed-1", "feed-2"]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    rerender(renderWith([]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+  });
+
+  it("sends the selected feed ids to the API", async () => {
+    render(renderWith(["feed-2", "feed-1"]));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    const feedId = new URL(url, "http://localhost").searchParams.get("feedId");
+    expect(feedId?.split(",").sort()).toEqual(["feed-1", "feed-2"]);
+  });
+});


### PR DESCRIPTION
Closes #1006.

## Confirmed the diagnosis before acting on it

The issue's analysis holds exactly. `SpeakerFilter`'s fetch effect was keyed on the `feedIds` array; both call sites (`SearchTopPanel.tsx:89`, `ask/page.tsx:403`) pass `Array.from(selectedFeedIds)` inline, so a new array object arrives on every parent render. `useEffect` compares by reference, so the effect re-ran on every keystroke: `setLoading(true)` → refetch → `setLoading(false)`.

**Quantified in a browser:** typing `"machine learning"` fires **19 unnecessary requests** and flashes `"Loading..."` 19 times.

## The fix

Keyed on a derived string rather than the array.

The issue offered memoising at both call sites as the alternative. I took the second option it recommended — the fix lives *inside* the component, so a third call site can't reintroduce the bug by forgetting to memoise.

The key is **sorted**, which fixes a second instance of the same class: reordering a selection is the same selection. Safe because the API filters with `= ANY($1::uuid[])` (`api/search/speakers/route.ts:27`), where order carries no meaning — checked rather than assumed.

## Two levels of test, because one wasn't enough

The unit tests prove the *mechanism*; the reported bug is *visual*. So both:

**Unit** (4 new): no refetch on an equal-but-new array; no refetch on reordered ids; **still refetches when the selection genuinely changes** — without that, "never fetch at all" would pass; and the ids still reach the API.

**Browser**: counts requests to `/api/search/speakers` while typing the issue's own repro. Reverting the fix makes it fail with the number:

```
Error: speaker list refetched 19 extra times while typing
```

## Mutants, each caught by its own test

| Mutant | Failed |
|---|---|
| key on `feedIds` again | both "does not refetch" tests |
| drop the sort | the reordering test |
| constant key (never refetch) | the "genuinely changes" test |

## Note on the call sites

I did **not** add `useMemo` at either call site. With the component keyed on a value rather than a reference, it would be redundant — and leaving it out keeps the guarantee in one place instead of three.

## Verification

1169 web unit tests, 45 e2e, `make ci-local` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin