### PR TITLE
build: `make update` and `make env-diff` (#937, phase 3 of 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,3 +154,12 @@ OLLAMA_URL=http://ollama:11434  # Ollama API endpoint for LLM inference
 # Images are linux/amd64 only. Building from source is the supported path on
 # any other architecture.
 # PODLOG_VERSION=stable
+#
+# Which channel `make update` follows when you do not pass VERSION=X.Y.Z:
+#
+#   stable   move to the newest release tag (default)
+#   edge     track main, rebuilding from source
+#
+# `make update VERSION=0.10.0` overrides this and pins an exact version,
+# which is also how you go back to an earlier one.
+# PODLOG_CHANNEL=stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ fresh empty `Unreleased` is left at the top.
 ## Unreleased
 
 ### Minor changes
+- `make update` updates a running install without you having to remember the order. It refuses to start if the queue is busy or you have uncommitted changes, takes a database backup and refuses to go on without one, moves to the new version, pulls the images, restarts, and tells you which settings the new version knows about that your configuration does not. If anything fails it prints the exact command to restore the backup it just took. `make update VERSION=0.10.0` pins a version, which is also how you go back to an earlier one. ([#937](https://github.com/brlauuu/podlog/issues/937))
+- `make env-diff` reports settings your `.env` is missing or no longer needs, without ever editing it. ([#937](https://github.com/brlauuu/podlog/issues/937))
 - You can now start Podlog from a published image instead of building it yourself: `make up-release` pulls a released build and starts it, no compiling. Set `PODLOG_VERSION` in `.env` to `stable`, `edge`, or an exact version like `0.10.0` — which is also how you go back to an older one. Images are for 64-bit Intel/AMD machines only; on anything else, build from source as before. `make up` is unchanged and still runs whatever you have built locally. ([#937](https://github.com/brlauuu/podlog/issues/937))
 
 ## 0.10.0 — 2026-08-27

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up up-release up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e ci-local migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
+.PHONY: up up-release update env-diff up-remote down down-remote build logs logs-remote test test-unit test-healthcheck test-e2e ci-local migrate shell-db shell-pipeline web ollama-pull version backfill env-check deps-outdated explore explore-down explore-logs backup-now backup-list restore-db restore-audio
 
 up:             ## Start full stack (builds from source)
 	@# --pull never (#937 phase 2). Once services carry an `image:` pointing at
@@ -9,6 +9,12 @@ up:             ## Start full stack (builds from source)
 	@# appear. `never` keeps this target meaning "run what is here".
 	docker compose up -d --pull never
 	@bash scripts/print-access.sh
+
+update:         ## Update safely: drain, back up, move, pull, restart. VERSION=X.Y.Z to pin.
+	@bash scripts/update.sh
+
+env-diff:       ## Report settings your .env is missing or no longer needs
+	@python3 scripts/env_diff.py
 
 up-release:     ## Start from published images without building (see PODLOG_VERSION)
 	@# Phase 2 of #937. `--no-build` is the point: without it compose would

--- a/apps/pipeline/tests/unit/test_env_diff_script.py
+++ b/apps/pipeline/tests/unit/test_env_diff_script.py
@@ -1,0 +1,111 @@
+"""Unit tests for scripts/env_diff.py — the config-drift report (#937 phase 3).
+
+Imported the same way test_healthcheck_script.py imports healthcheck.py:
+walk up for the repo root, since the depth differs between host and Docker.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_here = Path(__file__).resolve()
+REPO_ROOT = None
+for parent in _here.parents:
+    if (parent / "scripts" / "env_diff.py").exists():
+        REPO_ROOT = parent
+        break
+
+if REPO_ROOT is None:
+    pytest.skip("Cannot locate repo root with scripts/env_diff.py", allow_module_level=True)
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import env_diff  # noqa: E402
+
+
+class TestParseKeys:
+    def test_separates_live_keys_from_commented_ones(self):
+        live, commented = env_diff.parse_keys(
+            "A=1\n# B=2\n#C=3\n   D=4\n"
+        )
+        assert live == {"A", "D"}
+        assert commented == {"B", "C"}
+
+    def test_ignores_prose_and_blank_lines(self):
+        live, commented = env_diff.parse_keys(
+            "# Some explanation about things\n\n"
+            "# ---------------------------------\n"
+            "REAL=1\n"
+        )
+        assert live == {"REAL"}
+        assert commented == set()
+
+    def test_a_value_containing_an_equals_sign_is_still_one_key(self):
+        live, _ = env_diff.parse_keys("DATABASE_URL=postgres://u:p@h/db?a=b\n")
+        assert live == {"DATABASE_URL"}
+
+
+class TestDiff:
+    def test_reports_a_key_the_example_sets_and_env_does_not(self):
+        missing, unknown = env_diff.diff(env_text="A=1\n", example_text="A=1\nB=2\n")
+        assert missing == ["B"]
+        assert unknown == []
+
+    def test_a_commented_example_key_is_optional_not_missing(self):
+        # Most of .env.example is commented out on purpose -- it documents
+        # optional settings. Treating those as required would report drift on
+        # a perfectly normal install.
+        missing, unknown = env_diff.diff(env_text="A=1\n", example_text="A=1\n# B=2\n")
+        assert missing == []
+
+    def test_taking_up_an_optional_setting_is_not_unknown(self):
+        missing, unknown = env_diff.diff(env_text="A=1\nB=2\n", example_text="A=1\n# B=2\n")
+        assert missing == []
+        assert unknown == []
+
+    def test_reports_a_key_the_example_no_longer_mentions(self):
+        missing, unknown = env_diff.diff(env_text="A=1\nOLD=2\n", example_text="A=1\n")
+        assert missing == []
+        assert unknown == ["OLD"]
+
+    def test_clean_install_reports_nothing(self):
+        missing, unknown = env_diff.diff(env_text="A=1\nB=2\n", example_text="A=1\nB=2\n")
+        assert (missing, unknown) == ([], [])
+
+
+class TestExitStatus:
+    """A missing key fails; extra keys alone do not.
+
+    `make update` runs this and must not abort an otherwise fine update
+    because the operator kept a setting we retired.
+    """
+
+    def _run(self, tmp_path, env_text, example_text, monkeypatch):
+        env = tmp_path / ".env"
+        example = tmp_path / ".env.example"
+        env.write_text(env_text)
+        example.write_text(example_text)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["env_diff.py", "--env", str(env), "--example", str(example), "--quiet"],
+        )
+        return env_diff.main()
+
+    def test_missing_key_exits_nonzero(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, "A=1\n", "A=1\nB=2\n", monkeypatch) == 1
+
+    def test_extra_key_alone_exits_zero(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, "A=1\nOLD=2\n", "A=1\n", monkeypatch) == 0
+
+    def test_clean_exits_zero(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, "A=1\n", "A=1\n", monkeypatch) == 0
+
+    def test_missing_env_file_is_a_distinct_status(self, tmp_path, monkeypatch):
+        example = tmp_path / ".env.example"
+        example.write_text("A=1\n")
+        monkeypatch.setattr(
+            sys, "argv",
+            ["env_diff.py", "--env", str(tmp_path / "nope"), "--example", str(example), "--quiet"],
+        )
+        # 2, not 1: "you have no .env" is a different problem from "your .env
+        # is missing a key", and `make update` should not conflate them.
+        assert env_diff.main() == 2

--- a/docs/guide/01-installation.md
+++ b/docs/guide/01-installation.md
@@ -99,6 +99,40 @@ Which build you get is set by `PODLOG_VERSION` in `.env`:
 The images are **linux/amd64 only**. On any other architecture, building from
 source is the supported path.
 
+### Updating
+
+```bash
+make update                  # follow your channel
+make update VERSION=0.10.0   # pin an exact version, or go back to one
+```
+
+`make update` does the things that are easy to forget:
+
+1. **Refuses if you have uncommitted changes**, since updating moves `HEAD`.
+2. **Drains the queue.** The worker handles one episode at a time and a
+   transcription runs for minutes; restarting mid-job loses that work.
+3. **Takes a database backup first**, and refuses to continue without one.
+   Migrations run when the pipeline starts, so this is the only thing standing
+   between a bad migration and your transcripts.
+4. **Moves, pulls and restarts.**
+5. **Reports configuration drift** — settings the new version's `.env.example`
+   lists that your `.env` does not set. It never edits `.env`, which holds your
+   passwords and API keys. Run it on its own with `make env-diff`.
+
+If anything goes wrong it prints the exact command to get back:
+
+```
+make restore-db DATE=2026-08-27
+```
+
+Rolling back means restoring that dump and then `make update VERSION=<the one
+you were on>`. Not `alembic downgrade` — the downgrade paths have never been
+exercised and are not a supported route.
+
+Set `PODLOG_CHANNEL` in `.env` to choose what `make update` follows: `stable`
+for the newest release, or `edge` to track `main` (which rebuilds from source
+rather than pulling).
+
 `make up` and `make up-release` are deliberately separate: `make up` never
 contacts the registry, so it always runs the code in your working copy, even
 after you have edited it. `make up-release` never builds, so it cannot

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -103,23 +103,34 @@ res $FULL_RC "pipeline unit full + cov>=82"
 # not. `make test-unit` already compensates by running them on the host;
 # this step is the same compensation. Found when CI reported 1073 tests
 # against this script's 1050.
-step "Pipeline Healthcheck (host — skipped inside the container)"
-python3 -m pytest apps/pipeline/tests/unit/test_healthcheck_script.py -q 2>&1 | tail -2
-res ${PIPESTATUS[0]} "healthcheck script tests"
+# Tests for repo-root scripts/. The test image's build context is
+# apps/pipeline/, so these modules skip themselves inside the container and
+# have to run on the host. CI checks out the whole repo and runs them
+# normally, which is why the counts differ.
+HOST_ONLY_TESTS=(
+  apps/pipeline/tests/unit/test_healthcheck_script.py
+  apps/pipeline/tests/unit/test_env_diff_script.py
+)
 
-# Guard the general form of that bug: any further module that vanishes
-# inside the container would be just as silent. One module-level skip is
-# expected (healthcheck, covered above); more means something else is
-# quietly not running here.
+step "Pipeline host-only script tests (skipped inside the container)"
+python3 -m pytest "${HOST_ONLY_TESTS[@]}" -q 2>&1 | tail -2
+res ${PIPESTATUS[0]} "repo-root script tests"
+
+# Guard the general form of that bug: any further module that vanishes inside
+# the container would be just as silent. The expected count is derived from
+# the list above rather than hardcoded -- a magic number here would just get
+# bumped each time, which is how the check stops meaning anything.
 step "No unexpected module-level skips"
+EXPECTED_SKIPS=${#HOST_ONLY_TESTS[@]}
 SKIPPED=$(grep -oE '[0-9]+ skipped' "$FULL_LOG" | grep -oE '^[0-9]+' | tail -1)
 rm -f "$FULL_LOG"
-if [ "${SKIPPED:-0}" -le 1 ]; then
-  echo "PASS: $SKIPPED skipped (healthcheck module only)"
+if [ "${SKIPPED:-0}" -le "$EXPECTED_SKIPS" ]; then
+  echo "PASS: $SKIPPED skipped (the $EXPECTED_SKIPS host-only modules)"
 else
-  echo "FAIL: $SKIPPED skipped in the container, expected 1."
+  echo "FAIL: $SKIPPED skipped in the container, expected $EXPECTED_SKIPS."
   echo "      A test module is silently not running locally. Find it with:"
   echo "      docker compose -f docker-compose.test.yml run --rm test pytest tests/unit -rs"
+  echo "      If it is another repo-root script test, add it to HOST_ONLY_TESTS."
   FAIL=1
 fi
 

--- a/scripts/env_diff.py
+++ b/scripts/env_diff.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Compare .env against .env.example and report drift (#937, phase 3).
+
+Run directly, or as part of `make update`:
+
+    python3 scripts/env_diff.py            # compares ./.env against ./.env.example
+    python3 scripts/env_diff.py --quiet    # exit status only, for scripting
+
+WHY THIS NEVER WRITES
+
+`.env` holds the operator's secrets -- Postgres password, Fireworks and
+pyannote API keys, Telegram tokens. A tool that edits it during an update is
+one bug away from truncating them, and a backup of the database does not
+bring them back. So this reports and exits; applying anything is the
+operator's keystroke.
+
+WHAT COUNTS AS DRIFT
+
+Commented-out keys in .env.example are documentation of optional settings,
+not requirements -- most of the file is commented by design. Only keys that
+appear uncommented in the example are treated as expected. A key set in .env
+but absent from the example is reported separately and is usually harmless:
+either a setting that was retired upstream, or one the operator added.
+
+Exit status is 1 when a key expected by the example is missing from .env,
+0 otherwise -- including when the only finding is extra keys.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# KEY=value, with optional leading whitespace. Captures whether it was
+# commented out, because that distinction is the whole point above.
+LINE = re.compile(r"^(?P<comment>#\s*)?(?P<key>[A-Z][A-Z0-9_]*)=")
+
+
+def parse_keys(text: str) -> tuple[set[str], set[str]]:
+    """Return (uncommented keys, commented-out keys)."""
+    live: set[str] = set()
+    commented: set[str] = set()
+    for line in text.splitlines():
+        m = LINE.match(line.strip())
+        if not m:
+            continue
+        (commented if m.group("comment") else live).add(m.group("key"))
+    return live, commented
+
+
+def diff(env_text: str, example_text: str) -> tuple[list[str], list[str]]:
+    """Return (missing from .env, present in .env but not the example)."""
+    env_live, _ = parse_keys(env_text)
+    ex_live, ex_commented = parse_keys(example_text)
+
+    missing = sorted(ex_live - env_live)
+    # A commented-out example key is optional, so an env key matching one is
+    # not "unknown" -- it is someone taking up the offer.
+    unknown = sorted(env_live - ex_live - ex_commented)
+    return missing, unknown
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--env", default=str(ROOT / ".env"))
+    ap.add_argument("--example", default=str(ROOT / ".env.example"))
+    ap.add_argument("--quiet", action="store_true", help="exit status only")
+    args = ap.parse_args()
+
+    env_path, example_path = Path(args.env), Path(args.example)
+    if not example_path.exists():
+        print(f"[FAIL] no {example_path}", file=sys.stderr)
+        return 2
+    if not env_path.exists():
+        print(f"[FAIL] no {env_path} — copy .env.example and fill it in", file=sys.stderr)
+        return 2
+
+    missing, unknown = diff(env_path.read_text(), example_path.read_text())
+
+    if not args.quiet:
+        if missing:
+            print("Settings .env.example lists that your .env does not set:")
+            for k in missing:
+                print(f"  + {k}")
+            print(
+                "\n  Not necessarily a problem: many of these have a working default\n"
+                "  in the app, and the example is showing you the knob rather than\n"
+                "  requiring it. Read the comment above each in .env.example to tell.\n"
+                "  Add any you want by hand — this script never edits .env, which\n"
+                "  holds your passwords and API keys."
+            )
+        if unknown:
+            print("\nSettings in your .env that the example no longer lists:")
+            for k in unknown:
+                print(f"  - {k}")
+            print("\n  Usually harmless: either retired upstream, or something you added.")
+        if not missing and not unknown:
+            print("No configuration drift.")
+
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Update a running Podlog install (#937, phase 3).
+#
+#   make update                 follow PODLOG_CHANNEL from .env (default stable)
+#   make update VERSION=1.0.0   pin an exact version -- also the downgrade path
+#
+# The order below is the point of the script. Anyone can run `git pull &&
+# docker compose up -d`; what that misses is that the worker may be halfway
+# through transcribing an episode, that a migration runs on pipeline start
+# with no dump taken first, and that a failure leaves you with no stated way
+# back. Each step here exists because skipping it loses something.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+CHANNEL_DEFAULT=stable
+PIN="${VERSION:-}"
+
+say()  { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+fail() { printf '\033[31mFAILED: %s\033[0m\n' "$1" >&2; }
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+say "Checking the working copy"
+
+if [ -n "$(git status --porcelain)" ]; then
+  fail "the working copy has uncommitted changes."
+  echo "  Updating moves HEAD, which would either fail or bury your edits."
+  echo "  Commit or stash them first:  git stash"
+  exit 1
+fi
+echo "clean"
+
+CHANNEL="$CHANNEL_DEFAULT"
+if [ -f .env ]; then
+  FROM_ENV=$(grep -E '^\s*PODLOG_CHANNEL=' .env | tail -1 | cut -d= -f2- | tr -d ' "' || true)
+  [ -n "${FROM_ENV:-}" ] && CHANNEL="$FROM_ENV"
+fi
+
+if [ -n "$PIN" ]; then
+  echo "target: pinned version $PIN"
+elif [ "$CHANNEL" = "edge" ]; then
+  echo "target: edge (current main)"
+elif [ "$CHANNEL" = "stable" ]; then
+  echo "target: stable (newest release tag)"
+else
+  fail "PODLOG_CHANNEL is '$CHANNEL'; expected 'stable' or 'edge'."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Drain
+# ---------------------------------------------------------------------------
+# CLAUDE.md's "worker is non-interruptible" rule, enforced instead of written
+# down. concurrency=1 and a transcription can run for minutes; restarting
+# mid-job loses the work and the episode comes back as SYSTEM_ERROR via the
+# zombie sweep.
+say "Draining the queue"
+BUSY=$(docker compose exec -T db psql -U postgres podlog -tAc \
+  "SELECT count(*) FROM job_queue WHERE status IN ('pending','running');" 2>/dev/null | tr -d ' ')
+
+if [ -z "${BUSY:-}" ]; then
+  fail "could not reach the database to check the queue."
+  echo "  Is the stack running? Start it with 'make up', or stop everything"
+  echo "  first if you are updating a stopped install."
+  exit 1
+fi
+
+if [ "$BUSY" != "0" ]; then
+  echo "$BUSY job(s) pending or running."
+  echo "Stopping the worker gracefully (up to 60s for the current job)..."
+  docker compose stop -t 60 worker
+  STILL=$(docker compose exec -T db psql -U postgres podlog -tAc \
+    "SELECT count(*) FROM job_queue WHERE status = 'running';" 2>/dev/null | tr -d ' ')
+  if [ "${STILL:-0}" != "0" ]; then
+    fail "a job is still marked running after the grace period."
+    echo "  It will be picked up again after the update, but if it was mid-"
+    echo "  transcription that work is lost. Re-run when the queue is idle,"
+    echo "  or accept it and re-run this command."
+    exit 1
+  fi
+  echo "worker stopped, nothing running"
+else
+  echo "queue idle"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Back up
+# ---------------------------------------------------------------------------
+# Not "the nightly backup will do". A migration that goes wrong against a
+# day-old dump costs a day of transcription, which on this hardware is hours
+# of CPU you cannot get back.
+say "Taking a database backup"
+TODAY=$(date +%F)
+if ! docker compose exec -T backup rm -f /backups/.last_run 2>/dev/null; then
+  fail "could not reach the backup service."
+  echo "  Refusing to update without a fresh dump."
+  exit 1
+fi
+docker compose restart backup >/dev/null 2>&1
+echo "backup triggered; waiting for it to land..."
+for _ in $(seq 1 30); do
+  if docker compose exec -T backup sh -c "ls /backups/db/daily 2>/dev/null | grep -q '$TODAY'"; then
+    break
+  fi
+  sleep 2
+done
+if docker compose exec -T backup sh -c "ls /backups/db/daily 2>/dev/null | grep -q '$TODAY'"; then
+  echo "dump for $TODAY is on disk"
+else
+  fail "no dump dated $TODAY appeared within 60s."
+  echo "  Check 'docker compose logs backup'. Refusing to continue without one."
+  exit 1
+fi
+
+ROLLBACK="make restore-db DATE=$TODAY"
+
+# ---------------------------------------------------------------------------
+# 3. Move
+# ---------------------------------------------------------------------------
+say "Moving the working copy"
+BEFORE=$(git rev-parse --short HEAD)
+git fetch --tags --quiet || { fail "git fetch failed"; exit 1; }
+
+if [ -n "$PIN" ]; then
+  TARGET="v${PIN#v}"
+  git rev-parse -q --verify "refs/tags/$TARGET" >/dev/null || {
+    fail "no such tag: $TARGET"; echo "  Available: $(git tag | tail -5 | tr '\n' ' ')"; exit 1; }
+elif [ "$CHANNEL" = "edge" ]; then
+  TARGET="origin/main"
+else
+  TARGET=$(git tag -l 'v*' --sort=-v:refname | head -1)
+  [ -n "$TARGET" ] || { fail "no version tags found; nothing to update to"; exit 1; }
+fi
+
+git checkout --quiet "$TARGET" 2>/dev/null || { fail "could not check out $TARGET"; exit 1; }
+AFTER=$(git rev-parse --short HEAD)
+if [ "$BEFORE" = "$AFTER" ]; then
+  echo "already at $TARGET ($AFTER) — nothing to move"
+else
+  echo "$BEFORE -> $AFTER ($TARGET)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Images
+# ---------------------------------------------------------------------------
+say "Fetching images"
+if [ "$CHANNEL" = "edge" ] && [ -z "$PIN" ]; then
+  echo "edge builds from source"
+  docker compose build || { fail "build failed"; echo "  Roll back with: $ROLLBACK"; exit 1; }
+else
+  docker compose pull || {
+    fail "pull failed"
+    echo "  The published images are linux/amd64 only. On another architecture,"
+    echo "  build from source instead: make build && make up"
+    echo "  Roll back the database with: $ROLLBACK"
+    exit 1
+  }
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Config drift
+# ---------------------------------------------------------------------------
+say "Checking configuration"
+python3 scripts/env_diff.py || true   # advisory: never blocks an update
+
+# ---------------------------------------------------------------------------
+# 6. Restart
+# ---------------------------------------------------------------------------
+# Alembic runs on pipeline startup, so there is no separate migrate step --
+# but that also means the migration happens here, which is why step 2 was
+# not optional.
+say "Restarting"
+if [ "$CHANNEL" = "edge" ] && [ -z "$PIN" ]; then
+  docker compose up -d --pull never
+else
+  docker compose up -d --no-build
+fi
+RC=$?
+
+if [ "$RC" -ne 0 ]; then
+  fail "the stack did not come up."
+  echo "  Roll back with:  $ROLLBACK"
+  echo "  then:            make update VERSION=<the version you were on>"
+  exit 1
+fi
+
+say "Done"
+echo "Now on $(cat VERSION) ($AFTER)."
+echo "Watch the migration land:  docker compose logs -f pipeline"
+echo "If something is wrong:     $ROLLBACK"
+bash scripts/print-access.sh


### PR DESCRIPTION
Phase 3 of #937. Follows phase 1 (#967, GHCR publishing) and phase 2 (#1019, `make up-release`).

## Why a script rather than instructions

Anyone can run `git pull && docker compose up -d`. What that misses:

- the worker may be **halfway through a transcription** — concurrency is 1 and a job runs for minutes
- **Alembic migrates on pipeline start**, so the migration happens whether or not you took a dump
- a failure leaves **no stated way back**

Each step exists because skipping it loses something:

| Step | Guard |
|---|---|
| 0 | refuse on a dirty working copy — updating moves `HEAD` |
| 1 | drain the queue, or stop the worker gracefully **and verify nothing is still running** |
| 2 | force a backup, refuse to continue without one dated today |
| 3 | move: newest tag / `origin/main` / pinned `VERSION=` |
| 4 | pull, or build on `edge` |
| 5 | report config drift — advisory, never blocks |
| 6 | restart, and print the restore command on failure |

Step 1 is `CLAUDE.md`'s "worker is non-interruptible" rule, enforced instead of written down.

## `env_diff.py` is a script with tests, not shell

The rule it encodes isn't obvious: **a commented-out key in `.env.example` is documentation of an optional setting, not a requirement.** Most of that file is commented by design, so treating those as missing would report drift on every healthy install. 12 unit tests cover that and the exit-status contract.

It **never writes to `.env`**. That file holds the Postgres password and every API key; a tool that edits it mid-update is one bug away from truncating them, and a database dump doesn't bring them back.

Run against your real install it already found something:

```
$ make env-diff
Settings .env.example lists that your .env does not set:
  + DIARIZATION_PROVIDER
  + PYANNOTE_MODEL
```

Both have working defaults matching the example, so it's benign — which is why the wording says so rather than telling you to act.

## Two things verified rather than assumed

**The preflight guards each exit 1** — dirty tree, unknown channel, unreachable database — run against the real script. (Checking the status directly, not through a pipe, after `tail` reported 0 for a script that had exited 1.)

**`--sort=-v:refname` picks `v0.10.0` over `v0.7.0`.** Plain string sort picks `v0.7.0`:

```
script's expression: v0.10.0
string sort:         v0.7.0
```

So "move to the newest tag" would have started going **backwards** the moment a double-digit minor existed — which is the next release. Verified in a scratch repo with the tags actually created.

## What is not verified

**The backup / move / pull / restart path end to end.** It can't be exercised without performing a real update on a live install. The guards in front of it are tested; the body is not. Saying so plainly rather than implying the whole script is covered.

## The skip guard from #1002 earned its keep

`make ci-local` failed on this branch:

```
FAIL: 2 skipped in the container, expected 1.
```

The new script test skips inside the container for the same reason the healthcheck one does — the test image's build context is `apps/pipeline/`, so repo-root `scripts/` isn't there. Exactly the silent-skip case that guard was built for, and it fired on the next module to hit it.

Fixed by deriving the expected count from a `HOST_ONLY_TESTS` list rather than bumping the number — a magic number there would just get bumped each time, which is how the check stops meaning anything.

## Verification

1057 pipeline unit tests + 35 host-only script tests, `make ci-local` all green.

Refs #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXRfcXKsyWmHLFhUZunMin