### PR TITLE
test(pipeline): exercise the stage-to-stage handoff (#1015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Internal
+- Added a test that carries an episode through all seven pipeline stages in one run — download, transcribe, diarize, chunk, embed, infer, archive — and fails if any stage stops handing off to the next. Previously each stage was only ever tested on its own, which is why several recent bugs lived in the joins between them rather than inside any one stage. It runs in the nightly test suite. The file that claimed to do this already turned out to be a health check with a misleading name; both it and the agent-context file now say what they actually cover. ([#1015](https://github.com/brlauuu/podlog/issues/1015))
+
 ### Fixes
 - The Speaker dropdown on Search and Ask no longer flickers while you type. Every keystroke was re-fetching the speaker list and flashing it back to "Loading...", even though nothing about your filter selection had changed — nineteen wasted requests for a seventeen-character query. ([#1006](https://github.com/brlauuu/podlog/issues/1006))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,4 +225,5 @@ If the resolved version is still ≤ 7.37.x, the block stands and the audit find
 - CI enforces coverage thresholds: pipeline `--cov-fail-under=82` in `ci-full-unit.yml`, web `coverageThreshold` in `jest.config.js`
 
 **Not yet done:**
-- Full end-to-end pipeline smoke test in CI. The test exists (`apps/pipeline/tests/e2e/test_full_flow.py`, `@pytest.mark.e2e`, spins up the full Docker stack and exercises ingest→archive), but no CI job runs it: `ci-slow.yml` runs only pipeline `tests/integration/` and the web Playwright suite. Wiring the `tests/e2e/` full-flow test into CI is the remaining work.
+- Real ML in an end-to-end run. `apps/pipeline/tests/integration/test_pipeline_flow.py` (#1015) drives an episode through all seven stages — download → transcribe → diarize → chunk → embed → infer → archive — against a real database, the real job queue and the real task bodies, with only the model calls stubbed. It runs in `ci-slow.yml` with the rest of `tests/integration/`. What it does **not** do is execute Whisper or pyannote, which would mean model downloads and minutes of CPU per run; that is a deliberate trade, not an oversight.
+- `apps/pipeline/tests/e2e/` holds one health-check test (`test_full_flow.py`) that no CI job runs. Its name predates its contents — it does not exercise a full flow, and the flow test above is what does.

--- a/apps/pipeline/tests/e2e/test_full_flow.py
+++ b/apps/pipeline/tests/e2e/test_full_flow.py
@@ -1,8 +1,14 @@
 """
-End-to-end tests — PRD-01 §12
+Liveness check against a running stack — PRD-01 §12.
 
-Spins up the full Docker stack and exercises the complete ingestion flow
-using a mock RSS feed served by nginx (see docker-compose.test.yml).
+NOT a full-flow test, despite the filename. It asserts one thing: that
+/api/health answers on a stack that is already up. The complete
+ingest -> archive chain is exercised by
+tests/integration/test_pipeline_flow.py (#1015), which runs in CI.
+
+This file's docstring claimed to exercise "the complete ingestion flow"
+for months, and CLAUDE.md repeated the claim, which made the gap look
+like a wiring job rather than a missing test.
 
 Run with: make test-e2e
 """

--- a/apps/pipeline/tests/integration/test_pipeline_flow.py
+++ b/apps/pipeline/tests/integration/test_pipeline_flow.py
@@ -1,0 +1,207 @@
+"""Stage-to-stage flow through the pipeline (#1015).
+
+Every other pipeline test starts an episode mid-flight: `tests/integration/
+test_pipeline.py` seeds a `sample_episode`, sets `status = "transcribing"`,
+and calls one task. That covers each stage's depth and none of the joins
+between them.
+
+The joins are where this project's bugs have actually been. #968 (chunking
+and embedding missing from the stage list), #972 (two slot-numbering
+schemes colliding across a boundary), #983 (a stale error surviving the
+success path) were all seam defects, invisible to a test that runs one
+stage in isolation.
+
+There is no routing table to test -- each task hardcodes its successor at
+the end of its own body, seven `job_queue.enqueue` calls in seven files.
+This test drives the chain the way the worker does and asserts it holds.
+
+WHAT IS REAL AND WHAT IS STUBBED
+
+Real: the database, the job queue, `TASK_HANDLERS`, every task body, the
+chunking logic, and the archive file moves.
+
+Stubbed: the download, and the four calls into models we do not own
+(Whisper, pyannote, the embedding model, the NER/LLM inference). Running
+those for real would mean model downloads and minutes of CPU per run, to
+cover libraries whose behaviour is not ours. The stage bodies and their
+handoffs are ours.
+"""
+import shutil
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app import job_queue
+from app.config import settings
+from app.models import Chunk, Episode, Segment
+from app.task_registry import TASK_HANDLERS
+
+FIXTURE_AUDIO = Path(__file__).parent.parent / "fixtures" / "sample.mp3"
+
+# Every module that does `from app.database import SessionLocal` at import
+# time and therefore needs its own patch to reach the test session.
+TASK_MODULES = [
+    "app.tasks.download",
+    "app.tasks.transcribe",
+    "app.tasks.diarize",
+    "app.tasks.chunk",
+    "app.tasks.embed",
+    "app.tasks.infer",
+    "app.tasks.archive",
+]
+
+MOCK_SEGMENTS = [
+    {"start": 0.0, "end": 5.0, "text": "Welcome to the show, I am your host."},
+    {"start": 5.0, "end": 10.0, "text": "Thanks for having me on today."},
+    {"start": 10.0, "end": 15.0, "text": "Let us talk about the pipeline."},
+]
+
+MOCK_DIARIZATION = [
+    {"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0},
+    {"speaker": "SPEAKER_01", "start": 5.0, "end": 10.0},
+    {"speaker": "SPEAKER_00", "start": 10.0, "end": 15.0},
+]
+
+# A cap, not a expectation: a routing bug that enqueues in a cycle should
+# fail loudly here rather than hang CI until the job times out.
+MAX_JOBS = 20
+
+
+def _drain(db, observed_statuses, episode_id):
+    """Run queued jobs to completion, mirroring worker.py's dispatch.
+
+    Deliberately not `worker.main()`: that sleeps, installs signal handlers
+    and runs periodic tasks. This is the same three lines that matter --
+    poll, dispatch through TASK_HANDLERS, complete -- with nothing that
+    makes a test slow or non-deterministic.
+    """
+    ran = []
+    for _ in range(MAX_JOBS):
+        job = job_queue.poll(db)
+        if job is None:
+            break
+        ran.append(job.task)
+        TASK_HANDLERS[job.task](job.episode_id)
+        job_queue.complete(db, job)
+        ep = db.query(Episode).filter(Episode.id == episode_id).one()
+        observed_statuses.append(ep.status)
+    else:
+        raise AssertionError(
+            f"queue did not drain within {MAX_JOBS} jobs; ran {ran} -- "
+            "a stage is probably enqueueing itself"
+        )
+    return ran
+
+
+@pytest.fixture
+def flow(db_session, sample_episode, tmp_path):
+    """An episode ready to be downloaded, with the outside world stubbed."""
+    audio_src = tmp_path / "source.mp3"
+    shutil.copy(FIXTURE_AUDIO, audio_src)
+
+    flow_id = sample_episode.id
+    sample_episode.status = "pending"
+    sample_episode.audio_url = f"file://{audio_src}"
+    db_session.flush()
+
+    def fake_download(url, dest, episode_id, db):
+        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(audio_src, dest)
+
+    def _fake_compress(src, dest_dir, *args, **kwargs):
+        # ffmpeg exists in the test image, but re-encoding the fixture on every
+        # run buys nothing -- the file move is what archive is being tested for.
+        dest = Path(dest_dir) / f"{flow_id}.mp3"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(audio_src, dest)
+        return dest
+
+    def fake_embed(texts, runtime=None):
+        # 384 dims to match all-MiniLM-L6-v2, the configured default.
+        return [[0.01] * 384 for _ in texts]
+
+    with ExitStack() as stack:
+        for mod in TASK_MODULES:
+            stack.enter_context(patch(f"{mod}.SessionLocal", return_value=db_session))
+
+        stack.enter_context(patch("app.tasks.download._download_file", side_effect=fake_download))
+        stack.enter_context(patch("app.tasks.transcribe._convert_to_wav"))
+        stack.enter_context(patch("app.tasks.transcribe._unload_whisper"))
+        stack.enter_context(
+            patch("app.services.whisper.transcribe", return_value=(MOCK_SEGMENTS, "en", None))
+        )
+        stack.enter_context(patch("app.services.pyannote.diarize", return_value=MOCK_DIARIZATION))
+        stack.enter_context(patch("app.services.embed.embed_texts", side_effect=fake_embed))
+        # audio_raw_dir / audio_archive_dir / transcript_dir are all computed
+        # properties over data_dir, so redirecting the one field keeps every
+        # file this flow writes inside tmp_path.
+        stack.enter_context(patch.object(settings, "data_dir", str(tmp_path / "data")))
+        stack.enter_context(
+            patch("app.tasks.archive._compress_audio", side_effect=_fake_compress)
+        )
+
+        yield sample_episode
+
+
+class TestPipelineFlow:
+    def test_one_download_job_carries_the_episode_to_done(self, db_session, flow):
+        """The whole point: enqueue once, and the chain does the rest."""
+        observed: list[str] = []
+        job_queue.enqueue(db_session, str(flow.id), "download")
+
+        ran = _drain(db_session, observed, flow.id)
+
+        db_session.refresh(flow)
+        assert flow.status == "done", f"ended at {flow.status!r} after running {ran}"
+
+    def test_every_stage_runs_in_order(self, db_session, flow):
+        """Reaching `done` is not enough -- #968 was episodes skipping stages.
+
+        A chain that silently dropped embed would still finish; asserting the
+        endpoint alone would have called that a pass.
+        """
+        observed: list[str] = []
+        job_queue.enqueue(db_session, str(flow.id), "download")
+
+        ran = _drain(db_session, observed, flow.id)
+
+        assert ran == [
+            "download",
+            "transcribe",
+            "diarize",
+            "chunk",
+            "embed",
+            "infer",
+            "archive",
+        ]
+
+    def test_each_stage_leaves_what_the_next_one_needs(self, db_session, flow):
+        """The handoff, checked by its output rather than its status."""
+        job_queue.enqueue(db_session, str(flow.id), "download")
+        _drain(db_session, [], flow.id)
+
+        db_session.refresh(flow)
+
+        segments = db_session.query(Segment).filter(Segment.episode_id == flow.id).all()
+        assert len(segments) == len(MOCK_SEGMENTS), "transcribe left no segments for diarize"
+        assert any(s.speaker_label for s in segments), "diarize labelled nothing for chunk"
+
+        chunks = db_session.query(Chunk).filter(Chunk.episode_id == flow.id).all()
+        assert chunks, "chunk produced nothing for embed"
+        assert any(c.embedding is not None for c in chunks), "embed wrote no vectors"
+
+        assert flow.audio_local_path, "download recorded no audio path"
+        assert flow.has_diarization is True
+
+    def test_success_leaves_no_stale_error_state(self, db_session, flow):
+        """#983: inference_error survived the success path and kept showing."""
+        job_queue.enqueue(db_session, str(flow.id), "download")
+        _drain(db_session, [], flow.id)
+
+        db_session.refresh(flow)
+        assert flow.status == "done"
+        assert flow.error_message is None
+        assert flow.error_class is None
+        assert flow.inference_error is None


### PR DESCRIPTION
Closes #1015.

## The gap

Every other pipeline test starts an episode mid-flight — seed a `sample_episode`, set `status = "transcribing"`, call one task. That covers each stage's depth and **none of the joins between them**.

And the joins are where this project's bugs have been:

| Bug | What it was |
|---|---|
| #968 | `chunking`/`embedding` missing from the stage list — episodes vanished from the queue UI mid-pipeline |
| #972 | two slot-numbering schemes colliding across a boundary, silently losing names on 37 episodes |
| #983 | `inference_error` surviving the success path |

All three are seam defects. None was catchable by testing a stage in isolation.

There is no routing table to test, either — each task hardcodes its successor at the end of its own body. Seven `job_queue.enqueue` calls in seven files, unasserted until now.

## What it does

Enqueues **one** `download` job and drains the queue the way `worker.py:284` dispatches — poll, `TASK_HANDLERS`, complete. Not `worker.main()`, which sleeps, installs signal handlers and runs periodic tasks.

**Real:** database, job queue, every task body, the chunking logic, the archive file moves.
**Stubbed:** the download, and the four calls into models we don't own.

Running Whisper and pyannote for real would mean model downloads and minutes of CPU per run, to cover libraries whose behaviour isn't ours. The stage bodies and their handoffs *are* ours.

## The assertion that matters

Four tests, and the second is the point:

```python
assert ran == ["download", "transcribe", "diarize", "chunk", "embed", "infer", "archive"]
```

Reaching `done` is not enough — #968 was episodes *skipping* stages. A chain that silently dropped `embed` would still finish, and asserting the endpoint alone would call that a pass.

## Verified by breaking it, not by passing

| Mutant | Result |
|---|---|
| `chunk` no longer enqueues `embed` | **4 of 4 fail** |
| `embed` no longer enqueues `infer` | **3 of 4 fail** |

The drain loop is capped at 20 jobs, so a stage that enqueues itself fails loudly rather than hanging CI.

## Two corrections

`CLAUDE.md` said `tests/e2e/test_full_flow.py` "spins up the full Docker stack and exercises ingest→archive". It is **27 lines that call `/api/health`**. Its own docstring made the same claim.

That framing is why the gap sat open: it made this look like a wiring job — point CI at an existing test — rather than a test that was never written. Both descriptions now say what they actually cover.

## Placement

`tests/integration/`, not `tests/e2e/` — it needs the test database, and `ci-slow.yml:27` already runs that directory. No workflow change, and it runs from tonight.

I'd flagged in #1015 that the transactional `db_session` fixture wouldn't work here. That was wrong: patching `SessionLocal` per task module — the pattern `test_pipeline.py` already uses — makes it work fine.

## Verification

95 passed / 10 skipped across the full integration suite (was 91/10). `make ci-local`: all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin