### PR TITLE
build: run from published images with `make up-release` (#937, phase 2 of 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,3 +140,17 @@ OLLAMA_URL=http://ollama:11434  # Ollama API endpoint for LLM inference
 # self-heals. Raise EMBED_TIMEOUT_MS to pay the cold start instead.
 # EMBED_TIMEOUT_MS=2000
 # EMBED_COOLDOWN_MS=30000
+
+# ---------------------------------------------------------------------------
+# Published images (#937)
+# ---------------------------------------------------------------------------
+# Which published image `make up-release` starts. Ignored by `make build`,
+# which builds from source and simply tags the result with this value.
+#
+#   stable   the newest release (default)
+#   edge     current main, rebuilt on every merge
+#   X.Y.Z    an exact version, e.g. 0.10.0 -- also how you downgrade
+#
+# Images are linux/amd64 only. Building from source is the supported path on
+# any other architecture.
+# PODLOG_VERSION=stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Minor changes
+- You can now start Podlog from a published image instead of building it yourself: `make up-release` pulls a released build and starts it, no compiling. Set `PODLOG_VERSION` in `.env` to `stable`, `edge`, or an exact version like `0.10.0` — which is also how you go back to an older one. Images are for 64-bit Intel/AMD machines only; on anything else, build from source as before. `make up` is unchanged and still runs whatever you have built locally. ([#937](https://github.com/brlauuu/podlog/issues/937))
+
 ## 0.10.0 — 2026-08-27
 
 ### Major changes

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
-.PHONY: up up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e ci-local migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
+.PHONY: up up-release up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e ci-local migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
 
-up:             ## Start full stack
-	docker compose up -d
+up:             ## Start full stack (builds from source)
+	@# --pull never (#937 phase 2). Once services carry an `image:` pointing at
+	@# GHCR, a plain `up` tries the registry FIRST and only builds when the pull
+	@# fails. The published images are public, so as soon as a version tag
+	@# pushes `stable` this would silently start the released image instead of
+	@# the tree you have checked out -- your local edits simply would not
+	@# appear. `never` keeps this target meaning "run what is here".
+	docker compose up -d --pull never
+	@bash scripts/print-access.sh
+
+up-release:     ## Start from published images without building (see PODLOG_VERSION)
+	@# Phase 2 of #937. `--no-build` is the point: without it compose would
+	@# quietly fall back to building from source on a pull failure, which is
+	@# the one outcome this target exists to avoid -- a user on a laptop
+	@# discovering the multi-GB ML build they were trying to skip.
+	docker compose pull
+	docker compose up -d --no-build
 	@bash scripts/print-access.sh
 
 up-remote:      ## Start remote-inference profile (Fireworks providers, no Ollama)
-	docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d
+	docker compose -f docker-compose.yml -f docker-compose.remote.yml up -d --pull never
 	@bash scripts/print-access.sh
 
 down:           ## Stop all services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,16 @@
 services:
+# Phase 2 of #937: an `image:` alongside each `build:`, so one compose file
+# serves both paths instead of a release copy that silently drifts from the
+# real one.
+#
+#   make build && make up   -- builds from source, tags the result with the
+#                              name below. The development path, unchanged.
+#   make up-release         -- pulls the published image and starts without
+#                              building. The user path.
+#
+# PODLOG_VERSION selects which published image: `stable` (the newest release),
+# `edge` (current main), or an exact `X.Y.Z`. It has no effect when you build
+# locally -- the build just gets tagged with whatever it resolves to.
   db:
     image: pgvector/pgvector:pg15
     environment:
@@ -21,6 +33,7 @@ services:
       retries: 5
 
   pipeline:
+    image: ghcr.io/brlauuu/podlog-pipeline:${PODLOG_VERSION:-stable}
     build:
       context: ./apps/pipeline
       dockerfile: Dockerfile.control
@@ -78,6 +91,7 @@ services:
       start_period: 30s
 
   worker:
+    image: ghcr.io/brlauuu/podlog-worker:${PODLOG_VERSION:-stable}
     build:
       context: ./apps/pipeline
       dockerfile: Dockerfile.worker
@@ -118,6 +132,7 @@ services:
           memory: 20g
 
   web:
+    image: ghcr.io/brlauuu/podlog-web:${PODLOG_VERSION:-stable}
     build:
       # Context is the repo root so the Dockerfile can read the VERSION file
       # directly (a root .dockerignore keeps the context small).
@@ -185,6 +200,7 @@ services:
   # individual buckets; set all three to 0 to opt out entirely.
   # Backups land on the host at ./backups/ (gitignored).
   backup:
+    image: ghcr.io/brlauuu/podlog-backup:${PODLOG_VERSION:-stable}
     build: ./apps/backup
     environment:
       POSTGRES_HOST: db

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -78,6 +78,32 @@ Podlog is running.
 
 Open **http://localhost:3000** — you should see the Podlog home page with quick links to Search and Ask. The search page itself is at `/search`.
 
+### Starting from a published image instead
+
+`make build` compiles everything from source, which pulls several gigabytes of
+machine-learning dependencies and takes a while the first time. If you would
+rather run a released build:
+
+```bash
+make up-release   # pull the published images and start, no build
+```
+
+Which build you get is set by `PODLOG_VERSION` in `.env`:
+
+| Value | Meaning |
+|---|---|
+| `stable` | the newest release (default) |
+| `edge` | current `main`, rebuilt on every merge |
+| `0.10.0` | an exact version — also how you downgrade |
+
+The images are **linux/amd64 only**. On any other architecture, building from
+source is the supported path.
+
+`make up` and `make up-release` are deliberately separate: `make up` never
+contacts the registry, so it always runs the code in your working copy, even
+after you have edited it. `make up-release` never builds, so it cannot
+surprise you with a multi-gigabyte compile.
+
 The "same network" address is the one to use from a phone or another computer. Read the [Security model](#security-model) below before you use it: anyone who can reach that address has full control, with no login. If no LAN address is shown, either your machine has no network route or you have bound the web service to loopback — either way Podlog is reachable from this machine only.
 
 The address comes from DHCP and can change when your router or machine restarts. Reserve it in your router if you want it stable.


### PR DESCRIPTION
Phase 2 of #937. Follows phase 1 (#967), which publishes the four runtime images to GHCR.

## What it does

An `image:` alongside each `build:` for `pipeline`, `worker`, `web` and `backup` — one compose file serving both paths, rather than a `docker-compose.release.yml` that silently drifts from the real one.

```
make build && make up   builds from source, tags the result
make up-release         pulls the published image, never builds
```

`PODLOG_VERSION` selects which: `stable`, `edge`, or an exact `X.Y.Z` — which is also the downgrade path.

## The part worth reading: `make up` needed `--pull never`

Adding an `image:` key changes what a plain `docker compose up` does. It tries the **registry first**:

```
$ docker compose --dry-run up -d pipeline
 Image ghcr.io/brlauuu/podlog-pipeline:stable Pulling
 Image ghcr.io/brlauuu/podlog-pipeline:stable not found
 Image ghcr.io/brlauuu/podlog-pipeline:stable Building
```

It only fell back to building because **`stable` does not exist yet** — the publish workflow has pushed `edge` on merges, but no version tag since it landed. And the packages are anonymously pullable; I checked against the GHCR API rather than assuming:

```
$ curl -H "Authorization: Bearer $ANON_TOKEN" .../podlog-backup/manifests/edge
200
```

So **the first `v*` tag creates `stable` and arms the trap**: from then on, a plain `make up` would start the released image instead of the tree you have checked out, and your local edits would silently not appear. Given the next thing planned is tagging, this would have shipped and then bitten a week later.

`--pull never` keeps `make up` meaning "run what is here". Verified both directions by dry-run:

| Command | Registry requests |
|---|---|
| `up -d --pull never` (all four services) | **0** |
| `pull` | **6** |

## Verification

- The dev build path still works: `docker compose build backup` produces `ghcr.io/brlauuu/podlog-backup:stable`.
- `docker compose config` parses.
- `make ci-local`: all checks pass.

## Docs

`docs/guide/01-installation.md` gains a section on `make up-release` and `PODLOG_VERSION`, including the amd64-only note. Documented now rather than deferred to phase 4, since the target ships in this PR — phase 4 still owns the README restructure.

## Remaining in #937

Phase 3 (`make update` with channels, drain guard, forced backup, `make env-diff`), phase 4 (docs restructure), phase 5 (optional update notice).

Refs #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin