### PR TITLE
fix: pass PODLOG_LAN_URL through the restart in `make update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ fresh empty `Unreleased` is left at the top.
 
 ## Unreleased
 
+### Fixes
+- `make update` no longer blanks the LAN address panel in Settings. The restart at the end of an update did not pass the address through to the web container the way `make up` does, so after every update the panel went empty for anyone browsing from the machine running Podlog — while the update's own closing message printed the address correctly, so nothing looked wrong. ([#1027](https://github.com/brlauuu/podlog/pull/1027))
+
 ## 1.0.1 — 2026-08-28
 
 ### Fixes

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -222,10 +222,17 @@ python3 scripts/env_diff.py || true   # advisory: never blocks an update
 # but that also means the migration happens here, which is why step 2 was
 # not optional.
 say "Restarting"
+# PODLOG_LAN_URL has to be set on the `up` that creates the container, exactly
+# as the `up`, `up-release` and `up-remote` Makefile targets do. Restarting
+# without it leaves the web container holding an empty value, which blanks the
+# LAN address panel in Settings (#1012) for anyone browsing from the machine
+# itself -- the case that feature exists for. The update printed the address
+# correctly at the end while failing to pass it in, so nothing looked wrong.
+LAN_URL=$(bash scripts/print-access.sh --url-only 2>/dev/null || true)
 if [ "$CHANNEL" = "edge" ] && [ -z "$PIN" ]; then
-  docker compose up -d --pull never
+  PODLOG_LAN_URL="$LAN_URL" docker compose up -d --pull never
 else
-  docker compose up -d --no-build
+  PODLOG_LAN_URL="$LAN_URL" docker compose up -d --no-build
 fi
 RC=$?
 


### PR DESCRIPTION
Found while running `make update` end to end for the first time after #1025.

## The bug

`docker-compose.yml:177` gives the web container `PODLOG_LAN_URL: ${PODLOG_LAN_URL:-}`. Three Makefile targets populate it — `up`, `up-release`, `up-remote` — each with `PODLOG_LAN_URL="$(bash scripts/print-access.sh --url-only)"`. `update.sh`'s restart step did not, so every update left the container holding an empty value:

```
$ docker inspect podlog-web-1 … | grep LAN_URL
PODLOG_LAN_URL=
```

`/api/lan-address` falls back to the request's `Host` header, so reaching Podlog from a phone still worked. From the machine itself the Host is loopback, and the route deliberately returns nothing rather than echo back an untypeable `localhost` URL. So the Settings panel went blank in exactly the case its own source comments name as the one worth solving — *"sitting at the machine with a phone in your hand"* — while everything else looked fine.

What made it invisible: `update.sh` ends by running `scripts/print-access.sh`, so the update **prints the LAN address correctly** in its closing message while having failed to pass that same address into the container.

## Verification

Against a live stack mid-regression, before and after the fixed restart:

```
BEFORE: {"url":null,"source":null}
AFTER:  {"url":"http://192.168.1.190:3000","source":"host"}
```

and the container environment now carries `PODLOG_LAN_URL=http://192.168.1.190:3000`. `/api/version` still reports `1.0.1` either way, confirming only the environment changed.

## Docs

Checked the map in CLAUDE.md. `docs/guide/01-installation.md` documents the LAN address and the security warning around it; none of that changes — this restores documented behaviour rather than altering it. No PRD or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012w1C8pwtxuAzNtEAqCt5vS