### PR TITLE
fix: make update's backup step wait for the dump that is actually written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+
+- `make update` no longer fails at the backup step with *"no dump dated ... appeared within 60s"*. It was comparing the host's local date against a filename the backup service builds from UTC, so west-to-east of UTC every update run between local midnight and UTC midnight waited for a file that could never exist; it also gave a multi-gigabyte dump only 60 seconds to finish, and would have accepted a half-written or day-old dump as the rollback point. The wait now follows the actual dump, and lasts 30 minutes (override with `BACKUP_WAIT_SECONDS`).
+
 ## 1.0.0 — 2026-08-27
 
 ### Minor changes

--- a/docs/guide/20-updating.md
+++ b/docs/guide/20-updating.md
@@ -28,6 +28,9 @@ seconds, and then checks that nothing is still marked running before going on.
 Migrations run automatically when the pipeline starts, so the update *is* the
 migration. The nightly backup is not good enough here: restoring a day-old
 dump costs a day of transcription, which on modest hardware is hours of CPU.
+It waits up to 30 minutes for the dump to finish — a large library takes
+minutes — and accepts only a dump completed by this run, never one already on
+disk. Set `BACKUP_WAIT_SECONDS` if yours needs longer.
 
 **4. It moves the working copy** — to the newest release tag, to `main` on the
 `edge` channel, or to the tag you pinned with `VERSION=`.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -93,25 +93,56 @@ fi
 # day-old dump costs a day of transcription, which on this hardware is hours
 # of CPU you cannot get back.
 say "Taking a database backup"
-TODAY=$(date +%F)
+# Ask the container for the date, do not compute it here. backup.sh names the
+# dump from `date -u`, while this script runs in the host's timezone, so for
+# everyone east of UTC every `make update` run between local midnight and UTC
+# midnight waited for a file that could never appear.
+TODAY=$(docker compose exec -T backup date -u +%F 2>/dev/null | tr -d '\r')
+if [ -z "$TODAY" ]; then
+  fail "could not reach the backup service."
+  echo "  Refusing to update without a fresh dump."
+  exit 1
+fi
 if ! docker compose exec -T backup rm -f /backups/.last_run 2>/dev/null; then
   fail "could not reach the backup service."
   echo "  Refusing to update without a fresh dump."
   exit 1
 fi
+TRIGGERED_AT=$(docker compose exec -T backup date -u +%s 2>/dev/null | tr -d '\r')
 docker compose restart backup >/dev/null 2>&1
 echo "backup triggered; waiting for it to land..."
-for _ in $(seq 1 30); do
-  if docker compose exec -T backup sh -c "ls /backups/db/daily 2>/dev/null | grep -q '$TODAY'"; then
-    break
+# Existence of the file proves nothing, for two reasons. pg_dump writes
+# podlog-<date>.dump.partial and renames it only on success, so anything
+# matching the date can be a half-written file; and if the nightly run already
+# fired, yesterday's completed dump sits at the same path and would satisfy a
+# presence check instantly -- handing you a rollback point from before the
+# update, which is the one thing this step exists to prevent. So require a
+# dump whose mtime is after we triggered the run.
+DUMP="/backups/db/daily/podlog-$TODAY.dump"
+dump_landed() {
+  local mtime
+  mtime=$(docker compose exec -T backup stat -c %Y "$DUMP" 2>/dev/null | tr -d '\r')
+  [ -n "$mtime" ] && [ "$mtime" -ge "$TRIGGERED_AT" ]
+}
+
+# 30 minutes, not 60 seconds. The dump is proportional to the database, and a
+# real install's is gigabytes -- this step legitimately takes minutes.
+BACKUP_WAIT_SECONDS="${BACKUP_WAIT_SECONDS:-1800}"
+elapsed=0
+while ! dump_landed && [ "$elapsed" -lt "$BACKUP_WAIT_SECONDS" ]; do
+  sleep 5
+  elapsed=$((elapsed + 5))
+  if [ $((elapsed % 30)) -eq 0 ]; then
+    printf '  still dumping (%dm%02ds elapsed)\n' $((elapsed / 60)) $((elapsed % 60))
   fi
-  sleep 2
 done
-if docker compose exec -T backup sh -c "ls /backups/db/daily 2>/dev/null | grep -q '$TODAY'"; then
+if dump_landed; then
   echo "dump for $TODAY is on disk"
 else
-  fail "no dump dated $TODAY appeared within 60s."
+  fail "no dump dated $TODAY appeared within $((BACKUP_WAIT_SECONDS / 60))m."
   echo "  Check 'docker compose logs backup'. Refusing to continue without one."
+  echo "  If the dump is simply slow, re-run with a longer wait:"
+  echo "    BACKUP_WAIT_SECONDS=3600 make update"
   exit 1
 fi
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -109,6 +109,11 @@ if ! docker compose exec -T backup rm -f /backups/.last_run 2>/dev/null; then
   exit 1
 fi
 TRIGGERED_AT=$(docker compose exec -T backup date -u +%s 2>/dev/null | tr -d '\r')
+if [ -z "$TRIGGERED_AT" ]; then
+  fail "could not read the clock in the backup service."
+  echo "  Refusing to update without a fresh dump."
+  exit 1
+fi
 docker compose restart backup >/dev/null 2>&1
 echo "backup triggered; waiting for it to land..."
 # Existence of the file proves nothing, for two reasons. pg_dump writes
@@ -128,8 +133,21 @@ dump_landed() {
 # 30 minutes, not 60 seconds. The dump is proportional to the database, and a
 # real install's is gigabytes -- this step legitimately takes minutes.
 BACKUP_WAIT_SECONDS="${BACKUP_WAIT_SECONDS:-1800}"
+case "$BACKUP_WAIT_SECONDS" in
+  ''|*[!0-9]*) fail "BACKUP_WAIT_SECONDS must be a whole number of seconds, got: $BACKUP_WAIT_SECONDS"; exit 1 ;;
+esac
 elapsed=0
 while ! dump_landed && [ "$elapsed" -lt "$BACKUP_WAIT_SECONDS" ]; do
+  # Setting every retention tier to 0 disables backups (#682), and backup.sh
+  # then returns without dumping. Nothing about that state distinguishes
+  # itself from a slow dump, so without this check the update would sit here
+  # for the full 30 minutes before failing. Say it immediately instead.
+  if docker compose logs --tail 20 backup 2>/dev/null | grep -q 'backups disabled'; then
+    fail "backups are disabled (every retention tier is 0)."
+    echo "  The update runs migrations, so it will not proceed with no way back."
+    echo "  Set a daily retention above 0 in Settings, then re-run."
+    exit 1
+  fi
   sleep 5
   elapsed=$((elapsed + 5))
   if [ $((elapsed % 30)) -eq 0 ]; then


### PR DESCRIPTION
`make update` fails on a healthy install at step 2:

```
==> Taking a database backup
backup triggered; waiting for it to land...
FAILED: no dump dated 2026-08-28 appeared within 60s.
```

Three separate bugs in the backup gate of `scripts/update.sh`. Each one alone is enough to break or silently weaken the step; they had to be wrong together for it to ever appear to work.

**1. The date came from the wrong clock.** `update.sh` computed `TODAY=$(date +%F)` on the host, while `apps/backup/backup.sh:223` names the dump from `date -u`. Anywhere east of UTC, every run between local midnight and UTC midnight waits for a filename that cannot exist. Reproduced live:

```
container UTC date: 2026-08-27
host date:          2026-08-28
```

The date now comes from the backup container, so it is by construction the same clock that builds the filename.

**2. 60 seconds was never enough.** The dump is proportional to the database. On the install this was found on it is ~2 GB and writes at roughly 500 MB/min — about four minutes. Even with the date correct, the old gate would have failed. Now 30 minutes, with progress output every 30s and a `BACKUP_WAIT_SECONDS` override quoted in the failure message.

**3. The check would have accepted the wrong dump.** It was `ls /backups/db/daily | grep -q "$TODAY"`. That substring matches two files it must not:

- `podlog-<date>.dump.partial` — `pg_dump` writes there and renames only on success, so this is the half-written file.
- The completed dump the nightly run already left at that exact path earlier the same day.

Either would have been accepted as the pre-migration rollback point — a backup from *before* the update is the one thing this step exists to prevent. The gate now requires the exact final filename with an `mtime` at or after the moment this run triggered the backup.

## Verification

The freshness guard was exercised against the live backup container, with the day's existing 02:14 dump on disk:

```
PASS: stale dump rejected      (TRIGGERED_AT = now)
PASS: fresh dump accepted      (TRIGGERED_AT = 0)
```

That is the case the old `grep` got wrong, so it is the one worth proving. The timezone mismatch is shown directly above.

## Docs

`docs/guide/20-updating.md` step 3 now states the 30-minute wait, the `BACKUP_WAIT_SECONDS` override, and that only a dump completed by this run is accepted. Checked the rest of the map in CLAUDE.md: nothing else describes the backup gate's timing — `docs/guide/16-backups.md` covers the backup service itself, which is unchanged here. No PRD or config change.

## Note on releasing

The bug is in the updater itself, so `stable` cannot self-heal: step 3 does `git checkout "$TARGET"`, which on v1.0.0 restores the broken `update.sh` over the fixed one. Until a tag carries this, only `edge` has it. Worth cutting a 1.0.1 for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w1C8pwtxuAzNtEAqCt5vS